### PR TITLE
Implement multiple APIs from imgui-rs

### DIFF
--- a/backends/dear-imgui-winit/src/cursor.rs
+++ b/backends/dear-imgui-winit/src/cursor.rs
@@ -40,6 +40,8 @@ pub fn to_winit_cursor(cursor: MouseCursor) -> WinitCursor {
         MouseCursor::ResizeNESW => WinitCursor::NeswResize,
         MouseCursor::ResizeNWSE => WinitCursor::NwseResize,
         MouseCursor::Hand => WinitCursor::Pointer,
+        MouseCursor::Wait => WinitCursor::Wait,
+        MouseCursor::Progress => WinitCursor::Progress,
         MouseCursor::NotAllowed => WinitCursor::NotAllowed,
     }
 }

--- a/dear-imgui/Cargo.toml
+++ b/dear-imgui/Cargo.toml
@@ -16,7 +16,8 @@ features = ["freetype"]
 
 [dependencies]
 bitflags.workspace = true
-dear-imgui-sys = { path = "../dear-imgui-sys", version = "0.8" }
+#dear-imgui-sys = { path = "../dear-imgui-sys", version = "0.8" }
+dear-imgui-sys = "0.8"
 mint.workspace = true
 parking_lot.workspace = true
 cfg-if.workspace = true

--- a/dear-imgui/Cargo.toml
+++ b/dear-imgui/Cargo.toml
@@ -16,8 +16,7 @@ features = ["freetype"]
 
 [dependencies]
 bitflags.workspace = true
-#dear-imgui-sys = { path = "../dear-imgui-sys", version = "0.8" }
-dear-imgui-sys = "0.8"
+dear-imgui-sys = { path = "../dear-imgui-sys", version = "0.8" }
 mint.workspace = true
 parking_lot.workspace = true
 cfg-if.workspace = true

--- a/dear-imgui/src/context.rs
+++ b/dear-imgui/src/context.rs
@@ -767,6 +767,21 @@ impl SuspendedContext {
             Err(self)
         }
     }
+
+    /// Updates the extra Viewports created by ImGui.
+    /// Has to be called every frame if Viewports are enabled.
+    pub fn update_platform_windows(&mut self) {
+        unsafe {
+            sys::igUpdatePlatformWindows();
+        }
+    }
+    /// Basically just calls the [`PlatformViewportBackend`](crate::PlatformViewportBackend) and [`RendererViewportBackend`](crate::RendererViewportBackend)
+    /// functions. If you render your extra viewports manually this function is not needed at all.
+    pub fn render_platform_windows_default(&mut self) {
+        unsafe {
+            sys::igRenderPlatformWindowsDefault(std::ptr::null_mut(), std::ptr::null_mut());
+        }
+    }
 }
 
 // Dear ImGui is not thread-safe. The Context must not be sent or shared across

--- a/dear-imgui/src/context.rs
+++ b/dear-imgui/src/context.rs
@@ -668,6 +668,21 @@ impl Context {
 
         self.clipboard_ctx = clipboard_ctx;
     }
+
+    /// Updates the extra Viewports created by ImGui.
+    /// Has to be called every frame if Viewports are enabled.
+    pub fn update_platform_windows(&mut self) {
+        unsafe {
+            sys::igUpdatePlatformWindows();
+        }
+    }
+    /// Basically just calls the [`PlatformViewportBackend`](crate::PlatformViewportBackend) and [`RendererViewportBackend`](crate::RendererViewportBackend)
+    /// functions. If you render your extra viewports manually this function is not needed at all.
+    pub fn render_platform_windows_default(&mut self) {
+        unsafe {
+            sys::igRenderPlatformWindowsDefault(std::ptr::null_mut(), std::ptr::null_mut());
+        }
+    }
 }
 
 impl Drop for Context {
@@ -765,21 +780,6 @@ impl SuspendedContext {
             Ok(self.0)
         } else {
             Err(self)
-        }
-    }
-
-    /// Updates the extra Viewports created by ImGui.
-    /// Has to be called every frame if Viewports are enabled.
-    pub fn update_platform_windows(&mut self) {
-        unsafe {
-            sys::igUpdatePlatformWindows();
-        }
-    }
-    /// Basically just calls the [`PlatformViewportBackend`](crate::PlatformViewportBackend) and [`RendererViewportBackend`](crate::RendererViewportBackend)
-    /// functions. If you render your extra viewports manually this function is not needed at all.
-    pub fn render_platform_windows_default(&mut self) {
-        unsafe {
-            sys::igRenderPlatformWindowsDefault(std::ptr::null_mut(), std::ptr::null_mut());
         }
     }
 }

