### PR TITLE
fix: some parts incorrectly assumed `std::ffi::c_char` to be `i8`. On Linux/Android, `std::ffi::c_char` is `u8`.

### DIFF
--- a/dear-imgui/src/dock_builder.rs
+++ b/dear-imgui/src/dock_builder.rs
@@ -45,6 +45,7 @@ use crate::Id;
 use crate::sys;
 use crate::ui::Ui;
 use std::ffi::CString;
+use std::ffi::c_char;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::slice;
@@ -484,8 +485,8 @@ impl DockBuilder {
         if cstrings.is_empty() {
             return;
         }
-        let ptrs: Vec<*const i8> = cstrings.iter().map(|s| s.as_ptr()).collect();
-        let mut boxed: Box<[*const i8]> = ptrs.into_boxed_slice();
+        let ptrs: Vec<*const c_char> = cstrings.iter().map(|s| s.as_ptr()).collect();
+        let mut boxed: Box<[*const c_char]> = ptrs.into_boxed_slice();
         let boxed_len_i32 = match i32::try_from(boxed.len()) {
             Ok(n) => n,
             Err(_) => return,

--- a/dear-imgui/src/fonts/atlas.rs
+++ b/dear-imgui/src/fonts/atlas.rs
@@ -9,7 +9,7 @@
 
 use crate::fonts::Font;
 use crate::sys;
-use std::ffi::CString;
+use std::ffi::{CString, c_char};
 use std::marker::PhantomData;
 use std::ptr;
 use std::rc::Rc;
@@ -945,7 +945,7 @@ impl FontConfig {
 
         // Copy the name
         for (i, &byte) in name_bytes.iter().take(copy_len).enumerate() {
-            self.raw.Name[i] = byte as i8;
+            self.raw.Name[i] = byte as c_char;
         }
 
         self


### PR DESCRIPTION
This pull request affects the `dear-imgui-rs` crate.