--- a/dear-imgui/src/context.rs
+++ b/dear-imgui/src/context.rs
@@ -668,21 +668,6 @@ impl Context {
 
         self.clipboard_ctx = clipboard_ctx;
     }
-
-    /// Updates the extra Viewports created by ImGui.
-    /// Has to be called every frame if Viewports are enabled.
-    pub fn update_platform_windows(&mut self) {
-        unsafe {
-            sys::igUpdatePlatformWindows();
-        }
-    }
-    /// Basically just calls the [`PlatformViewportBackend`](crate::PlatformViewportBackend) and [`RendererViewportBackend`](crate::RendererViewportBackend)
-    /// functions. If you render your extra viewports manually this function is not needed at all.
-    pub fn render_platform_windows_default(&mut self) {
-        unsafe {
-            sys::igRenderPlatformWindowsDefault(std::ptr::null_mut(), std::ptr::null_mut());
-        }
-    }
 }
 
 impl Drop for Context {

--- a/dear-imgui/src/context.rs
+++ b/dear-imgui/src/context.rs
@@ -14,6 +14,7 @@ use std::ptr;
 
 use crate::clipboard::{ClipboardBackend, ClipboardContext};
 use crate::fonts::{Font, FontAtlas, SharedFontAtlas};
+use crate::input::MouseCursor;
 use crate::io::Io;
 
 use crate::sys;
@@ -225,6 +226,30 @@ impl Context {
                 panic!("Context::render() returned null draw data");
             }
             &*(dd as *const crate::render::DrawData)
+        }
+    }
+
+    /// Returns the currently desired mouse cursor type.
+    ///
+    /// This was set *last frame* by the [Ui] object, and will be reset when
+    /// [new_frame] is called.
+    ///
+    /// Returns `None` if no cursor should be displayed
+    ///
+    /// [new_frame]: Self::new_frame
+    #[doc(alias = "GetMouseCursor")]
+    pub fn mouse_cursor(&self) -> Option<MouseCursor> {
+        match unsafe { sys::igGetMouseCursor() } {
+            sys::ImGuiMouseCursor_Arrow => Some(MouseCursor::Arrow),
+            sys::ImGuiMouseCursor_TextInput => Some(MouseCursor::TextInput),
+            sys::ImGuiMouseCursor_ResizeAll => Some(MouseCursor::ResizeAll),
+            sys::ImGuiMouseCursor_ResizeNS => Some(MouseCursor::ResizeNS),
+            sys::ImGuiMouseCursor_ResizeEW => Some(MouseCursor::ResizeEW),
+            sys::ImGuiMouseCursor_ResizeNESW => Some(MouseCursor::ResizeNESW),
+            sys::ImGuiMouseCursor_ResizeNWSE => Some(MouseCursor::ResizeNWSE),
+            sys::ImGuiMouseCursor_Hand => Some(MouseCursor::Hand),
+            sys::ImGuiMouseCursor_NotAllowed => Some(MouseCursor::NotAllowed),
+            _ => None,
         }
     }
 

--- a/dear-imgui/src/input.rs
+++ b/dear-imgui/src/input.rs
@@ -56,6 +56,10 @@ pub enum MouseCursor {
     ResizeNWSE = sys::ImGuiMouseCursor_ResizeNWSE,
     /// Hand cursor
     Hand = sys::ImGuiMouseCursor_Hand,
+    /// Wait cursor
+    Wait = sys::ImGuiMouseCursor_Wait,
+    /// Progress cursor
+    Progress = sys::ImGuiMouseCursor_Progress,
     /// Not allowed cursor
     NotAllowed = sys::ImGuiMouseCursor_NotAllowed,
 }

--- a/dear-imgui/src/style.rs
+++ b/dear-imgui/src/style.rs
@@ -34,13 +34,13 @@
     clippy::cast_sign_loss,
     clippy::as_conversions
 )]
-use crate::Context;
 use crate::internal::RawWrapper;
 use crate::sys;
 use crate::utils::HoveredFlags;
 use crate::widget::TreeNodeFlags;
 use crate::widget::{TableFlags, TableRowFlags};
 use crate::window::WindowFlags;
+use crate::Context;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::cell::UnsafeCell;
@@ -70,6 +70,13 @@ impl Style {
     fn inner_mut(&mut self) -> &mut sys::ImGuiStyle {
         // Safety: caller has `&mut Style`, so this is a unique Rust borrow for this wrapper.
         unsafe { &mut *self.0.get() }
+    }
+
+    /// Scales all sizes in the style
+    pub fn scale_all_sizes(&mut self, scale_factor: f32) {
+        unsafe {
+            sys::ImGuiStyle_ScaleAllSizes(self.inner_mut(), scale_factor);
+        }
     }
 
     /// Get a color by style color identifier

--- a/dear-imgui/src/ui.rs
+++ b/dear-imgui/src/ui.rs
@@ -379,6 +379,14 @@ impl Ui {
         }
     }
 
+    /// Returns the width of the item given the pushed settings and the current cursor position.
+    ///
+    /// This is NOT necessarily the width of last item.
+    #[doc(alias = "CalcItemWidth")]
+    pub fn calc_item_width(&self) -> f32 {
+        unsafe { sys::igCalcItemWidth() }
+    }
+
     // ============================================================================
     // Style Access
     // ============================================================================

--- a/dear-imgui/src/widget/mod.rs
+++ b/dear-imgui/src/widget/mod.rs
@@ -110,6 +110,8 @@ bitflags::bitflags! {
         const SPAN_AVAIL_WIDTH = sys::ImGuiTreeNodeFlags_SpanAvailWidth as i32;
         /// Extend hit box to the left-most and right-most edges (bypass the indented area).
         const SPAN_FULL_WIDTH = sys::ImGuiTreeNodeFlags_SpanFullWidth as i32;
+        /// Frame will span all columns of its container table (text will still fit in current column)
+        const SPAN_ALL_COLUMNS = sys::ImGuiTreeNodeFlags_SpanAllColumns as i32;
         /// (WIP) Nav: left direction goes to parent. Only for the tree node, not the tree push.
         const NAV_LEFT_JUMPS_BACK_HERE = sys::ImGuiTreeNodeFlags_NavLeftJumpsToParent as i32;
         /// Combination of Leaf and NoTreePushOnOpen

--- a/dear-imgui/src/widget/tree.rs
+++ b/dear-imgui/src/widget/tree.rs
@@ -215,6 +215,12 @@ impl<'a, T: AsRef<str>, L: AsRef<str>> TreeNode<'a, T, L> {
         self
     }
 
+    /// Span the tree node of its container table
+    pub fn span_all_columns(mut self, value: bool) -> Self {
+        self.flags.set(TreeNodeFlags::SPAN_ALL_COLUMNS, value);
+        self
+    }
+
     /// Left direction may move to this tree node from any of its child
     pub fn nav_left_jumps_back_here(mut self, nav: bool) -> Self {
         self.flags.set(TreeNodeFlags::NAV_LEFT_JUMPS_BACK_HERE, nav);

--- a/dear-imgui/src/window/child_window.rs
+++ b/dear-imgui/src/window/child_window.rs
@@ -102,6 +102,13 @@ impl<'ui> ChildWindow<'ui> {
         self
     }
 
+    /// Enables/disables the horizontal scrollbar.
+    #[inline]
+    pub fn horizontal_scrollbar(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::HORIZONTAL_SCROLLBAR, value);
+        self
+    }
+
     /// Builds the child window and calls the provided closure
     pub fn build<F, R>(self, ui: &'ui Ui, f: F) -> Option<R>
     where

--- a/dear-imgui/src/window/mod.rs
+++ b/dear-imgui/src/window/mod.rs
@@ -51,6 +51,8 @@ use crate::{Condition, Ui};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+pub use child_window::*;
+
 pub(crate) mod child_window;
 pub(crate) mod content_region;
 pub(crate) mod scroll;

--- a/dear-imgui/src/window/mod.rs
+++ b/dear-imgui/src/window/mod.rs
@@ -148,6 +148,7 @@ pub struct Window<'ui> {
     size_condition: Condition,
     pos: Option<[f32; 2]>,
     pos_condition: Condition,
+    pos_pivot: [f32; 2],
     content_size: Option<[f32; 2]>,
     content_size_condition: Condition,
     collapsed: Option<bool>,
@@ -168,6 +169,7 @@ impl<'ui> Window<'ui> {
             size_condition: Condition::Always,
             pos: None,
             pos_condition: Condition::Always,
+            pos_pivot: [0.0, 0.0],
             content_size: None,
             content_size_condition: Condition::Always,
             collapsed: None,
@@ -210,6 +212,12 @@ impl<'ui> Window<'ui> {
         self
     }
 
+    /// Sets window position pivot
+    pub fn position_pivot(mut self, pivot: [f32; 2]) -> Self {
+        self.pos_pivot = pivot;
+        self
+    }
+
     /// Sets window content size
     pub fn content_size(mut self, size: [f32; 2], condition: Condition) -> Self {
         self.content_size = Some(size);
@@ -233,6 +241,141 @@ impl<'ui> Window<'ui> {
     /// Sets window background alpha
     pub fn bg_alpha(mut self, alpha: f32) -> Self {
         self.bg_alpha = Some(alpha);
+        self
+    }
+
+    /// Sets the title bar
+    pub fn title_bar(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_TITLE_BAR, !value);
+        self
+    }
+
+    /// Sets resizing with the lower-right grip
+    pub fn resizable(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_RESIZE, !value);
+        self
+    }
+
+    /// Sets moving the window
+    pub fn movable(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_MOVE, !value);
+        self
+    }
+
+    /// Sets scrollbars (scrolling is still possible with the mouse or programmatically)
+    pub fn scroll_bar(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_SCROLLBAR, !value);
+        self
+    }
+
+    /// Sets vertical scrolling with the mouse wheel
+    pub fn scrollable(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_SCROLL_WITH_MOUSE, !value);
+        self
+    }
+
+    /// Sets collapsing the window by double-clicking it
+    pub fn collapsible(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_COLLAPSE, !value);
+        self
+    }
+
+    /// Sets resizing the window to its content on every frame
+    pub fn always_auto_resize(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::ALWAYS_AUTO_RESIZE, value);
+        self
+    }
+
+    /// Sets drawing of background color and outside border
+    pub fn draw_background(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_BACKGROUND, !value);
+        self
+    }
+
+    /// Sets loading and saving of settings (e.g. from/to an .ini file)
+    pub fn save_settings(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_SAVED_SETTINGS, !value);
+        self
+    }
+
+    /// Sets catching mouse input.
+    pub fn mouse_inputs(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_MOUSE_INPUTS, !value);
+        self
+    }
+
+    /// Sets the menu bar
+    pub fn menu_bar(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::MENU_BAR, value);
+        self
+    }
+
+    /// Sets the horizontal scrollbar
+    pub fn horizontal_scrollbar(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::HORIZONTAL_SCROLLBAR, value);
+        self
+    }
+
+    /// Sets taking focus when transitioning from hidden to visible state
+    pub fn focus_on_appearing(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_FOCUS_ON_APPEARING, !value);
+        self
+    }
+
+    /// Sets bringing the window to front when taking focus (e.g. clicking it or programmatically
+    /// giving it focus).
+    pub fn bring_to_front_on_focus(mut self, value: bool) -> Self {
+        self.flags
+            .set(WindowFlags::NO_BRING_TO_FRONT_ON_FOCUS, !value);
+        self
+    }
+
+    /// When enabled, forces the vertical scrollbar to render regardless of the content size
+    pub fn always_vertical_scrollbar(mut self, value: bool) -> Self {
+        self.flags
+            .set(WindowFlags::ALWAYS_VERTICAL_SCROLLBAR, value);
+        self
+    }
+
+    /// When enabled, forces the horizontal scrollbar to render regardless of the content size
+    pub fn always_horizontal_scrollbar(mut self, value: bool) -> Self {
+        self.flags
+            .set(WindowFlags::ALWAYS_HORIZONTAL_SCROLLBAR, value);
+        self
+    }
+
+    /// Sets gamepad/keyboard navigation within the window
+    pub fn nav_inputs(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_NAV_INPUTS, !value);
+        self
+    }
+
+    /// Sets focusing toward this window with gamepad/keyboard navigation (e.g. CTRL+TAB)
+    pub fn nav_focus(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::NO_NAV_FOCUS, !value);
+        self
+    }
+    /// When enabled, appends '*' to title without affecting the ID, as a convenience
+    pub fn unsaved_document(mut self, value: bool) -> Self {
+        self.flags.set(WindowFlags::UNSAVED_DOCUMENT, value);
+        self
+    }
+
+    /// Disable gamepad/keyboard navigation and focusing
+    pub fn no_nav(mut self) -> Self {
+        self.flags |= WindowFlags::NO_NAV;
+        self
+    }
+
+    /// Disable all window decorations
+    pub fn no_decoration(mut self) -> Self {
+        self.flags |= WindowFlags::NO_DECORATION;
+        self
+    }
+
+    /// Disable input handling
+    pub fn no_inputs(mut self) -> Self {
+        self.flags |= WindowFlags::NO_INPUTS;
         self
     }
 
@@ -267,7 +410,12 @@ impl<'ui> Window<'ui> {
                     x: pos[0],
                     y: pos[1],
                 };
-                let pivot_vec = crate::sys::ImVec2 { x: 0.0, y: 0.0 };
+
+                let pivot_vec = crate::sys::ImVec2 {
+                    x: self.pos_pivot[0],
+                    y: self.pos_pivot[1],
+                };
+
                 crate::sys::igSetNextWindowPos(pos_vec, self.pos_condition as i32, pivot_vec);
             }
         }

--- a/examples/00-quickstart/menus_and_popups.rs
+++ b/examples/00-quickstart/menus_and_popups.rs
@@ -156,9 +156,9 @@ impl AppWindow {
         // Main menu bar
         if let Some(_bar) = ui.begin_main_menu_bar() {
             ui.menu("File", || {
-                if ui.menu_item_with_shortcut("New", "Ctrl+N") {}
-                if ui.menu_item_with_shortcut("Open...", "Ctrl+O") {}
-                if ui.menu_item_with_shortcut("Save", "Ctrl+S") {}
+                if ui.menu_item_config("New").shortcut("Ctrl+N").build() {}
+                if ui.menu_item_config("Open...").shortcut("Ctrl+O").build() {}
+                if ui.menu_item_config("Save").shortcut("Ctrl+S").build() {}
                 ui.separator();
                 if ui.menu_item("Preferences...") {
                     self.prefs_open = true;
@@ -171,8 +171,14 @@ impl AppWindow {
             });
 
             ui.menu("Edit", || {
-                ui.menu_item_enabled_selected("Undo", Some("Ctrl+Z"), false, false);
-                ui.menu_item_enabled_selected("Redo", Some("Ctrl+Y"), false, false);
+                ui.menu_item_config("Undo")
+                    .shortcut("Ctrl+Z")
+                    .enabled(false)
+                    .build();
+                ui.menu_item_config("Redo")
+                    .shortcut("Ctrl+Y")
+                    .enabled(false)
+                    .build();
                 ui.separator();
                 ui.menu_item("Cut");
                 ui.menu_item("Copy");
@@ -180,8 +186,10 @@ impl AppWindow {
             });
 
             ui.menu("View", || {
-                ui.menu_item_toggle_no_shortcut("Status Bar", &mut self.status_bar, true);
-                ui.menu_item_toggle_no_shortcut("Dark Theme", &mut self.theme_dark, true);
+                ui.menu_item_config("Status Bar")
+                    .build_with_ref(&mut self.status_bar);
+                ui.menu_item_config("Dark Theme")
+                    .build_with_ref(&mut self.theme_dark);
             });
 
             ui.menu("Help", || {
@@ -205,7 +213,12 @@ impl AppWindow {
                             ui.open_popup("RenameDoc");
                         }
                         let has_sel = self.selected.is_some();
-                        if ui.menu_item_enabled_selected_no_shortcut("Delete...", false, has_sel) {
+                        if ui
+                            .menu_item_config("Delete...")
+                            .enabled(false)
+                            .selected(has_sel)
+                            .build()
+                        {
                             self.confirm_delete_open = true;
                             ui.open_popup("ConfirmDelete");
                         }
@@ -240,7 +253,12 @@ impl AppWindow {
                         ui.close_current_popup();
                     }
                     let has_sel = self.selected.is_some();
-                    if ui.menu_item_enabled_selected_no_shortcut("Duplicate", false, has_sel) {
+                    if ui
+                        .menu_item_config("Duplicate")
+                        .enabled(false)
+                        .selected(has_sel)
+                        .build()
+                    {
                         if let Some(i) = self.selected {
                             let name = format!("{} Copy", self.sections[i]);
                             self.sections.push(name);
@@ -249,7 +267,12 @@ impl AppWindow {
                         ui.close_current_popup();
                     }
                     ui.separator();
-                    if ui.menu_item_enabled_selected_no_shortcut("Delete", false, has_sel) {
+                    if ui
+                        .menu_item_config("Delete")
+                        .enabled(false)
+                        .selected(has_sel)
+                        .build()
+                    {
                         if let Some(i) = self.selected {
                             self.sections.remove(i);
                             if self.sections.is_empty() {

--- a/examples/02-docking/dear_app_docking.rs
+++ b/examples/02-docking/dear_app_docking.rs
@@ -128,11 +128,16 @@ fn main() {
                     _m.end();
                 }
                 if let Some(_m) = ui.begin_menu("Windows") {
-                    ui.menu_item_toggle_no_shortcut("Main View", &mut state.show_main, true);
-                    ui.menu_item_toggle_no_shortcut("Command", &mut state.show_command, true);
-                    ui.menu_item_toggle_no_shortcut("Command 2", &mut state.show_command2, true);
-                    ui.menu_item_toggle_no_shortcut("Misc", &mut state.show_misc, true);
-                    ui.menu_item_toggle_no_shortcut("Logs", &mut state.show_logs, true);
+                    ui.menu_item_config("Main View")
+                        .build_with_ref(&mut state.show_main);
+                    ui.menu_item_config("Command")
+                        .build_with_ref(&mut state.show_command);
+                    ui.menu_item_config("Command 2")
+                        .build_with_ref(&mut state.show_command2);
+                    ui.menu_item_config("Misc")
+                        .build_with_ref(&mut state.show_misc);
+                    ui.menu_item_config("Logs")
+                        .build_with_ref(&mut state.show_logs);
                     _m.end();
                 }
                 _mb.end();
@@ -193,36 +198,37 @@ fn main() {
                             let mut no_central =
                                 new_flags.contains(DockFlags::NO_DOCKING_OVER_CENTRAL_NODE);
 
-                            if ui.menu_item_toggle_no_shortcut("NoSplit", &mut no_split, true) {
+                            if ui.menu_item_config("NoSplit").build_with_ref(&mut no_split) {
                                 if no_split {
                                     new_flags |= DockFlags::NO_DOCKING_SPLIT;
                                 } else {
                                     new_flags.remove(DockFlags::NO_DOCKING_SPLIT);
                                 }
                             }
-                            if ui.menu_item_toggle_no_shortcut("NoResize", &mut no_resize, true) {
+                            if ui
+                                .menu_item_config("NoResize")
+                                .build_with_ref(&mut no_resize)
+                            {
                                 if no_resize {
                                     new_flags |= DockFlags::NO_RESIZE;
                                 } else {
                                     new_flags.remove(DockFlags::NO_RESIZE);
                                 }
                             }
-                            if ui.menu_item_toggle_no_shortcut(
-                                "AutoHideTabBar",
-                                &mut auto_hide,
-                                true,
-                            ) {
+                            if ui
+                                .menu_item_config("AutoHideTabBar")
+                                .build_with_ref(&mut auto_hide)
+                            {
                                 if auto_hide {
                                     new_flags |= DockFlags::AUTO_HIDE_TAB_BAR;
                                 } else {
                                     new_flags.remove(DockFlags::AUTO_HIDE_TAB_BAR);
                                 }
                             }
-                            if ui.menu_item_toggle_no_shortcut(
-                                "NoDockingOverCentral",
-                                &mut no_central,
-                                true,
-                            ) {
+                            if ui
+                                .menu_item_config("NoDockingOverCentral")
+                                .build_with_ref(&mut no_central)
+                            {
                                 if no_central {
                                     new_flags |= DockFlags::NO_DOCKING_OVER_CENTRAL_NODE;
                                 } else {


### PR DESCRIPTION
- What
Adding multiple missing APIs that `imgui-rs` has.
MenuItem received a whole refactor. Instead of having multiple functions with some of the parameters, the MenuItem now uses a builder to be more versatile (`imgui-rs` way).

Since these are mainly copy-paste from the `imgui-rs`, feel free to suggest changes if the API doesn't match the expected for this project.

- Why
While transitioning from `imgui-rs` to this crate, I've needed access to these missing APIs.
This project is more active and has some great features that `imgui-rs` doesn't have, so I'm actively using it now and initially will focus on matching features that `imgui-rs` has and this repo doesn't.

- Affected crates
  - [x] dear-imgui-rs
  - [x] backends/dear-imgui-winit

- Behavior
  - [x] No behavior change (refactor/cleanup)

- Breaking changes
  - [ ] None
  - [x] Yes: MenuItem API uses a builder instead of multiple functions

- Testing / validation
  - Commands used (e.g., cargo build -p <crate> [...])
    - `cargo build`
    - sdl3 backend: `cargo run -p dear-imgui-examples --bin sdl3_opengl_multi_viewport --features "multi-viewport sdl3-opengl3"`
    - winit backend: `cargo run -p dear-imgui-examples --bin multi_viewport_wgpu --features multi-viewport`
  - Platforms/targets checked
    - stable-x86_64-pc-windows-msvc

- Docs
  - [x] N/A
