### PR TITLE
feat(api): audit and complete safe ImGui coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,9 @@ jobs:
       - name: Verify exact vendored source provenance
         run: python3 tools/source_metadata.py verify
 
+      - name: Verify high-level API coverage policy
+        run: python3 tools/api_surface_report.py --check
+
       - name: Regenerate and verify every core binding profile
         run: cargo run -p xtask -- verify-bindings --allow-dirty
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This is an intentionally source-breaking architecture release. It replaces shall
 - Make `ImGuiDockNode` opaque in core bindings and omit C/C++ `va_list` entry points. Private C++ layouts and `va_list` representations are not portable Rust ABI contracts.
 - Gate the blueprint stack-layout API and patched Dear ImGui core artifact behind `dear-imgui-rs/stack-layout` and `dear-node-editor/blueprints`. Normal node-editor builds use the unpatched core; the normal, freetype, stack-layout, and stack-layout + freetype feature combinations have distinct names, manifests, and cache identities. `stack-layout` remains required for the blueprints showcase and is rejected on WASM.
 - Make WASM support explicit. Only `wasm32-unknown-unknown` with the `wasm` feature may select the `imgui-sys-v0` import binding profile. Missing feature forwarding, WASI targets, Emscripten Rust targets, and `wasm + stack-layout` combinations fail at build time.
+- Replace the incomplete `FontLoader::{new,with_loader_init}` custom-loader stubs with `FontLoader::stb_truetype()`. Custom native loaders must now enter through `unsafe FontLoader::from_raw`, whose contract covers the complete callback table and all referenced state.
 
 #### Backends and runtime
 
@@ -47,6 +48,13 @@ This is an intentionally source-breaking architecture release. It replaces shall
 
 ### Added
 
+- Add typed item-state scopes through `ItemFlags`, `ItemStateFlags`, and `Ui::{push_item_flag,with_item_flag}`, plus typed X/Y style-variable overrides through `StyleVarVec2` and `Ui::{push_style_var_x,push_style_var_y}`.
+- Add `Ui::{calc_text_size,calc_text_size_with_opts}` for measuring text with the current font, including `##` suffix hiding and explicit wrap widths, without changing the next item width. Fixes #40, thanks @TheDaChicken.
+- Add safe IO coverage for analog keys, UTF-16 and UTF-8 text, native key metadata, event acceptance and clearing, F13-F24, app navigation keys, and the complete public gamepad key set.
+- Add checked list-clipper item and range inclusion with call-order and bounds validation.
+- Add explicit bitmap and vector embedded default fonts, font cache compaction, and loaded/debug-name queries.
+- Add safe style size scaling, style-color flashing, text-encoding diagnostics, and item-picker startup helpers.
+- Add effective managed or legacy texture ID lookup through `TextureRef::texture_id` and `DrawCmdParams::texture_id`.
 - Add a deterministic, host-independent binding specification shared by build scripts, regeneration, verification, packaging, and CI. It supplies self-contained standard-header shims, disables host include fallback, and hashes the generator contract, exact compatibility targets, formatter, allow/block lists, enum normalization, opaque types, and fixed WASM provider.
 - Add exact cimgui and nested Dear ImGui source revisions to package metadata so source identity survives `cargo package` without a `.git` directory.
 - Add strict `dear-imgui-sys` core native prebuilt manifests covering crate/version, target, link type, MSVC CRT, normalized artifact features, exact source revisions, and binding-spec hash. Missing, duplicate, unknown, or mismatched fields reject the core artifact.
@@ -54,6 +62,8 @@ This is an intentionally source-breaking architecture release. It replaces shall
 
 ### Changed
 
+- Guard every public cimgui generator declaration with a source-pinned API snapshot, and require every top-level `ImGui` function to map to a public safe Rust item or an explicit policy decision so CI rejects raw API drift and unreviewed safe API gaps.
+- Allow `TableColumnSetup::user_id` and the chainable table column builder to accept `u32` values directly while preserving typed `Id` inputs and non-zero validation. Fixes #39, thanks @TheDaChicken.
 - Share callback ownership, viewport recovery, and teardown through one private runtime across the Winit and SDL3 adapters for each renderer backend.
 - Update `dear-app`, renderer examples, and the browser demo to WGPU 30 surface color-space and queue-present APIs.
 - Regenerate and verify the Windows, non-Windows, and WASM core binding profiles from one canonical command while keeping extension generation on the fixed `imgui-sys-v0` provider contract.
@@ -63,6 +73,11 @@ This is an intentionally source-breaking architecture release. It replaces shall
 - Statically link the C++ standard library for Windows GNU native C++ builds so downstream executables no longer require a separate `libstdc++-6.dll` at runtime. The Windows GNU CI job checks the produced test binary import table for this regression. Fixes #36, thanks @HampusMat.
 - Use the same path-only `EntryId` contract for file-browser operations and directory scans so created, renamed, and symbolic-link entries remain selectable after rescans, including on Windows.
 - Exercise aggregate PlatformIO callbacks through the real C++ slots on both MSVC `/MD` and `/MT`, preventing Rust declarations from drifting away from the compiler ABI actually used by Dear ImGui.
+- Preserve tree-node ID semantics and push/pop pairing for string, pointer, and integer IDs, including `NO_TREE_PUSH_ON_OPEN`, and add explicit RAII tree scopes.
+- Submit the current combo entry as selected before applying default focus.
+- Apply backward multi-select ranges in Dear ImGui's requested direction with checked index conversion.
+- Resolve managed texture IDs in draw command parameters after processing texture requests, while allowing pending textures to be inspected without triggering Dear ImGui's renderer-upload assertion.
+- Avoid an out-of-bounds read when measuring text ending in a single `#`, and share the same sentinel-safe measurement path with `push_item_width_text`.
 
 ### Migration Examples
 

--- a/backends/dear-imgui-ash/src/renderer/draw.rs
+++ b/backends/dear-imgui-ash/src/renderer/draw.rs
@@ -274,9 +274,9 @@ pub(super) fn record_draw_commands(
                 dear_imgui_rs::render::DrawCmd::Elements {
                     count,
                     cmd_params,
-                    raw_cmd,
+                    raw_cmd: _,
                 } => {
-                    let tex_id = resolve_effective_texture_id(cmd_params.texture_id, raw_cmd);
+                    let tex_id = cmd_params.texture_id;
                     let ds = textures
                         .get_descriptor_set(tex_id.id())
                         .or_else(|| {
@@ -376,17 +376,4 @@ pub(super) fn record_draw_commands(
     }
 
     Ok(())
-}
-
-fn resolve_effective_texture_id(
-    legacy: TextureId,
-    raw_cmd: *const dear_imgui_rs::sys::ImDrawCmd,
-) -> TextureId {
-    if raw_cmd.is_null() {
-        return legacy;
-    }
-    unsafe {
-        let mut copy = *raw_cmd;
-        TextureId::from(dear_imgui_rs::sys::ImDrawCmd_GetTexID(&mut copy))
-    }
 }

--- a/backends/dear-imgui-glow/src/renderer/draw.rs
+++ b/backends/dear-imgui-glow/src/renderer/draw.rs
@@ -281,18 +281,13 @@ impl GlowRenderer {
                     DrawCmd::Elements {
                         count,
                         cmd_params,
-                        raw_cmd,
+                        raw_cmd: _,
                     } => {
-                        let tex_id_u64 = unsafe {
-                            let mut cmd_copy = *raw_cmd;
-                            dear_imgui_rs::sys::ImDrawCmd_GetTexID(&mut cmd_copy)
-                        } as u64;
-                        let tex_id = dear_imgui_rs::TextureId::from(tex_id_u64);
                         self.render_elements(
                             gl,
                             texture_map,
                             count,
-                            tex_id,
+                            cmd_params.texture_id,
                             &cmd_params,
                             draw_data,
                             sampler_filter,

--- a/backends/dear-imgui-wgpu/src/renderer/draw.rs
+++ b/backends/dear-imgui-wgpu/src/renderer/draw.rs
@@ -151,14 +151,9 @@ impl WgpuRenderer {
                     dear_imgui_rs::render::DrawCmd::Elements {
                         count,
                         cmd_params,
-                        raw_cmd,
+                        raw_cmd: _,
                     } => {
-                        // Resolve effective ImTextureID now (after texture updates)
-                        let tex_id = unsafe {
-                            let mut cmd_copy = *raw_cmd;
-                            dear_imgui_rs::sys::ImDrawCmd_GetTexID(&mut cmd_copy)
-                        };
-                        let tex_id = TextureId::from(tex_id);
+                        let tex_id = cmd_params.texture_id;
 
                         // Switch common bind group (sampler) if this texture uses a custom sampler
                         // or a standard sampler callback changed the default.

--- a/backends/dear-imgui-wgpu/src/renderer/render.rs
+++ b/backends/dear-imgui-wgpu/src/renderer/render.rs
@@ -298,14 +298,9 @@ impl WgpuRenderer {
                         dear_imgui_rs::render::DrawCmd::Elements {
                             count,
                             cmd_params,
-                            raw_cmd,
+                            raw_cmd: _,
                         } => {
-                            // Texture bind group resolution mirrors render_draw_lists_static
-                            // Resolve effective ImTextureID using raw_cmd (modern texture path)
-                            let mut cmd_copy = *raw_cmd;
-                            let tex_id = TextureId::from(dear_imgui_rs::sys::ImDrawCmd_GetTexID(
-                                &mut cmd_copy,
-                            ));
+                            let tex_id = cmd_params.texture_id;
 
                             // Switch common bind group (sampler) if this texture uses a custom sampler
                             // or a standard sampler callback changed the default.

--- a/dear-imgui/src/colors.rs
+++ b/dear-imgui/src/colors.rs
@@ -49,6 +49,7 @@ impl Color {
     ///
     /// ImGui packs colors with IM_COL32(R,G,B,A) into `(A<<24)|(B<<16)|(G<<8)|R`.
     /// This converts that ABGR-packed u32 into an RGBA float Color.
+    #[doc(alias = "ColorConvertU32ToFloat4")]
     pub fn from_imgui_u32(abgr: u32) -> Self {
         unsafe {
             let v = sys::igColorConvertU32ToFloat4(abgr);
@@ -67,6 +68,7 @@ impl Color {
     }
 
     /// Pack to ImGui ImU32 ABGR order `(A<<24)|(B<<16)|(G<<8)|R`.
+    #[doc(alias = "ColorConvertFloat4ToU32")]
     pub fn to_imgui_u32(self) -> u32 {
         unsafe {
             sys::igColorConvertFloat4ToU32(sys::ImVec4_c {

--- a/dear-imgui/src/context/core.rs
+++ b/dear-imgui/src/context/core.rs
@@ -35,6 +35,12 @@ use super::texture_registry::unregister_user_textures_for_context;
 ///
 /// let ctx2 = dear_imgui_rs::Context::create(); // PANIC
 /// ```
+#[doc(
+    alias = "CreateContext",
+    alias = "DestroyContext",
+    alias = "GetCurrentContext",
+    alias = "SetCurrentContext"
+)]
 #[derive(Debug)]
 pub struct Context {
     pub(super) raw: *mut sys::ImGuiContext,

--- a/dear-imgui/src/context/frame.rs
+++ b/dear-imgui/src/context/frame.rs
@@ -66,6 +66,7 @@ impl FramePrepareOptions {
 /// system consumes the token to render or snapshot the frame. The existing [`Context::frame`] and
 /// [`Context::render`] calls remain available for traditional immediate-mode loops.
 #[must_use = "dropping FrameToken ends the frame without rendering; call render() or render_snapshot() to produce draw data"]
+#[doc(alias = "EndFrame")]
 pub struct FrameToken<'ctx> {
     ctx: &'ctx mut Context,
     closed: bool,
@@ -121,6 +122,7 @@ impl Context {
     ///
     /// Note: you must update `io.DisplaySize` (and usually `io.DeltaTime`) before calling this,
     /// unless you are using a platform backend that does it for you (e.g. `dear-imgui-winit`).
+    #[doc(alias = "NewFrame")]
     pub fn frame(&mut self) -> &mut crate::ui::Ui {
         let _guard = CTX_MUTEX.lock();
         self.assert_current_context("Context::frame()");
@@ -178,6 +180,7 @@ dear-imgui-winit::WinitPlatform::prepare_frame().",
     ///
     /// Renderer backends receive mutable draw data because ImGui 1.92 texture requests require
     /// backends to write `TexID`/`Status` feedback into `ImTextureData`.
+    #[doc(alias = "Render", alias = "GetDrawData")]
     pub fn render(&mut self) -> &mut crate::render::DrawData {
         let _guard = CTX_MUTEX.lock();
         self.assert_current_context("Context::render()");

--- a/dear-imgui/src/context/platform.rs
+++ b/dear-imgui/src/context/platform.rs
@@ -8,6 +8,7 @@ impl Context {
     ///
     /// Note: `ImGuiPlatformIO` exists even when multi-viewport is disabled. We expose it
     /// unconditionally so callers can use ImGui 1.92+ texture management via `PlatformIO.Textures[]`.
+    #[doc(alias = "GetPlatformIO")]
     pub fn platform_io(&self) -> &crate::platform_io::PlatformIo {
         let _guard = CTX_MUTEX.lock();
         unsafe {
@@ -62,6 +63,7 @@ impl Context {
     /// This function should be called every frame when multi-viewport is enabled.
     /// It updates all platform windows and handles viewport management.
     #[cfg(feature = "multi-viewport")]
+    #[doc(alias = "UpdatePlatformWindows")]
     pub fn update_platform_windows(&mut self) {
         let _guard = CTX_MUTEX.lock();
         unsafe {
@@ -86,6 +88,7 @@ impl Context {
     /// This function renders all platform windows using the default implementation.
     /// It calls the platform and renderer backends to render each viewport.
     #[cfg(feature = "multi-viewport")]
+    #[doc(alias = "RenderPlatformWindowsDefault")]
     pub fn render_platform_windows_default(&mut self) {
         let _guard = CTX_MUTEX.lock();
         unsafe {
@@ -100,6 +103,7 @@ impl Context {
     /// This function should be called during shutdown to properly clean up
     /// all platform windows and their associated resources.
     #[cfg(feature = "multi-viewport")]
+    #[doc(alias = "DestroyPlatformWindows")]
     pub fn destroy_platform_windows(&mut self) {
         let _guard = CTX_MUTEX.lock();
         unsafe {

--- a/dear-imgui/src/drag_drop/source.rs
+++ b/dear-imgui/src/drag_drop/source.rs
@@ -59,6 +59,7 @@ impl<'ui, T: AsRef<str>> DragDropSource<'ui, T> {
     ///
     /// Returns a tooltip token if dragging started, `None` otherwise.
     #[inline]
+    #[doc(alias = "BeginDragDropSource", alias = "SetDragDropPayload")]
     pub fn begin_payload<P: Copy + 'static>(
         self,
         payload: P,
@@ -122,6 +123,7 @@ impl<'ui, T: AsRef<str>> DragDropSource<'ui, T> {
 /// While this token exists, you can add UI elements that will be shown
 /// as a tooltip during the drag operation.
 #[derive(Debug)]
+#[doc(alias = "EndDragDropSource")]
 pub struct DragDropSourceTooltip<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/drag_drop/target.rs
+++ b/dear-imgui/src/drag_drop/target.rs
@@ -11,6 +11,7 @@ use crate::{Ui, sys};
 /// This struct is created by [`Ui::drag_drop_target`] and provides
 /// methods for accepting different types of payloads.
 #[derive(Debug)]
+#[doc(alias = "EndDragDropTarget")]
 pub struct DragDropTarget<'ui>(pub(super) &'ui Ui);
 
 impl<'ui> DragDropTarget<'ui> {
@@ -48,6 +49,7 @@ impl<'ui> DragDropTarget<'ui> {
     /// * `flags` - Accept flags
     ///
     /// Returns `Some(Result<payload, error>)` if payload exists, `None` otherwise.
+    #[doc(alias = "AcceptDragDropPayload")]
     pub fn accept_payload<T: 'static + Copy, Name: AsRef<str>>(
         &self,
         name: Name,

--- a/dear-imgui/src/fonts/atlas/core/add_font.rs
+++ b/dear-imgui/src/fonts/atlas/core/add_font.rs
@@ -161,19 +161,31 @@ impl FontAtlas {
     /// Add the default font to the atlas
     #[doc(alias = "AddFontDefault")]
     pub fn add_font_default(&mut self, font_cfg: Option<&FontConfig>) -> &mut Font {
-        if let Some(cfg) = font_cfg {
-            cfg.validate_for_add_font_default("FontAtlas::add_font_default()");
-        }
-        unsafe {
-            let cfg_ptr = font_cfg.map_or(ptr::null(), |cfg| cfg.raw());
-            let font_ptr = sys::ImFontAtlas_AddFontDefault(self.raw, cfg_ptr);
-            if let Some(cfg) = font_cfg {
-                if cfg.raw.MergeMode {
-                    self.discard_bakes(0);
-                }
-            }
-            Font::from_raw_mut(font_ptr)
-        }
+        self.add_embedded_default_font(
+            font_cfg,
+            "FontAtlas::add_font_default()",
+            sys::ImFontAtlas_AddFontDefault,
+        )
+    }
+
+    /// Add Dear ImGui's scalable embedded default font.
+    #[doc(alias = "AddFontDefaultVector")]
+    pub fn add_font_default_vector(&mut self, font_cfg: Option<&FontConfig>) -> &mut Font {
+        self.add_embedded_default_font(
+            font_cfg,
+            "FontAtlas::add_font_default_vector()",
+            sys::ImFontAtlas_AddFontDefaultVector,
+        )
+    }
+
+    /// Add Dear ImGui's pixel-clean embedded default font.
+    #[doc(alias = "AddFontDefaultBitmap")]
+    pub fn add_font_default_bitmap(&mut self, font_cfg: Option<&FontConfig>) -> &mut Font {
+        self.add_embedded_default_font(
+            font_cfg,
+            "FontAtlas::add_font_default_bitmap()",
+            sys::ImFontAtlas_AddFontDefaultBitmap,
+        )
     }
 
     /// Add a font from a TTF file
@@ -392,6 +404,34 @@ impl FontAtlas {
                 }
                 Some(Font::from_raw_mut(font_ptr))
             }
+        }
+    }
+}
+
+impl FontAtlas {
+    fn add_embedded_default_font(
+        &mut self,
+        font_cfg: Option<&FontConfig>,
+        caller: &str,
+        add_font: unsafe extern "C" fn(
+            *mut sys::ImFontAtlas,
+            *const sys::ImFontConfig,
+        ) -> *mut sys::ImFont,
+    ) -> &mut Font {
+        if let Some(cfg) = font_cfg {
+            cfg.validate_for_add_font_default(caller);
+        }
+        unsafe {
+            let cfg_ptr = font_cfg.map_or(ptr::null(), FontConfig::raw);
+            let font_ptr = add_font(self.raw, cfg_ptr);
+            assert!(
+                !font_ptr.is_null(),
+                "{caller} failed to add the embedded font"
+            );
+            if font_cfg.is_some_and(|cfg| cfg.raw.MergeMode) {
+                self.discard_bakes(0);
+            }
+            Font::from_raw_mut(font_ptr)
         }
     }
 }

--- a/dear-imgui/src/fonts/atlas/core/build.rs
+++ b/dear-imgui/src/fonts/atlas/core/build.rs
@@ -52,4 +52,25 @@ impl FontAtlas {
             sys::igImFontAtlasBuildDiscardBakes(self.raw, unused_frames);
         }
     }
+
+    /// Compact cached glyphs and the current atlas texture.
+    ///
+    /// This is a no-op before the atlas builder and texture have been created.
+    /// It must not be called while the atlas is locked by a frame.
+    #[doc(alias = "CompactCache")]
+    pub fn compact_cache(&mut self) {
+        if self.raw.is_null() {
+            return;
+        }
+        unsafe {
+            assert!(
+                !(*self.raw).Locked,
+                "FontAtlas::compact_cache() cannot modify a locked font atlas"
+            );
+            if (*self.raw).Builder.is_null() || (*self.raw).TexData.is_null() {
+                return;
+            }
+            sys::ImFontAtlas_CompactCache(self.raw);
+        }
+    }
 }

--- a/dear-imgui/src/fonts/atlas/loader.rs
+++ b/dear-imgui/src/fonts/atlas/loader.rs
@@ -1,53 +1,44 @@
-use std::ffi::CString;
-
 use crate::sys;
 
-use super::core::FontAtlas;
-
-/// Font loader interface for custom font backends
+/// Borrowed handle to a complete Dear ImGui font-loader callback table.
 ///
-/// This provides a safe Rust interface to Dear ImGui's ImFontLoader system,
-/// allowing custom font loading implementations.
-pub struct FontLoader {
-    raw: sys::ImFontLoader,
-    _name: CString,
-}
+/// Safe code can obtain the built-in stb_truetype loader. Custom loaders must
+/// be created in native code and enter through [`FontLoader::from_raw`], whose
+/// safety contract covers every callback and stored pointer.
+#[repr(transparent)]
+pub struct FontLoader(sys::ImFontLoader);
 
 impl FontLoader {
-    /// Creates a new font loader with the given name
-    pub fn new(name: &str) -> Result<Self, std::ffi::NulError> {
-        let name_cstring = CString::new(name)?;
-        // Initialize via ImGui constructor to future-proof defaults
-        let mut raw = unsafe {
-            let p = sys::ImFontLoader_ImFontLoader();
-            if p.is_null() {
-                panic!("ImFontLoader_ImFontLoader() returned null");
-            }
-            let v = *p;
-            sys::ImFontLoader_destroy(p);
-            v
-        };
-        raw.Name = name_cstring.as_ptr();
-
-        Ok(Self {
-            raw,
-            _name: name_cstring,
-        })
+    /// Return Dear ImGui's built-in stb_truetype loader.
+    #[doc(alias = "ImFontAtlasGetFontLoaderForStbTruetype")]
+    pub fn stb_truetype() -> &'static Self {
+        let raw = unsafe { sys::igImFontAtlasGetFontLoaderForStbTruetype() };
+        assert!(
+            !raw.is_null(),
+            "Dear ImGui returned a null stb_truetype font loader"
+        );
+        unsafe { &*raw.cast::<Self>() }
     }
 
-    /// Returns a pointer to the raw ImFontLoader
+    /// Borrow an externally owned font loader.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must point to a fully initialized `ImFontLoader`. Its name and all
+    /// callback pointers, callback userdata, and referenced native state must
+    /// remain valid for `'a`. Every callback must obey Dear ImGui's ABI, must not
+    /// unwind across FFI, and must satisfy the callback-specific ownership rules.
+    pub unsafe fn from_raw<'a>(raw: *const sys::ImFontLoader) -> &'a Self {
+        assert!(
+            !raw.is_null(),
+            "FontLoader::from_raw() received a null pointer"
+        );
+        unsafe { &*raw.cast::<Self>() }
+    }
+
+    /// Return the borrowed raw loader pointer.
     pub(crate) fn as_ptr(&self) -> *const sys::ImFontLoader {
-        &self.raw
-    }
-
-    /// Sets the loader initialization callback
-    pub fn with_loader_init<F>(self, _callback: F) -> Self
-    where
-        F: Fn(&mut FontAtlas) -> bool + 'static,
-    {
-        // Note: For now, we'll use the default STB TrueType loader
-        // Custom callbacks would require more complex lifetime management
-        self
+        &self.0
     }
 }
 
@@ -105,5 +96,17 @@ impl std::ops::BitOr for FontLoaderFlags {
 impl std::ops::BitOrAssign for FontLoaderFlags {
     fn bitor_assign(&mut self, rhs: Self) {
         self.0 |= rhs.0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn builtin_font_loader_has_required_callbacks() {
+        let loader = super::FontLoader::stb_truetype();
+        let raw = loader.as_ptr();
+        assert!(!raw.is_null());
+        assert!(!unsafe { (*raw).Name }.is_null());
+        assert!(unsafe { (*raw).FontBakedLoadGlyph }.is_some());
     }
 }

--- a/dear-imgui/src/fonts/atlas/tests.rs
+++ b/dear-imgui/src/fonts/atlas/tests.rs
@@ -267,6 +267,19 @@ fn font_sources_reject_invalid_sizes_before_ffi() {
 }
 
 #[test]
+fn explicit_embedded_fonts_and_cache_compaction_are_safe() {
+    let mut ctx = crate::Context::create();
+
+    ctx.font_atlas_mut().compact_cache();
+    let bitmap = ctx.font_atlas_mut().add_font_default_bitmap(None).id();
+    let vector = ctx.font_atlas_mut().add_font_default_vector(None).id();
+    assert_ne!(bitmap, vector);
+
+    assert!(ctx.font_atlas_mut().build());
+    ctx.font_atlas_mut().compact_cache();
+}
+
+#[test]
 fn set_texture_id_preserves_managed_tex_data_reference() {
     let mut ctx = crate::Context::create();
     let mut fonts = ctx.font_atlas_mut();

--- a/dear-imgui/src/fonts/font.rs
+++ b/dear-imgui/src/fonts/font.rs
@@ -65,6 +65,25 @@ impl Font {
         self.0.get()
     }
 
+    /// Return whether this font has loaded runtime data.
+    #[doc(alias = "IsLoaded")]
+    pub fn is_loaded(&self) -> bool {
+        unsafe { sys::ImFont_IsLoaded(self.raw()) }
+    }
+
+    /// Return the font name used by Dear ImGui's debug tools.
+    #[doc(alias = "GetDebugName")]
+    pub fn debug_name(&self) -> &str {
+        unsafe {
+            let name = sys::ImFont_GetDebugName(self.raw());
+            if name.is_null() {
+                ""
+            } else {
+                std::ffi::CStr::from_ptr(name).to_str().unwrap_or("")
+            }
+        }
+    }
+
     /// Check if a glyph is available in this font
     #[doc(alias = "IsGlyphInFont")]
     pub fn is_glyph_in_font(&self, c: char) -> bool {
@@ -206,6 +225,16 @@ mod tests {
             }))
             .is_err()
         );
+    }
+
+    #[test]
+    fn loaded_font_exposes_its_debug_name() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+        let font = ui.current_font();
+
+        assert!(font.is_loaded());
+        assert!(!font.debug_name().is_empty());
     }
 
     #[test]

--- a/dear-imgui/src/input/keyboard.rs
+++ b/dear-imgui/src/input/keyboard.rs
@@ -162,6 +162,30 @@ pub enum Key {
     F11 = sys::ImGuiKey_F11 as i32,
     /// F12 key
     F12 = sys::ImGuiKey_F12 as i32,
+    /// F13 key
+    F13 = sys::ImGuiKey_F13 as i32,
+    /// F14 key
+    F14 = sys::ImGuiKey_F14 as i32,
+    /// F15 key
+    F15 = sys::ImGuiKey_F15 as i32,
+    /// F16 key
+    F16 = sys::ImGuiKey_F16 as i32,
+    /// F17 key
+    F17 = sys::ImGuiKey_F17 as i32,
+    /// F18 key
+    F18 = sys::ImGuiKey_F18 as i32,
+    /// F19 key
+    F19 = sys::ImGuiKey_F19 as i32,
+    /// F20 key
+    F20 = sys::ImGuiKey_F20 as i32,
+    /// F21 key
+    F21 = sys::ImGuiKey_F21 as i32,
+    /// F22 key
+    F22 = sys::ImGuiKey_F22 as i32,
+    /// F23 key
+    F23 = sys::ImGuiKey_F23 as i32,
+    /// F24 key
+    F24 = sys::ImGuiKey_F24 as i32,
 
     // --- Punctuation and extra named keys ---
     /// Apostrophe (') key
@@ -233,8 +257,62 @@ pub enum Key {
     /// Numpad equal
     KeypadEqual = sys::ImGuiKey_KeypadEqual as i32,
 
+    /// Application back navigation key
+    AppBack = sys::ImGuiKey_AppBack as i32,
+    /// Application forward navigation key
+    AppForward = sys::ImGuiKey_AppForward as i32,
+
     /// OEM 102 key (ISO < > |)
     Oem102 = sys::ImGuiKey_Oem102 as i32,
+
+    /// Gamepad start button
+    GamepadStart = sys::ImGuiKey_GamepadStart as i32,
+    /// Gamepad back/select button
+    GamepadBack = sys::ImGuiKey_GamepadBack as i32,
+    /// Gamepad left face button
+    GamepadFaceLeft = sys::ImGuiKey_GamepadFaceLeft as i32,
+    /// Gamepad right face button
+    GamepadFaceRight = sys::ImGuiKey_GamepadFaceRight as i32,
+    /// Gamepad upper face button
+    GamepadFaceUp = sys::ImGuiKey_GamepadFaceUp as i32,
+    /// Gamepad lower face button
+    GamepadFaceDown = sys::ImGuiKey_GamepadFaceDown as i32,
+    /// Gamepad D-pad left
+    GamepadDpadLeft = sys::ImGuiKey_GamepadDpadLeft as i32,
+    /// Gamepad D-pad right
+    GamepadDpadRight = sys::ImGuiKey_GamepadDpadRight as i32,
+    /// Gamepad D-pad up
+    GamepadDpadUp = sys::ImGuiKey_GamepadDpadUp as i32,
+    /// Gamepad D-pad down
+    GamepadDpadDown = sys::ImGuiKey_GamepadDpadDown as i32,
+    /// Gamepad left shoulder button
+    GamepadL1 = sys::ImGuiKey_GamepadL1 as i32,
+    /// Gamepad right shoulder button
+    GamepadR1 = sys::ImGuiKey_GamepadR1 as i32,
+    /// Gamepad left analog trigger
+    GamepadL2 = sys::ImGuiKey_GamepadL2 as i32,
+    /// Gamepad right analog trigger
+    GamepadR2 = sys::ImGuiKey_GamepadR2 as i32,
+    /// Gamepad left stick button
+    GamepadL3 = sys::ImGuiKey_GamepadL3 as i32,
+    /// Gamepad right stick button
+    GamepadR3 = sys::ImGuiKey_GamepadR3 as i32,
+    /// Gamepad left stick leaning left
+    GamepadLStickLeft = sys::ImGuiKey_GamepadLStickLeft as i32,
+    /// Gamepad left stick leaning right
+    GamepadLStickRight = sys::ImGuiKey_GamepadLStickRight as i32,
+    /// Gamepad left stick leaning up
+    GamepadLStickUp = sys::ImGuiKey_GamepadLStickUp as i32,
+    /// Gamepad left stick leaning down
+    GamepadLStickDown = sys::ImGuiKey_GamepadLStickDown as i32,
+    /// Gamepad right stick leaning left
+    GamepadRStickLeft = sys::ImGuiKey_GamepadRStickLeft as i32,
+    /// Gamepad right stick leaning right
+    GamepadRStickRight = sys::ImGuiKey_GamepadRStickRight as i32,
+    /// Gamepad right stick leaning up
+    GamepadRStickUp = sys::ImGuiKey_GamepadRStickUp as i32,
+    /// Gamepad right stick leaning down
+    GamepadRStickDown = sys::ImGuiKey_GamepadRStickDown as i32,
 }
 
 impl From<Key> for sys::ImGuiKey {

--- a/dear-imgui/src/io/events.rs
+++ b/dear-imgui/src/io/events.rs
@@ -2,21 +2,52 @@ use crate::io::{Io, assert_finite_vec2};
 use crate::sys;
 
 impl Io {
-    /// Add a key event to the input queue
+    /// Add a key event to the input queue.
+    #[doc(alias = "AddKeyEvent")]
     pub fn add_key_event(&mut self, key: crate::Key, down: bool) {
         unsafe {
             sys::ImGuiIO_AddKeyEvent(self.inner_mut() as *mut _, key.into(), down);
         }
     }
 
-    /// Add a character input event to the input queue
+    /// Add a key or gamepad event with an analog value in `0.0..=1.0`.
+    #[doc(alias = "AddKeyAnalogEvent")]
+    pub fn add_key_analog_event(&mut self, key: crate::Key, down: bool, value: f32) {
+        assert!(
+            value.is_finite() && (0.0..=1.0).contains(&value),
+            "Io::add_key_analog_event() value must be finite and in 0.0..=1.0"
+        );
+        unsafe {
+            sys::ImGuiIO_AddKeyAnalogEvent(self.inner_mut() as *mut _, key.into(), down, value);
+        }
+    }
+
+    /// Add a character input event to the input queue.
+    #[doc(alias = "AddInputCharacter")]
     pub fn add_input_character(&mut self, character: char) {
         unsafe {
             sys::ImGuiIO_AddInputCharacter(self.inner_mut() as *mut _, character as u32);
         }
     }
 
-    /// Add a mouse position event to the input queue
+    /// Add one UTF-16 code unit, preserving Dear ImGui's surrogate-pair state.
+    #[doc(alias = "AddInputCharacterUTF16")]
+    pub fn add_input_character_utf16(&mut self, code_unit: u16) {
+        unsafe {
+            sys::ImGuiIO_AddInputCharacterUTF16(self.inner_mut() as *mut _, code_unit);
+        }
+    }
+
+    /// Add all Unicode scalar values from a UTF-8 Rust string.
+    #[doc(alias = "AddInputCharactersUTF8")]
+    pub fn add_input_characters_utf8(&mut self, text: impl AsRef<str>) {
+        for character in text.as_ref().chars() {
+            self.add_input_character(character);
+        }
+    }
+
+    /// Add a mouse position event to the input queue.
+    #[doc(alias = "AddMousePosEvent")]
     pub fn add_mouse_pos_event(&mut self, pos: [f32; 2]) {
         assert_finite_vec2("Io::add_mouse_pos_event()", "pos", pos);
         unsafe {
@@ -24,14 +55,16 @@ impl Io {
         }
     }
 
-    /// Add a mouse button event to the input queue
+    /// Add a mouse button event to the input queue.
+    #[doc(alias = "AddMouseButtonEvent")]
     pub fn add_mouse_button_event(&mut self, button: crate::input::MouseButton, down: bool) {
         unsafe {
             sys::ImGuiIO_AddMouseButtonEvent(self.inner_mut() as *mut _, button.into(), down);
         }
     }
 
-    /// Add a mouse wheel event to the input queue
+    /// Add a mouse wheel event to the input queue.
+    #[doc(alias = "AddMouseWheelEvent")]
     pub fn add_mouse_wheel_event(&mut self, wheel: [f32; 2]) {
         assert_finite_vec2("Io::add_mouse_wheel_event()", "wheel", wheel);
         unsafe {
@@ -41,32 +74,165 @@ impl Io {
 
     /// Add a mouse source event to the input queue.
     ///
-    /// When the input source switches between mouse / touch screen / pen,
-    /// backends should call this before submitting other mouse events for
-    /// the frame.
+    /// Backends should call this before other mouse events when switching
+    /// between mouse, touch-screen, and pen input.
+    #[doc(alias = "AddMouseSourceEvent")]
     pub fn add_mouse_source_event(&mut self, source: crate::input::MouseSource) {
         unsafe {
             sys::ImGuiIO_AddMouseSourceEvent(self.inner_mut() as *mut _, source.into());
         }
     }
 
-    /// Queue the hovered viewport id for the current frame.
+    /// Queue the hovered viewport ID for the current frame.
     ///
-    /// When multi-viewport is enabled and the backend can reliably obtain
-    /// the ImGui viewport hovered by the OS mouse, it should set
-    /// `BackendFlags::HAS_MOUSE_HOVERED_VIEWPORT` and call this once per
-    /// frame.
+    /// Backends should also set `BackendFlags::HAS_MOUSE_HOVERED_VIEWPORT`.
+    #[doc(alias = "AddMouseViewportEvent")]
     pub fn add_mouse_viewport_event(&mut self, viewport_id: crate::Id) {
         unsafe {
             sys::ImGuiIO_AddMouseViewportEvent(self.inner_mut() as *mut _, viewport_id.raw());
         }
     }
 
-    /// Notify Dear ImGui that the application window gained or lost focus
-    /// This mirrors `io.AddFocusEvent()` in Dear ImGui and is used by platform backends.
+    /// Notify Dear ImGui that the application gained or lost focus.
+    #[doc(alias = "AddFocusEvent")]
     pub fn add_focus_event(&mut self, focused: bool) {
         unsafe {
             sys::ImGuiIO_AddFocusEvent(self.inner_mut() as *mut _, focused);
         }
+    }
+
+    /// Store native key metadata for legacy backend interoperability.
+    ///
+    /// `native_legacy_index`, when present, must be in `0..512`.
+    #[doc(alias = "SetKeyEventNativeData")]
+    pub fn set_key_event_native_data(
+        &mut self,
+        key: crate::Key,
+        native_keycode: i32,
+        native_scancode: i32,
+        native_legacy_index: Option<i32>,
+    ) {
+        let key: sys::ImGuiKey = key.into();
+        assert!(
+            (sys::ImGuiKey_NamedKey_BEGIN..sys::ImGuiKey_NamedKey_END).contains(&key),
+            "Io::set_key_event_native_data() key must be a named non-modifier key"
+        );
+        let native_legacy_index = native_legacy_index.unwrap_or(-1);
+        assert!(
+            native_legacy_index == -1
+                || (0..sys::ImGuiKey_NamedKey_BEGIN).contains(&native_legacy_index),
+            "Io::set_key_event_native_data() native_legacy_index must be in 0..512"
+        );
+        unsafe {
+            sys::ImGuiIO_SetKeyEventNativeData(
+                self.inner_mut() as *mut _,
+                key,
+                native_keycode,
+                native_scancode,
+                native_legacy_index,
+            );
+        }
+    }
+
+    /// Enable or pause acceptance of queued keyboard, mouse, and text events.
+    #[doc(alias = "SetAppAcceptingEvents")]
+    pub fn set_app_accepting_events(&mut self, accepting_events: bool) {
+        unsafe {
+            sys::ImGuiIO_SetAppAcceptingEvents(self.inner_mut() as *mut _, accepting_events);
+        }
+    }
+
+    /// Clear all pending input events that have not been processed by a frame.
+    #[doc(alias = "ClearEventsQueue")]
+    pub fn clear_events_queue(&mut self) {
+        unsafe { sys::ImGuiIO_ClearEventsQueue(self.inner_mut() as *mut _) }
+    }
+
+    /// Release all keyboard/gamepad state and clear queued text characters.
+    #[doc(alias = "ClearInputKeys")]
+    pub fn clear_input_keys(&mut self) {
+        unsafe { sys::ImGuiIO_ClearInputKeys(self.inner_mut() as *mut _) }
+    }
+
+    /// Release all mouse buttons and reset mouse position and wheel state.
+    #[doc(alias = "ClearInputMouse")]
+    pub fn clear_input_mouse(&mut self) {
+        unsafe { sys::ImGuiIO_ClearInputMouse(self.inner_mut() as *mut _) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sys;
+
+    #[test]
+    fn extended_input_events_update_and_clear_context_state() {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+
+        ctx.io_mut().set_app_accepting_events(true);
+        ctx.io_mut().add_key_analog_event(crate::Key::A, true, 0.5);
+        ctx.io_mut()
+            .set_key_event_native_data(crate::Key::A, 65, 30, Some(65));
+        assert!(ctx.frame().is_key_down(crate::Key::A));
+        ctx.io_mut().clear_input_keys();
+        assert!(!ctx.io().inner().KeysData[key_data_index(crate::Key::A)].Down);
+        let _ = ctx.render();
+
+        ctx.io_mut().add_key_event(crate::Key::A, true);
+        ctx.io_mut().clear_events_queue();
+        assert!(!ctx.frame().is_key_down(crate::Key::A));
+        let _ = ctx.render();
+
+        ctx.io_mut().set_app_accepting_events(false);
+        ctx.io_mut().add_key_event(crate::Key::A, true);
+        assert!(!ctx.frame().is_key_down(crate::Key::A));
+        let _ = ctx.render();
+
+        ctx.io_mut().set_app_accepting_events(true);
+        ctx.io_mut().add_input_character_utf16(b'A' as u16);
+        ctx.io_mut().add_input_characters_utf8("B界");
+        let _ = ctx.frame();
+        assert_eq!(ctx.io().inner().InputQueueCharacters.Size, 3);
+        ctx.io_mut().clear_input_keys();
+        assert_eq!(ctx.io().inner().InputQueueCharacters.Size, 0);
+
+        ctx.io_mut().inner_mut().MouseDown[0] = true;
+        ctx.io_mut().clear_input_mouse();
+        assert!(!ctx.io().inner().MouseDown[0]);
+        let _ = ctx.render();
+    }
+
+    fn key_data_index(key: crate::Key) -> usize {
+        usize::try_from(key as sys::ImGuiKey - sys::ImGuiKey_NamedKey_BEGIN).unwrap()
+    }
+
+    #[test]
+    fn extended_input_events_validate_values_before_ffi() {
+        let mut ctx = crate::Context::create();
+        let io = ctx.io_mut();
+
+        for value in [f32::NAN, f32::INFINITY, -0.1, 1.1] {
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    io.add_key_analog_event(crate::Key::GamepadL2, true, value);
+                }))
+                .is_err()
+            );
+        }
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                io.set_key_event_native_data(crate::Key::ModCtrl, 0, 0, None);
+            }))
+            .is_err()
+        );
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                io.set_key_event_native_data(crate::Key::A, 0, 0, Some(512));
+            }))
+            .is_err()
+        );
     }
 }

--- a/dear-imgui/src/layout/group.rs
+++ b/dear-imgui/src/layout/group.rs
@@ -3,6 +3,7 @@ use crate::sys;
 
 create_token!(
     /// Tracks a layout group that can be ended with `end` or by dropping.
+    #[doc(alias = "EndGroup")]
     pub struct GroupToken<'ui>;
 
     /// Drops the layout group manually. You can also just allow this token

--- a/dear-imgui/src/lib.rs
+++ b/dear-imgui/src/lib.rs
@@ -125,9 +125,8 @@
 //!   - `WantUpdates`: upload pending `UpdateRect`s, then set status to `OK`.
 //!   - `WantDestroy`: delete/free the GPU texture and set status to `Destroyed`.
 //! - Use `DrawData::textures()` only for read-only inspection or snapshots.
-//! - When binding textures for draw commands, do not rely only on `DrawCmdParams.texture_id`.
-//!   With the modern system it may be `0`. Resolve the effective id at bind time using
-//!   `ImDrawCmd_GetTexID(raw_cmd)` along with your renderer state.
+//! - Bind [`DrawCmdParams::texture_id`](render::DrawCmdParams::texture_id). Command iteration
+//!   resolves the effective ID for both legacy and managed texture references.
 //! - Optional: some backends perform a font-atlas fallback upload on initialization.
 //!   This affects only the font texture for the first frame; user textures go through
 //!   the modern `ImTextureData` path.
@@ -148,12 +147,11 @@
 //!     }
 //! }
 //!
-//! // 3) Rendering: resolve texture at bind-time
+//! // 3) Rendering: use the already resolved effective texture ID
 //! for cmd in draw_list.commands() {
 //!     match cmd {
-//!         Elements { cmd_params, raw_cmd, .. } => {
-//!             let effective = unsafe { sys::ImDrawCmd_GetTexID(raw_cmd) };
-//!             bind_texture(effective);
+//!         Elements { cmd_params, .. } => {
+//!             bind_texture(cmd_params.texture_id);
 //!             draw(cmd_params);
 //!         }
 //!         _ => { /* ... */ }
@@ -276,6 +274,15 @@ pub extern crate dear_imgui_sys as sys;
 ///
 /// This avoids leaking the `sys` type in safe APIs and improves clarity
 /// when passing/returning identifiers (e.g., dock ids, viewport ids).
+///
+/// Construct an explicit user-defined ID with [`Id::from`] and a `u32`. When
+/// the ID should follow Dear ImGui's current ID stack, prefer [`Ui::get_id`].
+///
+/// ```
+/// # use dear_imgui_rs::Id;
+/// let id = Id::from(42_u32);
+/// assert_eq!(id.raw(), 42);
+/// ```
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Id(pub(crate) sys::ImGuiID);

--- a/dear-imgui/src/list_clipper.rs
+++ b/dear-imgui/src/list_clipper.rs
@@ -337,7 +337,8 @@ mod tests {
         let ui = ctx.frame();
 
         ui.window("list_clipper_invalid_includes").build(|| {
-            for range in [5..4, 0..11] {
+            for (start, end) in [(5usize, 4usize), (0, 11)] {
+                let range = std::ops::Range { start, end };
                 let mut clipper = ListClipper::new(10usize).begin(ui);
                 assert!(
                     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/dear-imgui/src/list_clipper.rs
+++ b/dear-imgui/src/list_clipper.rs
@@ -62,7 +62,7 @@ impl ListClipper {
                 panic!("ImGuiListClipper_ImGuiListClipper() returned null");
             }
             sys::ImGuiListClipper_Begin(ptr, items_count, self.items_height);
-            ListClipperToken::new(ui, ptr)
+            ListClipperToken::new(ui, ptr, self.items_count)
         })
     }
 }
@@ -75,16 +75,64 @@ impl ListClipper {
 pub struct ListClipperToken<'ui> {
     ui: &'ui Ui,
     list_clipper: *mut sys::ImGuiListClipper,
+    items_count: usize,
+    stepped: bool,
     ended: bool,
 }
 
 impl<'ui> ListClipperToken<'ui> {
-    fn new(ui: &'ui Ui, list_clipper: *mut sys::ImGuiListClipper) -> Self {
+    fn new(ui: &'ui Ui, list_clipper: *mut sys::ImGuiListClipper, items_count: usize) -> Self {
         Self {
             ui,
             list_clipper,
+            items_count,
+            stepped: false,
             ended: false,
         }
+    }
+
+    /// Keep one item from being clipped, regardless of its visibility.
+    ///
+    /// This must be called before the first [`Self::step`].
+    #[doc(alias = "IncludeItemByIndex")]
+    pub fn include_item_by_index(&mut self, item_index: usize) {
+        let item_end = item_index
+            .checked_add(1)
+            .expect("ListClipperToken::include_item_by_index() index overflowed");
+        self.include_items_by_index(item_index..item_end);
+    }
+
+    /// Keep a half-open item range from being clipped, regardless of visibility.
+    ///
+    /// This must be called before the first [`Self::step`]. Empty ranges are a no-op.
+    #[doc(alias = "IncludeItemsByIndex")]
+    pub fn include_items_by_index(&mut self, items: Range<usize>) {
+        assert!(
+            !self.ended && !self.stepped,
+            "ListClipperToken::include_items_by_index() must be called before the first step()"
+        );
+        assert!(
+            items.start <= items.end,
+            "ListClipperToken::include_items_by_index() range start must not exceed its end"
+        );
+        assert!(
+            items.end <= self.items_count,
+            "ListClipperToken::include_items_by_index() range exceeds the item count"
+        );
+        if items.is_empty() {
+            return;
+        }
+        let item_begin = items_count_to_i32(
+            items.start,
+            "ListClipperToken::include_items_by_index() range start",
+        );
+        let item_end = items_count_to_i32(
+            items.end,
+            "ListClipperToken::include_items_by_index() range end",
+        );
+        self.ui.run_with_bound_context(|| unsafe {
+            sys::ImGuiListClipper_IncludeItemsByIndex(self.list_clipper, item_begin, item_end);
+        });
     }
 
     /// Progress the list clipper.
@@ -101,6 +149,7 @@ impl<'ui> ListClipperToken<'ui> {
         if self.ended {
             panic!("ListClipperToken::step() called after the clipper has ended");
         }
+        self.stepped = true;
         let ret = self
             .ui
             .run_with_bound_context(|| unsafe { sys::ImGuiListClipper_Step(self.list_clipper) });
@@ -245,6 +294,59 @@ mod tests {
                     .collect();
                 assert_eq!(indices, vec![0, 1, 2]);
             });
+    }
+
+    #[test]
+    fn include_items_returns_non_visible_ranges_and_enforces_call_order() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+
+        ui.window("list_clipper_includes")
+            .size([96.0, 96.0], crate::Condition::Always)
+            .build(|| {
+                let mut clipper = ListClipper::new(1_000usize).items_height(16.0).begin(ui);
+                clipper.include_item_by_index(900);
+                clipper.include_items_by_index(950..953);
+
+                let mut included = [false; 4];
+                while clipper.step() {
+                    for index in clipper.display_range() {
+                        if index == 900 {
+                            included[0] = true;
+                        }
+                        if (950..953).contains(&index) {
+                            included[index - 949] = true;
+                        }
+                        ui.text(format!("row {index}"));
+                    }
+                }
+                assert!(included.into_iter().all(|seen| seen));
+
+                assert!(
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        clipper.include_item_by_index(1);
+                    }))
+                    .is_err()
+                );
+            });
+    }
+
+    #[test]
+    fn include_items_rejects_invalid_ranges_before_ffi() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+
+        ui.window("list_clipper_invalid_includes").build(|| {
+            for range in [5..4, 0..11] {
+                let mut clipper = ListClipper::new(10usize).begin(ui);
+                assert!(
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        clipper.include_items_by_index(range.clone());
+                    }))
+                    .is_err()
+                );
+            }
+        });
     }
 }
 

--- a/dear-imgui/src/render/draw_data/cmd.rs
+++ b/dear-imgui/src/render/draw_data/cmd.rs
@@ -1,6 +1,6 @@
 use super::callbacks::{StandardDrawCallback, classify_standard_draw_callback};
 use crate::sys;
-use crate::texture::TextureId;
+use crate::texture::{TextureId, effective_texture_id};
 use std::slice;
 
 /// Iterator over draw commands
@@ -18,21 +18,8 @@ impl<'a> Iterator for DrawCmdIterator<'a> {
     type Item = DrawCmd;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|cmd| {
-            let cmd_params = DrawCmdParams {
-                clip_rect: [
-                    cmd.ClipRect.x,
-                    cmd.ClipRect.y,
-                    cmd.ClipRect.z,
-                    cmd.ClipRect.w,
-                ],
-                // Use raw field; backends may resolve effective TexID later
-                texture_id: TextureId::from(cmd.TexRef._TexID),
-                vtx_offset: cmd.VtxOffset as usize,
-                idx_offset: cmd.IdxOffset as usize,
-            };
-
-            match classify_standard_draw_callback(cmd.UserCallback) {
+        self.iter.next().map(
+            |cmd| match classify_standard_draw_callback(cmd.UserCallback) {
                 Some(StandardDrawCallback::ResetRenderState) => DrawCmd::ResetRenderState,
                 Some(StandardDrawCallback::SetSamplerLinear) => DrawCmd::SetSamplerLinear,
                 Some(StandardDrawCallback::SetSamplerNearest) => DrawCmd::SetSamplerNearest,
@@ -41,14 +28,27 @@ impl<'a> Iterator for DrawCmdIterator<'a> {
                         callback: raw_callback,
                         raw_cmd: cmd,
                     },
-                    None => DrawCmd::Elements {
-                        count: cmd.ElemCount as usize,
-                        cmd_params,
-                        raw_cmd: cmd as *const sys::ImDrawCmd,
-                    },
+                    None => {
+                        let cmd_params = DrawCmdParams {
+                            clip_rect: [
+                                cmd.ClipRect.x,
+                                cmd.ClipRect.y,
+                                cmd.ClipRect.z,
+                                cmd.ClipRect.w,
+                            ],
+                            texture_id: unsafe { effective_texture_id(&cmd.TexRef) },
+                            vtx_offset: cmd.VtxOffset as usize,
+                            idx_offset: cmd.IdxOffset as usize,
+                        };
+                        DrawCmd::Elements {
+                            count: cmd.ElemCount as usize,
+                            cmd_params,
+                            raw_cmd: cmd as *const sys::ImDrawCmd,
+                        }
+                    }
                 },
-            }
-        })
+            },
+        )
     }
 }
 
@@ -59,11 +59,8 @@ pub struct DrawCmdParams {
     pub clip_rect: [f32; 4],
     /// Texture ID to use for rendering
     ///
-    /// Notes:
-    /// - For legacy paths (plain `TextureId`), this is the effective id.
-    /// - With the modern texture system (ImTextureRef/ImTextureData), this may be 0.
-    ///   Renderer backends should resolve the effective id at bind time using
-    ///   `ImDrawCmd_GetTexID` with the `raw_cmd` pointer and the backend render state.
+    /// This is the effective ID resolved from either a legacy `TextureId` or a
+    /// managed `ImTextureData` reference when the command is iterated.
     pub texture_id: TextureId,
     /// Vertex buffer offset
     pub vtx_offset: usize,
@@ -81,10 +78,8 @@ pub enum DrawCmd {
         cmd_params: DrawCmdParams,
         /// Raw command pointer for backends
         ///
-        /// Backend note: when using the modern texture system, resolve the effective
-        /// texture id at bind time via `ImDrawCmd_GetTexID(raw_cmd)` together with your
-        /// renderer state. This pointer is only valid during the `render_draw_data()`
-        /// call that produced it; do not store it.
+        /// This pointer is only valid while iterating the source draw list; do not
+        /// store it. Texture binding should use [`DrawCmdParams::texture_id`].
         raw_cmd: *const sys::ImDrawCmd,
     },
     /// Reset render state
@@ -98,4 +93,50 @@ pub enum DrawCmd {
         callback: unsafe extern "C" fn(*const sys::ImDrawList, cmd: *const sys::ImDrawCmd),
         raw_cmd: *const sys::ImDrawCmd,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn draw_command_params_resolve_managed_texture_ids() {
+        let mut texture = crate::texture::TextureData::new();
+        let texture_id = TextureId::new(17);
+        texture.set_tex_id(texture_id);
+
+        let mut command = sys::ImDrawCmd::default();
+        command.TexRef = sys::ImTextureRef {
+            _TexData: texture.as_raw_mut(),
+            _TexID: 0,
+        };
+        command.ElemCount = 3;
+        let commands = [command];
+
+        let draw_command = DrawCmdIterator::new(commands.iter()).next().unwrap();
+        let DrawCmd::Elements { cmd_params, .. } = draw_command else {
+            panic!("expected an element draw command");
+        };
+        assert_eq!(cmd_params.texture_id, texture_id);
+    }
+
+    #[test]
+    fn draw_command_iteration_allows_pending_managed_textures() {
+        let mut texture = crate::texture::TextureData::new();
+        assert!(texture.tex_id().is_null());
+
+        let mut command = sys::ImDrawCmd::default();
+        command.TexRef = sys::ImTextureRef {
+            _TexData: texture.as_raw_mut(),
+            _TexID: 0,
+        };
+        command.ElemCount = 3;
+        let commands = [command];
+
+        let draw_command = DrawCmdIterator::new(commands.iter()).next().unwrap();
+        let DrawCmd::Elements { cmd_params, .. } = draw_command else {
+            panic!("expected an element draw command");
+        };
+        assert!(cmd_params.texture_id.is_null());
+    }
 }

--- a/dear-imgui/src/stacks.rs
+++ b/dear-imgui/src/stacks.rs
@@ -12,10 +12,12 @@
 
 mod font;
 mod id;
+mod item;
 mod layout;
 mod style;
 
 pub use font::FontStackToken;
 pub use id::{FocusScopeToken, IdStackToken};
+pub use item::{ItemFlagStackToken, ItemFlags, ItemStateFlags};
 pub use layout::{ItemWidthStackToken, TextWrapPosStackToken};
 pub use style::{ColorStackToken, StyleStackToken};

--- a/dear-imgui/src/stacks/id.rs
+++ b/dear-imgui/src/stacks/id.rs
@@ -52,6 +52,7 @@ impl Ui {
 create_token!(
     /// Tracks an ID pushed to the ID stack that can be popped by calling `.pop()`
     /// or by dropping. See [`crate::Ui::push_id`] for more details.
+    #[doc(alias = "PopID")]
     pub struct IdStackToken<'ui>;
 
     /// Pops a change from the ID stack

--- a/dear-imgui/src/stacks/item.rs
+++ b/dear-imgui/src/stacks/item.rs
@@ -1,0 +1,180 @@
+use bitflags::bitflags;
+
+use crate::{Ui, sys};
+
+bitflags! {
+    /// Flags that can be applied to subsequently submitted items.
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct ItemFlags: i32 {
+        /// No item flags.
+        const NONE = sys::ImGuiItemFlags_None as i32;
+        /// Disable keyboard tabbing while retaining directional navigation.
+        const NO_TAB_STOP = sys::ImGuiItemFlags_NoTabStop as i32;
+        /// Disable keyboard and gamepad navigation.
+        const NO_NAV = sys::ImGuiItemFlags_NoNav as i32;
+        /// Prevent the item from receiving default navigation focus.
+        const NO_NAV_DEFAULT_FOCUS = sys::ImGuiItemFlags_NoNavDefaultFocus as i32;
+        /// Enable repeat behavior for button-like items.
+        const BUTTON_REPEAT = sys::ImGuiItemFlags_ButtonRepeat as i32;
+        /// Automatically close a parent popup after activating a menu item or selectable.
+        const AUTO_CLOSE_POPUPS = sys::ImGuiItemFlags_AutoClosePopups as i32;
+        /// Allow duplicate item IDs without a debug conflict warning.
+        const ALLOW_DUPLICATE_ID = sys::ImGuiItemFlags_AllowDuplicateId as i32;
+    }
+}
+
+bitflags! {
+    /// Flags recorded for the last submitted item.
+    ///
+    /// This includes the public flags accepted by [`Ui::push_item_flag`] plus
+    /// read-only state such as [`Self::DISABLED`]. Unknown internal bits are
+    /// retained when returned by [`Ui::item_flags`].
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct ItemStateFlags: i32 {
+        /// No item flags.
+        const NONE = sys::ImGuiItemFlags_None as i32;
+        /// Keyboard tabbing was disabled while retaining directional navigation.
+        const NO_TAB_STOP = sys::ImGuiItemFlags_NoTabStop as i32;
+        /// Keyboard and gamepad navigation was disabled.
+        const NO_NAV = sys::ImGuiItemFlags_NoNav as i32;
+        /// The item could not receive default navigation focus.
+        const NO_NAV_DEFAULT_FOCUS = sys::ImGuiItemFlags_NoNavDefaultFocus as i32;
+        /// Repeat behavior was enabled for the item.
+        const BUTTON_REPEAT = sys::ImGuiItemFlags_ButtonRepeat as i32;
+        /// The item could automatically close its parent popup.
+        const AUTO_CLOSE_POPUPS = sys::ImGuiItemFlags_AutoClosePopups as i32;
+        /// Duplicate IDs were allowed for the item.
+        const ALLOW_DUPLICATE_ID = sys::ImGuiItemFlags_AllowDuplicateId as i32;
+        /// The last item was disabled.
+        const DISABLED = sys::ImGuiItemFlags_Disabled as i32;
+    }
+}
+
+impl Default for ItemFlags {
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+impl Default for ItemStateFlags {
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+impl From<ItemFlags> for ItemStateFlags {
+    fn from(flags: ItemFlags) -> Self {
+        Self::from_bits_retain(flags.bits())
+    }
+}
+
+create_token!(
+    /// Tracks item flags pushed with [`Ui::push_item_flag`].
+    pub struct ItemFlagStackToken<'ui>;
+
+    /// Pops item flags pushed with [`Ui::push_item_flag`].
+    #[doc(alias = "PopItemFlag")]
+    drop { unsafe { sys::igPopItemFlag() } }
+);
+
+impl ItemFlagStackToken<'_> {
+    /// Pops the item flag scope.
+    pub fn pop(self) {
+        self.end()
+    }
+}
+
+impl Ui {
+    /// Returns the flags recorded for the last submitted item.
+    ///
+    /// Unknown bits introduced by newer Dear ImGui versions are retained.
+    #[doc(alias = "GetItemFlags")]
+    pub fn item_flags(&self) -> ItemStateFlags {
+        self.run_with_bound_context(|| unsafe {
+            ItemStateFlags::from_bits_retain(sys::igGetItemFlags())
+        })
+    }
+
+    /// Enables or disables flags for subsequently submitted items.
+    ///
+    /// The returned token restores the previous item flags when dropped.
+    #[doc(alias = "PushItemFlag")]
+    pub fn push_item_flag(&self, flags: ItemFlags, enabled: bool) -> ItemFlagStackToken<'_> {
+        self.run_with_bound_context(|| unsafe { sys::igPushItemFlag(flags.bits(), enabled) });
+        ItemFlagStackToken::new(self)
+    }
+
+    /// Runs `f` with the requested item flags enabled or disabled.
+    ///
+    /// The previous flags are restored even if `f` panics.
+    #[doc(alias = "PushItemFlag", alias = "PopItemFlag")]
+    pub fn with_item_flag<R>(&self, flags: ItemFlags, enabled: bool, f: impl FnOnce() -> R) -> R {
+        let _flags = self.push_item_flag(flags, enabled);
+        f()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_context() -> crate::Context {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+        ctx
+    }
+
+    #[test]
+    fn item_flag_scope_is_typed_and_restores_previous_flags() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+
+        ui.window("item_flags").build(|| {
+            ui.with_item_flag(
+                ItemFlags::NO_NAV | ItemFlags::ALLOW_DUPLICATE_ID,
+                true,
+                || {
+                    ui.button("scoped");
+                    let flags = ui.item_flags();
+                    assert!(flags.contains(ItemStateFlags::NO_NAV));
+                    assert!(flags.contains(ItemStateFlags::ALLOW_DUPLICATE_ID));
+                },
+            );
+
+            ui.button("restored");
+            let flags = ui.item_flags();
+            assert!(!flags.contains(ItemStateFlags::NO_NAV));
+            assert!(!flags.contains(ItemStateFlags::ALLOW_DUPLICATE_ID));
+        });
+    }
+
+    #[test]
+    fn item_flag_scope_can_clear_defaults_and_reports_disabled_items() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+
+        ui.window("item_flag_values").build(|| {
+            ui.button("default");
+            assert!(ui.item_flags().contains(ItemStateFlags::AUTO_CLOSE_POPUPS));
+
+            {
+                let _flags = ui.push_item_flag(ItemFlags::AUTO_CLOSE_POPUPS, false);
+                ui.button("without_auto_close");
+                assert!(!ui.item_flags().contains(ItemStateFlags::AUTO_CLOSE_POPUPS));
+            }
+
+            ui.button("restored_default");
+            assert!(ui.item_flags().contains(ItemStateFlags::AUTO_CLOSE_POPUPS));
+
+            {
+                let _disabled = ui.begin_disabled();
+                ui.button("disabled");
+                assert!(ui.item_flags().contains(ItemStateFlags::DISABLED));
+            }
+        });
+    }
+}

--- a/dear-imgui/src/stacks/layout.rs
+++ b/dear-imgui/src/stacks/layout.rs
@@ -19,16 +19,18 @@ impl Ui {
 
     /// Sets the width of the next item(s) to be the same as the width of the given text.
     ///
+    /// Text is measured with [`Ui::calc_text_size`] using its default options.
+    ///
     /// Returns an `ItemWidthStackToken`. The pushed width item is popped when either
     /// `ItemWidthStackToken` goes out of scope, or `.end()` is called.
     #[doc(alias = "PushItemWidth")]
     pub fn push_item_width_text(&self, text: impl AsRef<str>) -> ItemWidthStackToken<'_> {
-        let text_width = unsafe {
-            let text_ptr = self.scratch_txt(text);
-            let out = sys::igCalcTextSize(text_ptr, std::ptr::null(), false, -1.0);
-            out.x
-        };
-        self.push_item_width(text_width)
+        let text = text.as_ref();
+        self.run_with_bound_context(|| unsafe {
+            let text_width = self.calc_text_size_bound(text, false, -1.0)[0];
+            sys::igPushItemWidth(text_width);
+        });
+        ItemWidthStackToken::new(self)
     }
 
     /// Sets the position where text will wrap around.
@@ -49,6 +51,7 @@ impl Ui {
 create_token!(
     /// Tracks a change made with [`Ui::push_item_width`] that can be popped
     /// by calling [`ItemWidthStackToken::end`] or dropping.
+    #[doc(alias = "PopItemWidth")]
     pub struct ItemWidthStackToken<'ui>;
 
     /// Pops an item width change made with [`Ui::push_item_width`].
@@ -59,9 +62,39 @@ create_token!(
 create_token!(
     /// Tracks a change made with [`Ui::push_text_wrap_pos`] that can be popped
     /// by calling [`TextWrapPosStackToken::end`] or dropping.
+    #[doc(alias = "PopTextWrapPos")]
     pub struct TextWrapPosStackToken<'ui>;
 
     /// Pops a text wrap position change made with [`Ui::push_text_wrap_pos`].
     #[doc(alias = "PopTextWrapPos")]
     drop { unsafe { sys::igPopTextWrapPos() } }
 );
+
+#[cfg(test)]
+mod tests {
+    fn setup_context() -> crate::Context {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+        ctx
+    }
+
+    #[test]
+    fn text_item_width_scope_matches_measurement_and_restores_previous_width() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+
+        ui.window("text_item_width").build(|| {
+            let original_width = ui.calc_item_width();
+            let text_width = ui.calc_text_size("measured width")[0];
+
+            {
+                let _width = ui.push_item_width_text("measured width");
+                assert_eq!(ui.calc_item_width(), text_width);
+            }
+
+            assert_eq!(ui.calc_item_width(), original_width);
+        });
+    }
+}

--- a/dear-imgui/src/stacks/style.rs
+++ b/dear-imgui/src/stacks/style.rs
@@ -1,4 +1,7 @@
-use crate::style::{StyleColor, StyleVar, validate_style_color, validate_style_var};
+use crate::style::{
+    StyleColor, StyleVar, StyleVarVec2, validate_style_color, validate_style_var,
+    validate_style_var_component,
+};
 use crate::{Ui, sys};
 
 impl Ui {
@@ -60,11 +63,28 @@ impl Ui {
         self.run_with_bound_context(|| unsafe { push_style_var(style_var) });
         StyleStackToken::new(self)
     }
+
+    /// Overrides the X component of a two-component style variable.
+    #[doc(alias = "PushStyleVarX")]
+    pub fn push_style_var_x(&self, style_var: StyleVarVec2, value: f32) -> StyleStackToken<'_> {
+        validate_style_var_component("Ui::push_style_var_x()", style_var, value);
+        self.run_with_bound_context(|| unsafe { sys::igPushStyleVarX(style_var.raw(), value) });
+        StyleStackToken::new(self)
+    }
+
+    /// Overrides the Y component of a two-component style variable.
+    #[doc(alias = "PushStyleVarY")]
+    pub fn push_style_var_y(&self, style_var: StyleVarVec2, value: f32) -> StyleStackToken<'_> {
+        validate_style_var_component("Ui::push_style_var_y()", style_var, value);
+        self.run_with_bound_context(|| unsafe { sys::igPushStyleVarY(style_var.raw(), value) });
+        StyleStackToken::new(self)
+    }
 }
 
 create_token!(
     /// Tracks a color pushed to the color stack that can be popped by calling `.end()`
     /// or by dropping.
+    #[doc(alias = "PopStyleColor")]
     pub struct ColorStackToken<'ui>;
 
     /// Pops a change from the color stack.
@@ -81,6 +101,7 @@ impl ColorStackToken<'_> {
 create_token!(
     /// Tracks a style pushed to the style stack that can be popped by calling `.end()`
     /// or by dropping.
+    #[doc(alias = "PopStyleVar")]
     pub struct StyleStackToken<'ui>;
 
     /// Pops a change from the style stack.
@@ -251,5 +272,58 @@ unsafe fn push_style_var(style_var: StyleVar) {
         DockingSeparatorSize(v) => unsafe {
             sys::igPushStyleVar_Float(sys::ImGuiStyleVar_DockingSeparatorSize as i32, v)
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_context() -> crate::Context {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+        ctx
+    }
+
+    #[test]
+    fn style_var_component_scopes_are_typed_and_restore_values() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+        let original = ui.clone_style().window_padding();
+
+        {
+            let _x = ui.push_style_var_x(StyleVarVec2::WindowPadding, 17.0);
+            assert_eq!(ui.clone_style().window_padding(), [17.0, original[1]]);
+        }
+        assert_eq!(ui.clone_style().window_padding(), original);
+
+        {
+            let _y = ui.push_style_var_y(StyleVarVec2::WindowPadding, 23.0);
+            assert_eq!(ui.clone_style().window_padding(), [original[0], 23.0]);
+        }
+        assert_eq!(ui.clone_style().window_padding(), original);
+    }
+
+    #[test]
+    fn style_var_components_validate_values_before_ffi() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+
+        for value in [-1.0, f32::NAN, f32::INFINITY] {
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let _token = ui.push_style_var_x(StyleVarVec2::WindowPadding, value);
+                }))
+                .is_err()
+            );
+        }
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _token = ui.push_style_var_y(StyleVarVec2::WindowTitleAlign, 1.1);
+            }))
+            .is_err()
+        );
     }
 }

--- a/dear-imgui/src/string/buffer.rs
+++ b/dear-imgui/src/string/buffer.rs
@@ -1,3 +1,4 @@
+use std::ops::Range;
 use std::os::raw::c_char;
 
 /// Internal buffer for UI string operations
@@ -24,6 +25,21 @@ impl UiBuffer {
 
         let start_of_substr = self.push(txt);
         unsafe { self.offset(start_of_substr) }
+    }
+
+    /// Stages an explicit text range followed by a readable NUL sentinel.
+    ///
+    /// Unlike [`Self::scratch_txt`], this preserves interior NUL bytes because
+    /// range-based Dear ImGui APIs receive the end pointer separately.
+    pub fn scratch_txt_range(&mut self, txt: impl AsRef<str>) -> Range<*const c_char> {
+        self.refresh_buffer();
+
+        let start = self.buffer.len();
+        self.buffer.extend_from_slice(txt.as_ref().as_bytes());
+        let end = self.buffer.len();
+        self.buffer.push(0);
+
+        unsafe { self.offset(start)..self.offset(end) }
     }
 
     /// Internal method to push an option text to our scratch buffer.

--- a/dear-imgui/src/string/tests.rs
+++ b/dear-imgui/src/string/tests.rs
@@ -41,6 +41,16 @@ fn ui_buffer_sanitizes_interior_nul() {
 }
 
 #[test]
+fn ui_buffer_text_range_preserves_bytes_and_appends_readable_nul() {
+    let mut buf = UiBuffer::new(1024);
+    let range = buf.scratch_txt_range("a\0b#");
+    let len = unsafe { range.end.offset_from(range.start) as usize };
+    let bytes = unsafe { std::slice::from_raw_parts(range.start.cast::<u8>(), len + 1) };
+
+    assert_eq!(bytes, b"a\0b#\0");
+}
+
+#[test]
 fn tls_scratch_txt_is_nul_terminated() {
     let ptr = tls_scratch_txt("hello");
     let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();

--- a/dear-imgui/src/style.rs
+++ b/dear-imgui/src/style.rs
@@ -56,6 +56,8 @@ pub use core::Style;
 pub use direction::Direction;
 pub use theme::{ColorOverride, StyleTweaks, TableTheme, Theme, ThemePreset, WindowTheme};
 pub use tree::TreeLineMode;
-pub use var::StyleVar;
+pub use var::{StyleVar, StyleVarVec2};
 
-pub(crate) use validation::{validate_style_color, validate_style_var};
+pub(crate) use validation::{
+    validate_style_color, validate_style_var, validate_style_var_component,
+};

--- a/dear-imgui/src/style/core.rs
+++ b/dear-imgui/src/style/core.rs
@@ -15,6 +15,21 @@ const _: [(); std::mem::size_of::<sys::ImGuiStyle>()] = [(); std::mem::size_of::
 const _: [(); std::mem::align_of::<sys::ImGuiStyle>()] = [(); std::mem::align_of::<Style>()];
 
 impl Style {
+    /// Scale every size and spacing value using Dear ImGui's DPI-aware rules.
+    ///
+    /// This also updates Dear ImGui's internal main style scale and preserves
+    /// sentinel values used by selected style fields.
+    #[doc(alias = "ScaleAllSizes")]
+    pub fn scale_all_sizes(&mut self, scale_factor: f32) {
+        assert!(
+            scale_factor.is_finite() && scale_factor > 0.0,
+            "Style::scale_all_sizes() scale_factor must be finite and positive"
+        );
+        unsafe {
+            sys::ImGuiStyle_ScaleAllSizes(self.inner_mut(), scale_factor);
+        }
+    }
+
     #[inline]
     pub(super) fn inner(&self) -> &sys::ImGuiStyle {
         // Safety: `Style` is a view into ImGui-owned style data. Dear ImGui can update style state
@@ -51,5 +66,26 @@ impl RawWrapper for Style {
 
     unsafe fn raw_mut(&mut self) -> &mut Self::Raw {
         self.inner_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn scale_all_sizes_uses_upstream_rounding_and_rejects_invalid_factors() {
+        let mut ctx = crate::Context::create();
+        let style = ctx.style_mut();
+        style.set_window_padding([3.0, 5.0]);
+        style.scale_all_sizes(2.0);
+        assert_eq!(style.window_padding(), [6.0, 10.0]);
+
+        for scale_factor in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    style.scale_all_sizes(scale_factor);
+                }))
+                .is_err()
+            );
+        }
     }
 }

--- a/dear-imgui/src/style/validation.rs
+++ b/dear-imgui/src/style/validation.rs
@@ -1,4 +1,4 @@
-use super::{Direction, StyleVar};
+use super::{Direction, StyleVar, StyleVarVec2};
 
 const TABLE_ANGLED_HEADERS_MAX_ANGLE: f32 = 50.0 * std::f32::consts::PI / 180.0;
 
@@ -150,5 +150,19 @@ pub(crate) fn validate_style_var(caller: &str, style_var: StyleVar) {
         DockingSeparatorSize(value) => {
             assert_non_negative_f32(caller, "DockingSeparatorSize", value);
         }
+    }
+}
+
+pub(crate) fn validate_style_var_component(caller: &str, style_var: StyleVarVec2, value: f32) {
+    use StyleVarVec2::*;
+
+    match style_var {
+        WindowTitleAlign
+        | TableAngledHeadersTextAlign
+        | ButtonTextAlign
+        | SelectableTextAlign
+        | SeparatorTextAlign => assert_unit_f32(caller, "value", value),
+        WindowPadding | WindowMinSize | FramePadding | ItemSpacing | ItemInnerSpacing
+        | CellPadding | SeparatorTextPadding => assert_non_negative_f32(caller, "value", value),
     }
 }

--- a/dear-imgui/src/style/var.rs
+++ b/dear-imgui/src/style/var.rs
@@ -89,3 +89,58 @@ pub enum StyleVar {
     /// Thickness of resizing border between docked windows
     DockingSeparatorSize(f32),
 }
+
+/// A two-component style variable whose X or Y component can be overridden.
+///
+/// Use this with [`Ui::push_style_var_x`](crate::Ui::push_style_var_x) or
+/// [`Ui::push_style_var_y`](crate::Ui::push_style_var_y). Scalar style
+/// variables are intentionally not representable by this type.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum StyleVarVec2 {
+    /// Padding within a window.
+    WindowPadding,
+    /// Minimum window size.
+    WindowMinSize,
+    /// Alignment for title bar text.
+    WindowTitleAlign,
+    /// Padding within a framed rectangle.
+    FramePadding,
+    /// Horizontal and vertical spacing between widgets or lines.
+    ItemSpacing,
+    /// Spacing between elements of a composed widget.
+    ItemInnerSpacing,
+    /// Padding within a table cell.
+    CellPadding,
+    /// Alignment of angled table headers within the cell.
+    TableAngledHeadersTextAlign,
+    /// Alignment of button text when the button is larger than its text.
+    ButtonTextAlign,
+    /// Alignment of selectable text when the selectable is larger than its text.
+    SelectableTextAlign,
+    /// Alignment of text within a separator.
+    SeparatorTextAlign,
+    /// Padding around text in a separator.
+    SeparatorTextPadding,
+}
+
+impl StyleVarVec2 {
+    pub(crate) const fn raw(self) -> i32 {
+        match self {
+            Self::WindowPadding => crate::sys::ImGuiStyleVar_WindowPadding as i32,
+            Self::WindowMinSize => crate::sys::ImGuiStyleVar_WindowMinSize as i32,
+            Self::WindowTitleAlign => crate::sys::ImGuiStyleVar_WindowTitleAlign as i32,
+            Self::FramePadding => crate::sys::ImGuiStyleVar_FramePadding as i32,
+            Self::ItemSpacing => crate::sys::ImGuiStyleVar_ItemSpacing as i32,
+            Self::ItemInnerSpacing => crate::sys::ImGuiStyleVar_ItemInnerSpacing as i32,
+            Self::CellPadding => crate::sys::ImGuiStyleVar_CellPadding as i32,
+            Self::TableAngledHeadersTextAlign => {
+                crate::sys::ImGuiStyleVar_TableAngledHeadersTextAlign as i32
+            }
+            Self::ButtonTextAlign => crate::sys::ImGuiStyleVar_ButtonTextAlign as i32,
+            Self::SelectableTextAlign => crate::sys::ImGuiStyleVar_SelectableTextAlign as i32,
+            Self::SeparatorTextAlign => crate::sys::ImGuiStyleVar_SeparatorTextAlign as i32,
+            Self::SeparatorTextPadding => crate::sys::ImGuiStyleVar_SeparatorTextPadding as i32,
+        }
+    }
+}

--- a/dear-imgui/src/texture.rs
+++ b/dear-imgui/src/texture.rs
@@ -20,5 +20,6 @@ pub use format::{TextureFormat, get_format_bytes_per_pixel, get_format_name};
 pub use id::{ManagedTextureId, RawTextureId, TextureId};
 pub use owned::OwnedTextureData;
 pub use rect::TextureRect;
+pub(crate) use reference::effective_texture_id;
 pub use reference::{TextureRef, create_texture_ref};
 pub use status::{TextureStatus, get_status_name};

--- a/dear-imgui/src/texture/reference.rs
+++ b/dear-imgui/src/texture/reference.rs
@@ -88,6 +88,29 @@ impl<'tex> TextureRef<'tex> {
     pub fn raw(self) -> sys::ImTextureRef {
         self.raw
     }
+
+    /// Resolve the effective texture ID.
+    ///
+    /// For managed references this reads the current ID from the borrowed
+    /// [`TextureData`]; legacy references return their embedded ID.
+    #[doc(alias = "GetTexID")]
+    pub fn texture_id(self) -> TextureId {
+        unsafe { effective_texture_id(&self.raw) }
+    }
+}
+
+/// Resolve a raw texture reference without asserting that a managed texture
+/// has already been uploaded by a renderer.
+///
+/// # Safety
+///
+/// A non-null `_TexData` pointer must be valid for reads.
+pub(crate) unsafe fn effective_texture_id(raw: &sys::ImTextureRef) -> TextureId {
+    if raw._TexData.is_null() {
+        TextureId::from(raw._TexID)
+    } else {
+        unsafe { TextureId::from((*raw._TexData).TexID) }
+    }
 }
 
 impl<'tex> From<TextureId> for TextureRef<'tex> {
@@ -143,5 +166,21 @@ pub fn create_texture_ref(texture_id: TextureId) -> sys::ImTextureRef {
     sys::ImTextureRef {
         _TexData: std::ptr::null_mut(),
         _TexID: texture_id.id() as sys::ImTextureID,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn texture_ref_resolves_legacy_and_managed_ids() {
+        let legacy_id = TextureId::new(7);
+        assert_eq!(TextureRef::from(legacy_id).texture_id(), legacy_id);
+
+        let mut texture = TextureData::new();
+        let managed_id = TextureId::new(11);
+        texture.set_tex_id(managed_id);
+        assert_eq!(texture.texture_ref().texture_id(), managed_id);
     }
 }

--- a/dear-imgui/src/ui/core.rs
+++ b/dear-imgui/src/ui/core.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::context::binding::{CTX_MUTEX, with_bound_context};
 
 impl Ui {
-    pub(super) fn assert_finite_f32(caller: &str, name: &str, value: f32) {
+    pub(crate) fn assert_finite_f32(caller: &str, name: &str, value: f32) {
         assert!(value.is_finite(), "{caller} {name} must be finite");
     }
 
@@ -64,6 +64,17 @@ impl Ui {
         unsafe {
             let handle = &mut *self.buffer.get();
             handle.scratch_txt(txt)
+        }
+    }
+
+    /// Stages an explicit text range with a readable NUL sentinel at its end.
+    pub(crate) fn scratch_txt_range(
+        &self,
+        txt: impl AsRef<str>,
+    ) -> std::ops::Range<*const std::os::raw::c_char> {
+        unsafe {
+            let handle = &mut *self.buffer.get();
+            handle.scratch_txt_range(txt)
         }
     }
 

--- a/dear-imgui/src/ui/debug_tools.rs
+++ b/dear-imgui/src/ui/debug_tools.rs
@@ -63,6 +63,37 @@ impl Ui {
         });
     }
 
+    /// Renders a table that breaks `text` down into UTF-8 bytes and codepoints.
+    ///
+    /// This is intended for diagnosing text encoding and missing-glyph issues.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `text` contains an interior NUL byte, which the upstream
+    /// NUL-terminated API cannot represent.
+    #[doc(alias = "DebugTextEncoding")]
+    pub fn debug_text_encoding(&self, text: impl AsRef<str>) {
+        let text = text.as_ref();
+        assert!(
+            !text.contains('\0'),
+            "Ui::debug_text_encoding() text must not contain interior NUL bytes"
+        );
+        let text = self.scratch_txt(text);
+        self.run_with_bound_context(|| unsafe { sys::igDebugTextEncoding(text) });
+    }
+
+    /// Temporarily flashes a style color in Dear ImGui's debug tools.
+    #[doc(alias = "DebugFlashStyleColor")]
+    pub fn debug_flash_style_color(&self, color: crate::StyleColor) {
+        self.run_with_bound_context(|| unsafe { sys::igDebugFlashStyleColor(color as i32) });
+    }
+
+    /// Starts Dear ImGui's interactive item picker debug tool.
+    #[doc(alias = "DebugStartItemPicker")]
+    pub fn debug_start_item_picker(&self) {
+        self.run_with_bound_context(|| unsafe { sys::igDebugStartItemPicker() });
+    }
+
     /// Returns the Dear ImGui version string
     #[doc(alias = "GetVersion")]
     pub fn get_version(&self) -> &str {
@@ -74,5 +105,33 @@ impl Ui {
             let c_str = std::ffi::CStr::from_ptr(version_ptr);
             c_str.to_str().unwrap_or("Unknown")
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn public_debug_helpers_are_safe_to_call_in_a_frame() {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+        let ui = ctx.frame();
+
+        ui.window("debug_helpers").build(|| {
+            let cursor_y = ui.cursor_pos_y();
+            ui.debug_text_encoding("A UTF-8 string: 界");
+            assert!(ui.cursor_pos_y() > cursor_y);
+
+            ui.debug_flash_style_color(crate::StyleColor::Text);
+            ui.debug_start_item_picker();
+        });
+
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                ui.debug_text_encoding("A\0B");
+            }))
+            .is_err()
+        );
     }
 }

--- a/dear-imgui/src/ui/widgets.rs
+++ b/dear-imgui/src/ui/widgets.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl Ui {
     /// Display text
-    #[doc(alias = "TextUnformatted")]
+    #[doc(alias = "Text", alias = "TextUnformatted")]
     pub fn text<T: AsRef<str>>(&self, text: T) {
         let s = text.as_ref();
         self.run_with_bound_context(|| unsafe {

--- a/dear-imgui/src/widget/combo/token.rs
+++ b/dear-imgui/src/widget/combo/token.rs
@@ -3,6 +3,7 @@ use crate::ui::Ui;
 
 /// Tracks a combo box that can be ended by calling `.end()` or by dropping
 #[must_use]
+#[doc(alias = "EndCombo")]
 pub struct ComboBoxToken<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/widget/combo/ui.rs
+++ b/dear-imgui/src/widget/combo/ui.rs
@@ -114,11 +114,13 @@ impl Ui {
         ) {
             for (idx, item) in items.iter().enumerate() {
                 let is_selected = idx == *current_item;
+                let clicked = self
+                    .selectable_config(label_fn(item).as_ref())
+                    .selected(is_selected)
+                    .build();
                 if is_selected {
                     self.set_item_default_focus();
                 }
-
-                let clicked = self.selectable(label_fn(item).as_ref());
 
                 if clicked {
                     *current_item = idx;
@@ -165,11 +167,13 @@ impl Ui {
                 }
                 let idx_i32 = idx as i32;
                 let is_selected = idx_i32 == *current_item;
+                let clicked = self
+                    .selectable_config(label_fn(item).as_ref())
+                    .selected(is_selected)
+                    .build();
                 if is_selected {
                     self.set_item_default_focus();
                 }
-
-                let clicked = self.selectable(label_fn(item).as_ref());
                 if clicked {
                     *current_item = idx_i32;
                     result = true;
@@ -203,10 +207,9 @@ impl Ui {
         self.combo_i32(label, current_item, items, |s| Cow::Borrowed(s.as_ref()))
     }
 
-    /// Sets the default focus for the next item
+    /// Makes the last submitted item the default focus of a newly appearing window.
+    #[doc(alias = "SetItemDefaultFocus")]
     pub fn set_item_default_focus(&self) {
-        unsafe {
-            sys::igSetItemDefaultFocus();
-        }
+        self.run_with_bound_context(|| unsafe { sys::igSetItemDefaultFocus() });
     }
 }

--- a/dear-imgui/src/widget/list_box.rs
+++ b/dear-imgui/src/widget/list_box.rs
@@ -58,6 +58,7 @@ impl<T: AsRef<str>> ListBox<T> {
     ///
     /// Returns `None` if the list box is not open and no content should be rendered.
     #[must_use]
+    #[doc(alias = "BeginListBox", alias = "ListBox")]
     pub fn begin(self, ui: &Ui) -> Option<ListBoxToken<'_>> {
         assert_finite_vec2("ListBox::begin()", "size", self.size);
         let size_vec = sys::ImVec2 {
@@ -84,6 +85,7 @@ impl<T: AsRef<str>> ListBox<T> {
 
 /// Tracks a list box that can be ended by calling `.end()`
 /// or by dropping
+#[doc(alias = "EndListBox")]
 pub struct ListBoxToken<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/widget/menu/tokens.rs
+++ b/dear-imgui/src/widget/menu/tokens.rs
@@ -3,6 +3,7 @@ use crate::ui::Ui;
 
 /// Tracks a main menu bar that can be ended by calling `.end()` or by dropping
 #[must_use]
+#[doc(alias = "EndMainMenuBar")]
 pub struct MainMenuBarToken<'ui> {
     _ui: &'ui Ui,
 }
@@ -28,6 +29,7 @@ impl Drop for MainMenuBarToken<'_> {
 
 /// Tracks a menu bar that can be ended by calling `.end()` or by dropping
 #[must_use]
+#[doc(alias = "EndMenuBar")]
 pub struct MenuBarToken<'ui> {
     _ui: &'ui Ui,
 }
@@ -53,6 +55,7 @@ impl Drop for MenuBarToken<'_> {
 
 /// Tracks a menu that can be ended by calling `.end()` or by dropping
 #[must_use]
+#[doc(alias = "EndMenu")]
 pub struct MenuToken<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/widget/misc/button_repeat.rs
+++ b/dear-imgui/src/widget/misc/button_repeat.rs
@@ -1,24 +1,11 @@
-use crate::{Ui, sys};
+use crate::{ItemFlagStackToken, ItemFlags, Ui};
 
 // ============================================================================
 // Button repeat (convenience over item flag)
 // ============================================================================
 
-create_token!(
-    /// Tracks a button repeat item flag pushed with [`Ui::push_button_repeat`].
-    pub struct ButtonRepeatToken<'ui>;
-
-    /// Pops the button repeat item flag.
-    #[doc(alias = "PopButtonRepeat")]
-    drop { unsafe { sys::igPopItemFlag() } }
-);
-
-impl ButtonRepeatToken<'_> {
-    /// Pops the button repeat item flag.
-    pub fn pop(self) {
-        self.end()
-    }
-}
+/// Tracks a button repeat item flag pushed with [`Ui::push_button_repeat`].
+pub type ButtonRepeatToken<'ui> = ItemFlagStackToken<'ui>;
 
 impl Ui {
     /// Enable/disable repeating behavior for subsequent buttons.
@@ -26,10 +13,7 @@ impl Ui {
     /// Internally uses `PushItemFlag(ImGuiItemFlags_ButtonRepeat, repeat)`.
     #[doc(alias = "PushButtonRepeat")]
     pub fn push_button_repeat(&self, repeat: bool) -> ButtonRepeatToken<'_> {
-        self.run_with_bound_context(|| unsafe {
-            sys::igPushItemFlag(sys::ImGuiItemFlags_ButtonRepeat as i32, repeat)
-        });
-        ButtonRepeatToken::new(self)
+        self.push_item_flag(ItemFlags::BUTTON_REPEAT, repeat)
     }
 
     /// Push a button repeat item flag, run `f`, then pop the flag.

--- a/dear-imgui/src/widget/misc/disabled.rs
+++ b/dear-imgui/src/widget/misc/disabled.rs
@@ -7,6 +7,7 @@ use crate::sys;
 
 /// Tracks a disabled scope begun with [`Ui::begin_disabled`] and ended on drop.
 #[must_use]
+#[doc(alias = "EndDisabled")]
 pub struct DisabledToken<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/widget/multi_select/requests.rs
+++ b/dear-imgui/src/widget/multi_select/requests.rs
@@ -3,6 +3,18 @@ use crate::{Id, sys};
 use super::basic_selection::BasicSelection;
 use super::storage::MultiSelectIndexStorage;
 
+fn request_range(
+    request: &sys::ImGuiSelectionRequest,
+    items_count: usize,
+) -> Option<std::ops::RangeInclusive<usize>> {
+    let first = usize::try_from(request.RangeFirstItem).ok()?;
+    let last = usize::try_from(request.RangeLastItem).ok()?;
+    if first > last || first >= items_count {
+        return None;
+    }
+    Some(first..=last.min(items_count.saturating_sub(1)))
+}
+
 /// Apply `ImGuiMultiSelectIO` requests to index-based selection storage.
 ///
 /// This mirrors `ImGuiSelectionExternalStorage::ApplyRequests` from Dear ImGui,
@@ -37,14 +49,16 @@ pub(super) unsafe fn apply_multi_select_requests_indexed<S: MultiSelectIndexStor
                     storage.set_selected(idx, req.Selected);
                 }
             } else if req.Type == sys::ImGuiSelectionRequestType_SetRange {
-                let first = req.RangeFirstItem as i32;
-                let last = req.RangeLastItem as i32;
-                if first < 0 || last < first {
-                    continue;
-                }
-                let last_clamped = std::cmp::min(last as usize, items_count.saturating_sub(1));
-                for idx in first as usize..=last_clamped {
-                    storage.set_selected(idx, req.Selected);
+                if let Some(range) = request_range(req, items_count) {
+                    if req.RangeDirection < 0 {
+                        for idx in range.rev() {
+                            storage.set_selected(idx, req.Selected);
+                        }
+                    } else {
+                        for idx in range {
+                            storage.set_selected(idx, req.Selected);
+                        }
+                    }
                 }
             }
         }
@@ -84,17 +98,70 @@ pub(super) unsafe fn apply_multi_select_requests_basic<G>(
                     selection.set_selected(id, req.Selected);
                 }
             } else if req.Type == sys::ImGuiSelectionRequestType_SetRange {
-                let first = req.RangeFirstItem as i32;
-                let last = req.RangeLastItem as i32;
-                if first < 0 || last < first {
-                    continue;
-                }
-                let last_clamped = std::cmp::min(last as usize, items_count.saturating_sub(1));
-                for idx in first as usize..=last_clamped {
-                    let id = id_at_index(idx);
-                    selection.set_selected(id, req.Selected);
+                if let Some(range) = request_range(req, items_count) {
+                    if req.RangeDirection < 0 {
+                        for idx in range.rev() {
+                            let id = id_at_index(idx);
+                            selection.set_selected(id, req.Selected);
+                        }
+                    } else {
+                        for idx in range {
+                            let id = id_at_index(idx);
+                            selection.set_selected(id, req.Selected);
+                        }
+                    }
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct RecordingStorage {
+        selected: Vec<bool>,
+        updates: Vec<usize>,
+    }
+
+    impl MultiSelectIndexStorage for RecordingStorage {
+        fn len(&self) -> usize {
+            self.selected.len()
+        }
+
+        fn is_selected(&self, index: usize) -> bool {
+            self.selected[index]
+        }
+
+        fn set_selected(&mut self, index: usize, selected: bool) {
+            self.selected[index] = selected;
+            self.updates.push(index);
+        }
+    }
+
+    #[test]
+    fn indexed_requests_preserve_backward_range_direction() {
+        let mut request = sys::ImGuiSelectionRequest {
+            Type: sys::ImGuiSelectionRequestType_SetRange,
+            Selected: true,
+            RangeDirection: -1,
+            RangeFirstItem: 1,
+            RangeLastItem: 3,
+        };
+        let mut io = sys::ImGuiMultiSelectIO::default();
+        io.ItemsCount = 5;
+        io.Requests.Data = &mut request;
+        io.Requests.Size = 1;
+        io.Requests.Capacity = 1;
+        let mut storage = RecordingStorage {
+            selected: vec![false; 5],
+            updates: Vec::new(),
+        };
+
+        unsafe { apply_multi_select_requests_indexed(&mut io, &mut storage) };
+
+        assert_eq!(storage.updates, vec![3, 2, 1]);
+        assert_eq!(storage.selected, vec![false, true, true, true, false]);
     }
 }

--- a/dear-imgui/src/widget/multi_select/ui.rs
+++ b/dear-imgui/src/widget/multi_select/ui.rs
@@ -13,6 +13,7 @@ impl Ui {
     /// `EndMultiSelect()` pair. It does not drive any selection storage by
     /// itself; use `begin_io()` / `end().io()` and the helper methods to
     /// implement custom patterns.
+    #[doc(alias = "BeginMultiSelect", alias = "EndMultiSelect")]
     pub fn begin_multi_select_raw(
         &self,
         flags: impl Into<MultiSelectOptions>,
@@ -50,6 +51,7 @@ impl Ui {
     ///   stored entirely on the application side.
     /// - Per-item selection toggles can be queried via
     ///   [`Ui::is_item_toggled_selection`].
+    #[doc(alias = "SetNextItemSelectionUserData")]
     pub fn multi_select_indexed<S, F>(
         &self,
         storage: &mut S,

--- a/dear-imgui/src/widget/popup/tokens.rs
+++ b/dear-imgui/src/widget/popup/tokens.rs
@@ -3,6 +3,7 @@ use crate::ui::Ui;
 
 /// Tracks a popup that can be ended by calling `.end()` or by dropping
 #[must_use]
+#[doc(alias = "EndPopup")]
 pub struct PopupToken<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/widget/tab/tokens.rs
+++ b/dear-imgui/src/widget/tab/tokens.rs
@@ -4,6 +4,7 @@ use crate::ui::Ui;
 /// Token representing an active tab bar
 #[derive(Debug)]
 #[must_use]
+#[doc(alias = "EndTabBar")]
 pub struct TabBarToken<'ui> {
     _ui: &'ui Ui,
 }
@@ -30,6 +31,7 @@ impl<'ui> Drop for TabBarToken<'ui> {
 /// Token representing an active tab item
 #[derive(Debug)]
 #[must_use]
+#[doc(alias = "EndTabItem")]
 pub struct TabItemToken<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/widget/table/builder.rs
+++ b/dear-imgui/src/widget/table/builder.rs
@@ -1,5 +1,4 @@
-use crate::Id;
-use crate::ui::Ui;
+use crate::{Id, ui::Ui};
 
 use super::{
     TableColumnFlags, TableColumnIndent, TableColumnSetup, TableColumnWidth, TableFlags,
@@ -78,28 +77,16 @@ impl<'ui> TableBuilder<'ui> {
         mut self,
         cols: impl IntoIterator<Item = TableColumnSetup<Name>>,
     ) -> Self {
-        self.columns.clear();
-        for c in cols {
-            self.columns.push(TableColumnSetup {
-                name: c.name.into(),
-                flags: c.flags,
-                width: c.width,
-                indent: c.indent,
-                user_id: c.user_id,
-            });
-        }
+        self.columns = cols
+            .into_iter()
+            .map(|column| column.map_name(Into::into))
+            .collect();
         self
     }
 
     /// Add a single column setup
     pub fn add_column<Name: Into<Cow<'ui, str>>>(mut self, col: TableColumnSetup<Name>) -> Self {
-        self.columns.push(TableColumnSetup {
-            name: col.name.into(),
-            flags: col.flags,
-            width: col.width,
-            indent: col.indent,
-            user_id: col.user_id,
-        });
+        self.columns.push(col.map_name(Into::into));
         self
     }
 
@@ -155,52 +142,44 @@ impl<'ui> TableBuilder<'ui> {
 #[derive(Debug)]
 pub struct ColumnBuilder<'ui> {
     parent: TableBuilder<'ui>,
-    name: Cow<'ui, str>,
-    flags: TableColumnFlags,
-    width: Option<TableColumnWidth>,
-    indent: Option<TableColumnIndent>,
-    user_id: Option<Id>,
+    column: TableColumnSetup<Cow<'ui, str>>,
 }
 
 impl<'ui> ColumnBuilder<'ui> {
     fn new(parent: TableBuilder<'ui>, name: impl Into<Cow<'ui, str>>) -> Self {
         Self {
             parent,
-            name: name.into(),
-            flags: TableColumnFlags::NONE,
-            width: None,
-            indent: None,
-            user_id: None,
+            column: TableColumnSetup::new(name.into()),
         }
     }
 
     /// Set column flags.
     pub fn flags(mut self, flags: TableColumnFlags) -> Self {
-        self.flags = flags;
+        self.column.flags = flags;
         self
     }
 
     /// Set fixed width or stretch weight (ImGui uses same field for both).
     pub fn width(mut self, width: f32) -> Self {
-        self.width = Some(TableColumnWidth::Fixed(width));
+        self.column.width = Some(TableColumnWidth::Fixed(width));
         self
     }
 
     /// Alias of `width()` to express stretch weights.
     pub fn weight(mut self, weight: f32) -> Self {
-        self.width = Some(TableColumnWidth::Stretch(weight));
+        self.column.width = Some(TableColumnWidth::Stretch(weight));
         self
     }
 
     /// Set this column's indentation policy.
     pub fn indent(mut self, indent: TableColumnIndent) -> Self {
-        self.indent = Some(indent);
+        self.column.indent = Some(indent);
         self
     }
 
     /// Enable or disable indentation for this column.
     pub fn indent_enabled(mut self, enabled: bool) -> Self {
-        self.indent = Some(if enabled {
+        self.column.indent = Some(if enabled {
             TableColumnIndent::Enable
         } else {
             TableColumnIndent::Disable
@@ -211,28 +190,24 @@ impl<'ui> ColumnBuilder<'ui> {
     /// Toggle angled header flag.
     pub fn angled_header(mut self, enabled: bool) -> Self {
         if enabled {
-            self.flags.insert(TableColumnFlags::ANGLED_HEADER);
+            self.column.flags.insert(TableColumnFlags::ANGLED_HEADER);
         } else {
-            self.flags.remove(TableColumnFlags::ANGLED_HEADER);
+            self.column.flags.remove(TableColumnFlags::ANGLED_HEADER);
         }
         self
     }
 
-    /// Set user id for this column.
-    pub fn user_id(mut self, id: Id) -> Self {
-        self.user_id = Some(assert_explicit_user_id(id, "ColumnBuilder::user_id()"));
+    /// Sets the non-zero user ID associated with this column.
+    ///
+    /// See [`TableColumnSetup::user_id`] for accepted inputs and value semantics.
+    pub fn user_id(mut self, id: impl Into<Id>) -> Self {
+        self.column.user_id = Some(assert_explicit_user_id(id, "ColumnBuilder::user_id()"));
         self
     }
 
     /// Finish this column and return to the table builder.
     pub fn done(mut self) -> TableBuilder<'ui> {
-        self.parent.columns.push(TableColumnSetup {
-            name: self.name,
-            flags: self.flags,
-            width: self.width,
-            indent: self.indent,
-            user_id: self.user_id,
-        });
+        self.parent.columns.push(self.column);
         self.parent
     }
 }

--- a/dear-imgui/src/widget/table/core.rs
+++ b/dear-imgui/src/widget/table/core.rs
@@ -44,6 +44,7 @@ impl Ui {
     /// [begin_table_header](Self::begin_table_header) or the more complex
     /// [table_setup_column](Self::table_setup_column).
     #[must_use = "if return is dropped immediately, table is ended immediately."]
+    #[doc(alias = "BeginTable")]
     pub fn begin_table(
         &self,
         str_id: impl AsRef<str>,
@@ -153,6 +154,7 @@ impl Ui {
     }
 
     /// Setup a column for the current table
+    #[doc(alias = "TableSetupColumn")]
     pub fn table_setup_column(
         &self,
         label: impl AsRef<str>,
@@ -224,6 +226,7 @@ impl Ui {
     }
 
     /// Submit all headers cells based on data provided to TableSetupColumn() + submit context menu
+    #[doc(alias = "TableHeadersRow")]
     pub fn table_headers_row(&self) {
         self.run_with_bound_context(|| {
             assert_current_table("Ui::table_headers_row()");
@@ -234,11 +237,13 @@ impl Ui {
     }
 
     /// Append into the next column (or first column of next row if currently in last column)
+    #[doc(alias = "TableNextColumn")]
     pub fn table_next_column(&self) -> bool {
         self.run_with_bound_context(|| unsafe { sys::igTableNextColumn() })
     }
 
     /// Append into the specified column
+    #[doc(alias = "TableSetColumnIndex")]
     pub fn table_set_column_index(&self, column: impl Into<TableColumnIndex>) -> bool {
         let column = column.into();
         let column_n = column.into_i32("Ui::table_set_column_index()");
@@ -251,6 +256,7 @@ impl Ui {
     }
 
     /// Append into the next row
+    #[doc(alias = "TableNextRow")]
     pub fn table_next_row(&self) {
         self.table_next_row_with_flags(TableRowFlags::NONE, 0.0);
     }

--- a/dear-imgui/src/widget/table/setup.rs
+++ b/dear-imgui/src/widget/table/setup.rs
@@ -58,9 +58,24 @@ impl<Name> TableColumnSetup<Name> {
         self
     }
 
-    /// Sets the user ID
-    pub fn user_id(mut self, id: Id) -> Self {
+    /// Sets the non-zero user ID associated with this column.
+    ///
+    /// Accepts an [`Id`] or a `u32` value. Dear ImGui returns the value unchanged
+    /// in table sort specifications; unlike [`Ui::push_id`](crate::Ui::push_id),
+    /// it is not hashed through the ID stack. Omit this method to leave the user
+    /// ID unspecified.
+    pub fn user_id(mut self, id: impl Into<Id>) -> Self {
         self.user_id = Some(assert_explicit_user_id(id, "TableColumnSetup::user_id()"));
         self
+    }
+
+    pub(crate) fn map_name<M>(self, map: impl FnOnce(Name) -> M) -> TableColumnSetup<M> {
+        TableColumnSetup {
+            name: map(self.name),
+            flags: self.flags,
+            width: self.width,
+            indent: self.indent,
+            user_id: self.user_id,
+        }
     }
 }

--- a/dear-imgui/src/widget/table/tests.rs
+++ b/dear-imgui/src/widget/table/tests.rs
@@ -29,6 +29,50 @@ fn table_user_ids_hide_zero_sentinel() {
     );
 }
 
+#[test]
+fn table_user_id_builders_accept_integer_ids() {
+    let setup_id = 7;
+    let setup = TableColumnSetup::new("column").user_id(setup_id);
+    assert_eq!(setup.user_id, Some(crate::Id::from(7u32)));
+
+    let mut ctx = setup_context();
+    let ui = ctx.frame();
+    let setup_id = 8;
+    let builder_id = 9;
+    let _ = ui.window("table_integer_user_id").build(|| {
+        {
+            let _table = ui.begin_table("setup", 1).unwrap();
+            ui.table_setup_column(
+                "column",
+                TableColumnFlags::NONE,
+                None,
+                Some(setup_id.into()),
+            );
+            assert_eq!(unsafe { current_table_column_user_id(0) }, setup_id);
+        }
+
+        ui.table("table")
+            .column("column")
+            .user_id(builder_id)
+            .done()
+            .build(|_| {
+                assert_eq!(unsafe { current_table_column_user_id(0) }, builder_id);
+            });
+    });
+}
+
+unsafe fn current_table_column_user_id(column: usize) -> u32 {
+    let table = unsafe { sys::igGetCurrentTable() };
+    assert!(!table.is_null());
+    let columns = unsafe { (*table).Columns.Data };
+    let columns_end = unsafe { (*table).Columns.DataEnd };
+    assert!(!columns.is_null());
+    assert!(!columns_end.is_null());
+    let column_count = unsafe { columns_end.offset_from(columns) as usize };
+    assert!(column < column_count);
+    unsafe { (*columns.add(column)).UserID }
+}
+
 unsafe fn current_table_draw_channel() -> i32 {
     let table = assert_current_table("current_table_draw_channel()");
     let draw_list = unsafe { (*(*table).InnerWindow).DrawList };

--- a/dear-imgui/src/widget/table/tokens.rs
+++ b/dear-imgui/src/widget/table/tokens.rs
@@ -3,6 +3,7 @@ use crate::ui::Ui;
 
 /// Tracks a table that can be ended by calling `.end()` or by dropping
 #[must_use]
+#[doc(alias = "EndTable")]
 pub struct TableToken<'ui> {
     _ui: &'ui Ui,
 }

--- a/dear-imgui/src/widget/table/validation.rs
+++ b/dear-imgui/src/widget/table/validation.rs
@@ -124,7 +124,8 @@ pub(crate) fn assert_current_table_row(caller: &str) {
     );
 }
 
-pub(crate) fn assert_explicit_user_id(id: Id, caller: &str) -> Id {
+pub(crate) fn assert_explicit_user_id(id: impl Into<Id>, caller: &str) -> Id {
+    let id = id.into();
     assert!(
         id.raw() != 0,
         "{caller} user_id must be non-zero; use None for automatic user id"

--- a/dear-imgui/src/widget/text.rs
+++ b/dear-imgui/src/widget/text.rs
@@ -19,6 +19,63 @@ use crate::style::StyleColor;
 use crate::sys;
 
 impl Ui {
+    /// Calculates the size required to render text with the current font and font size.
+    ///
+    /// This is equivalent to [`Ui::calc_text_size_with_opts`] with
+    /// `hide_text_after_double_hash` set to `false` and wrapping disabled.
+    #[doc(alias = "CalcTextSize")]
+    pub fn calc_text_size(&self, text: impl AsRef<str>) -> [f32; 2] {
+        self.calc_text_size_with_opts(text, false, -1.0)
+    }
+
+    /// Calculates the size required to render text with explicit display options.
+    ///
+    /// When `hide_text_after_double_hash` is `true`, the `##` label suffix is
+    /// excluded from the measurement. A positive `wrap_width` enables wrapping;
+    /// values at or below zero disable it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `wrap_width` is not finite.
+    #[doc(alias = "CalcTextSize")]
+    pub fn calc_text_size_with_opts(
+        &self,
+        text: impl AsRef<str>,
+        hide_text_after_double_hash: bool,
+        wrap_width: f32,
+    ) -> [f32; 2] {
+        Self::assert_finite_f32("Ui::calc_text_size_with_opts()", "wrap_width", wrap_width);
+        let text = text.as_ref();
+
+        self.run_with_bound_context(|| unsafe {
+            self.calc_text_size_bound(text, hide_text_after_double_hash, wrap_width)
+        })
+    }
+
+    /// Measures text while the owning ImGui context is already current.
+    ///
+    /// # Safety
+    ///
+    /// The caller must bind this `Ui`'s live ImGui context for the duration of
+    /// the call.
+    pub(crate) unsafe fn calc_text_size_bound(
+        &self,
+        text: &str,
+        hide_text_after_double_hash: bool,
+        wrap_width: f32,
+    ) -> [f32; 2] {
+        let text_range = self.scratch_txt_range(text);
+        let size = unsafe {
+            sys::igCalcTextSize(
+                text_range.start,
+                text_range.end,
+                hide_text_after_double_hash,
+                wrap_width,
+            )
+        };
+        [size.x, size.y]
+    }
+
     /// Display colored text
     ///
     /// This implementation uses zero-copy optimization with `igTextEx`,
@@ -119,5 +176,46 @@ impl Ui {
     pub fn text_link_open_url(&self, label: impl AsRef<str>, url: impl AsRef<str>) -> bool {
         let (label_ptr, url_ptr) = self.scratch_txt_two(label, url);
         self.run_with_bound_context(|| unsafe { sys::igTextLinkOpenURL(label_ptr, url_ptr) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn setup_context() -> crate::Context {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+        ctx
+    }
+
+    #[test]
+    fn calc_text_size_supports_default_and_advanced_options() {
+        let mut ctx = setup_context();
+        let ui = ctx.frame();
+
+        let default_size = ui.calc_text_size("Column##sort_key");
+        let explicit_default = ui.calc_text_size_with_opts("Column##sort_key", false, -1.0);
+        let visible_label = ui.calc_text_size_with_opts("Column##sort_key", true, -1.0);
+        let trailing_hash = ui.calc_text_size_with_opts("Column#", true, -1.0);
+
+        assert_eq!(default_size, explicit_default);
+        assert!(visible_label[0] < default_size[0]);
+        assert_eq!(visible_label[1], default_size[1]);
+        assert_eq!(trailing_hash, ui.calc_text_size("Column#"));
+
+        let unwrapped = ui.calc_text_size("one two three four");
+        let wrapped = ui.calc_text_size_with_opts("one two three four", false, unwrapped[0] / 2.0);
+        assert!(wrapped[0] < unwrapped[0]);
+        assert!(wrapped[1] > unwrapped[1]);
+
+        for wrap_width in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let _ = ui.calc_text_size_with_opts("text", false, wrap_width);
+                }))
+                .is_err()
+            );
+        }
     }
 }

--- a/dear-imgui/src/widget/tooltip.rs
+++ b/dear-imgui/src/widget/tooltip.rs
@@ -94,7 +94,7 @@ impl Ui {
     /// Sets a tooltip for the last item with simple text content.
     ///
     /// Uses the non-variadic `BeginItemTooltip` path and renders unformatted text.
-    #[doc(alias = "SetItemTooltip")]
+    #[doc(alias = "SetItemTooltip", alias = "BeginItemTooltip")]
     pub fn set_item_tooltip(&self, text: impl AsRef<str>) {
         let s = text.as_ref();
         self.run_with_bound_context(|| unsafe {

--- a/dear-imgui/src/widget/tree/builder.rs
+++ b/dear-imgui/src/widget/tree/builder.rs
@@ -141,6 +141,7 @@ impl<'a, T: AsRef<str>, L: AsRef<str>> TreeNode<'a, T, L> {
     ///
     /// Returns `None` if the tree node is not open and no content should be rendered.
     pub fn push(self) -> Option<TreeNodeToken<'a>> {
+        let pushes_tree = !self.flags.contains(TreeNodeFlags::NO_TREE_PUSH_ON_OPEN);
         let open = self.ui.run_with_bound_context(|| unsafe {
             if let Some(opened_cond) = self.opened_cond {
                 sys::igSetNextItemOpen(self.opened, opened_cond as i32);
@@ -149,37 +150,41 @@ impl<'a, T: AsRef<str>, L: AsRef<str>> TreeNode<'a, T, L> {
             match &self.id {
                 TreeNodeId::Str(s) => {
                     if let Some(label) = self.label.as_ref() {
+                        const FMT: &[u8; 3] = b"%s\0";
                         let (id_ptr, label_ptr) = self.ui.scratch_txt_two(s, label);
-                        sys::igPushID_Str(id_ptr);
-                        let open = sys::igTreeNodeEx_Str(label_ptr, self.flags.bits());
-                        sys::igPopID();
-                        open
+                        sys::igTreeNodeEx_StrStr(
+                            id_ptr,
+                            self.flags.bits(),
+                            FMT.as_ptr().cast(),
+                            label_ptr,
+                        )
                     } else {
                         let label_ptr = self.ui.scratch_txt(s);
                         sys::igTreeNodeEx_Str(label_ptr, self.flags.bits())
                     }
                 }
                 TreeNodeId::Ptr(ptr) => {
+                    const FMT: &[u8; 3] = b"%s\0";
                     let label = self.label.as_ref().map_or("", |l| l.as_ref());
                     let label_ptr = self.ui.scratch_txt(label);
-                    sys::igPushID_Ptr(*ptr as *const std::os::raw::c_void);
-                    let open = sys::igTreeNodeEx_Str(label_ptr, self.flags.bits());
-                    sys::igPopID();
-                    open
+                    sys::igTreeNodeEx_Ptr(
+                        ptr.cast(),
+                        self.flags.bits(),
+                        FMT.as_ptr().cast(),
+                        label_ptr,
+                    )
                 }
                 TreeNodeId::Int(i) => {
                     let label = self.label.as_ref().map_or("", |l| l.as_ref());
                     let label_ptr = self.ui.scratch_txt(label);
-                    sys::igPushID_Int(*i);
-                    let open = sys::igTreeNodeEx_Str(label_ptr, self.flags.bits());
-                    sys::igPopID();
-                    open
+                    let id = sys::igGetID_Int(*i);
+                    sys::igTreeNodeBehavior(id, self.flags.bits(), label_ptr, std::ptr::null())
                 }
             }
         });
 
         if open {
-            Some(TreeNodeToken::new(self.ui))
+            Some(TreeNodeToken::from_tree_node(self.ui, pushes_tree))
         } else {
             None
         }

--- a/dear-imgui/src/widget/tree/entry.rs
+++ b/dear-imgui/src/widget/tree/entry.rs
@@ -12,6 +12,7 @@ impl Ui {
     /// configurations on the tree node.
     ///
     /// [tree_node_config]: Self::tree_node_config
+    #[doc(alias = "TreeNode", alias = "TreeNodeEx")]
     pub fn tree_node<I, T>(&self, id: I) -> Option<TreeNodeToken<'_>>
     where
         I: Into<TreeNodeId<T>>,
@@ -31,6 +32,26 @@ impl Ui {
         T: AsRef<str>,
     {
         TreeNode::new(id.into(), self)
+    }
+
+    /// Starts a tree indentation and ID scope without rendering a tree node.
+    ///
+    /// The returned token restores the tree depth, indentation, and ID stack
+    /// when dropped.
+    #[doc(alias = "TreePush")]
+    pub fn tree_push(&self, id: impl AsRef<str>) -> TreeNodeToken<'_> {
+        let id = self.scratch_txt(id);
+        self.run_with_bound_context(|| unsafe { sys::igTreePush_Str(id) });
+        TreeNodeToken::new(self)
+    }
+
+    /// Starts a tree indentation and ID scope using a pointer value as the ID.
+    ///
+    /// The pointer is used only as an identifier and is not dereferenced.
+    #[doc(alias = "TreePush")]
+    pub fn tree_push_ptr<T>(&self, id: *const T) -> TreeNodeToken<'_> {
+        self.run_with_bound_context(|| unsafe { sys::igTreePush_Ptr(id.cast()) });
+        TreeNodeToken::new(self)
     }
 
     /// Creates a collapsing header widget
@@ -70,5 +91,109 @@ impl Ui {
     #[doc(alias = "TreeNodeGetOpen")]
     pub fn tree_node_get_open(&self, storage_id: Id) -> bool {
         self.run_with_bound_context(|| unsafe { sys::igTreeNodeGetOpen(storage_id.raw()) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn manual_tree_scopes_restore_tree_depth_and_id_stack() {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+        let ui = ctx.frame();
+
+        ui.window("tree_push").build(|| {
+            let window = unsafe { crate::sys::igGetCurrentWindowRead() };
+            let initial_depth = unsafe { (*window).DC.TreeDepth };
+            let initial_id_stack_size = unsafe { (*window).IDStack.Size };
+
+            {
+                let _tree = ui.tree_push("string_scope");
+                assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth + 1);
+                assert_eq!(unsafe { (*window).IDStack.Size }, initial_id_stack_size + 1);
+            }
+
+            assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth);
+            assert_eq!(unsafe { (*window).IDStack.Size }, initial_id_stack_size);
+
+            let marker = 0_u8;
+            let tree = ui.tree_push_ptr(&marker);
+            assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth + 1);
+            tree.pop();
+            assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth);
+            assert_eq!(unsafe { (*window).IDStack.Size }, initial_id_stack_size);
+        });
+    }
+
+    #[test]
+    fn tree_node_tokens_match_push_flags_and_keep_custom_ids_stable() {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        let _ = ctx.font_atlas_mut().build();
+        let ui = ctx.frame();
+
+        ui.window("tree_node_tokens").build(|| {
+            let window = unsafe { crate::sys::igGetCurrentWindowRead() };
+            let initial_depth = unsafe { (*window).DC.TreeDepth };
+            let initial_id_stack_size = unsafe { (*window).IDStack.Size };
+
+            let no_push = ui
+                .tree_node_config("no_push")
+                .opened(true, crate::Condition::Always)
+                .no_tree_push_on_open(true)
+                .push()
+                .expect("forced-open tree node");
+            assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth);
+            assert_eq!(unsafe { (*window).IDStack.Size }, initial_id_stack_size);
+            drop(no_push);
+            assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth);
+            assert_eq!(unsafe { (*window).IDStack.Size }, initial_id_stack_size);
+
+            let first = ui
+                .tree_node_config("stable_id")
+                .label("First label")
+                .opened(true, crate::Condition::Always)
+                .push()
+                .expect("forced-open tree node");
+            let first_id = ui.item_id();
+            drop(first);
+
+            let second = ui
+                .tree_node_config("stable_id")
+                .label("Second label")
+                .opened(true, crate::Condition::Always)
+                .push()
+                .expect("forced-open tree node");
+            let second_id = ui.item_id();
+            drop(second);
+            assert_eq!(first_id, second_id);
+
+            let first_int = ui
+                .tree_node_config(7_i32)
+                .label("First integer label")
+                .opened(true, crate::Condition::Always)
+                .nav_left_jumps_back_here(true)
+                .push()
+                .expect("forced-open tree node");
+            let first_int_id = ui.item_id();
+            assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth + 1);
+            assert_eq!(unsafe { (*window).IDStack.Size }, initial_id_stack_size + 1);
+            drop(first_int);
+
+            let second_int = ui
+                .tree_node_config(7_i32)
+                .label("Second integer label")
+                .opened(true, crate::Condition::Always)
+                .push()
+                .expect("forced-open tree node");
+            let second_int_id = ui.item_id();
+            drop(second_int);
+            assert_eq!(first_int_id, second_int_id);
+            assert_eq!(unsafe { (*window).DC.TreeDepth }, initial_depth);
+            assert_eq!(unsafe { (*window).IDStack.Size }, initial_id_stack_size);
+        });
     }
 }

--- a/dear-imgui/src/widget/tree/token.rs
+++ b/dear-imgui/src/widget/tree/token.rs
@@ -3,14 +3,26 @@ use crate::ui::Ui;
 
 /// Tracks a tree node that can be popped by calling `.pop()` or by dropping
 #[must_use]
+#[doc(alias = "TreePop")]
 pub struct TreeNodeToken<'ui> {
     _ui: &'ui Ui,
+    pop_tree_node: bool,
 }
 
 impl<'ui> TreeNodeToken<'ui> {
-    /// Creates a new tree node token
+    /// Creates a token for an explicitly pushed tree scope.
     pub(super) fn new(ui: &'ui Ui) -> Self {
-        TreeNodeToken { _ui: ui }
+        Self {
+            _ui: ui,
+            pop_tree_node: true,
+        }
+    }
+
+    pub(super) fn from_tree_node(ui: &'ui Ui, pop_tree_node: bool) -> Self {
+        Self {
+            _ui: ui,
+            pop_tree_node,
+        }
     }
 
     /// Pops the tree node
@@ -21,7 +33,10 @@ impl<'ui> TreeNodeToken<'ui> {
 
 impl Drop for TreeNodeToken<'_> {
     fn drop(&mut self) {
-        self._ui
-            .run_with_bound_context(|| unsafe { sys::igTreePop() });
+        self._ui.run_with_bound_context(|| unsafe {
+            if self.pop_tree_node {
+                sys::igTreePop();
+            }
+        });
     }
 }

--- a/dear-imgui/src/window/child_window.rs
+++ b/dear-imgui/src/window/child_window.rs
@@ -128,6 +128,7 @@ impl<'ui> ChildWindow<'ui> {
     }
 
     /// Builds the child window and calls the provided closure
+    #[doc(alias = "BeginChild", alias = "EndChild")]
     pub fn build<F, R>(self, ui: &'ui Ui, f: F) -> Option<R>
     where
         F: FnOnce() -> R,

--- a/dear-imgui/src/window/mod.rs
+++ b/dear-imgui/src/window/mod.rs
@@ -212,6 +212,7 @@ impl<'ui> Window<'ui> {
     }
 
     /// Sets window size
+    #[doc(alias = "SetNextWindowSize")]
     pub fn size(mut self, size: [f32; 2], condition: Condition) -> Self {
         self.size = Some(size);
         self.size_condition = condition;
@@ -229,6 +230,7 @@ impl<'ui> Window<'ui> {
     }
 
     /// Sets window position
+    #[doc(alias = "SetNextWindowPos")]
     pub fn position(mut self, pos: [f32; 2], condition: Condition) -> Self {
         self.pos = Some(pos);
         self.pos_condition = condition;
@@ -236,12 +238,14 @@ impl<'ui> Window<'ui> {
     }
 
     /// Sets window content size
+    #[doc(alias = "SetNextWindowContentSize")]
     pub fn content_size(mut self, size: [f32; 2]) -> Self {
         self.content_size = Some(size);
         self
     }
 
     /// Sets window collapsed state
+    #[doc(alias = "SetNextWindowCollapsed")]
     pub fn collapsed(mut self, collapsed: bool, condition: Condition) -> Self {
         self.collapsed = Some(collapsed);
         self.collapsed_condition = condition;
@@ -249,12 +253,14 @@ impl<'ui> Window<'ui> {
     }
 
     /// Sets window focused state
+    #[doc(alias = "SetNextWindowFocus")]
     pub fn focused(mut self, focused: bool) -> Self {
         self.focused = Some(focused);
         self
     }
 
     /// Sets window background alpha
+    #[doc(alias = "SetNextWindowBgAlpha")]
     pub fn bg_alpha(mut self, alpha: f32) -> Self {
         self.bg_alpha = Some(alpha);
         self
@@ -402,6 +408,7 @@ impl<'ui> Window<'ui> {
 }
 
 /// Token representing an active window
+#[doc(alias = "End")]
 pub struct WindowToken<'ui> {
     ui: &'ui Ui,
 }

--- a/docs/API_COVERAGE.md
+++ b/docs/API_COVERAGE.md
@@ -24,16 +24,69 @@ Run:
 
 ```bash
 python tools/api_surface_report.py --format plain --limit 40
+python tools/api_surface_report.py --check
 ```
 
-This prints a representative list of public ImGui functions that are not referenced by the
-high-level crate (either via `#[doc(alias = "...")]` or via a sys call).
+The tool has two deliberately different coverage layers.
+
+### Generator contract snapshot: all namespaces
+
+`tools/api_surface_snapshot.json` records every public function declaration emitted by cimgui's
+generator across all namespaces. The canonical record includes the symbol, namespace, signature,
+return type, arguments, defaults, generator traits, and the exact cimgui and Dear ImGui source
+revisions. `--check` rejects added, removed, or changed declarations and source revision drift.
+
+This layer detects raw API drift; it does **not** claim that every non-`ImGui` namespace function has
+a safe Rust wrapper. After reviewing an intentional upstream change, refresh it explicitly with:
+
+```bash
+python tools/api_surface_report.py --update-snapshot
+```
+
+The snapshot currently covers function declarations. Enum values, flag bits, and public struct
+fields still require their existing upgrade audit and are not independently snapshotted by this
+tool.
+
+### Safe semantic audit: top-level `ImGui` functions
+
+For top-level `ImGui` functions, the report treats a matching `#[doc(alias = "...")]` on a public,
+safe Rust item as direct safe API coverage. A builder, RAII token, context lifecycle, or typed
+composition should carry the aliases of the upstream operations it replaces. Every remaining
+function must have an explicit decision in `tools/api_surface_policy.json`:
+
+- `intentional-sys-only`: wrapping it would expose variadic formatting, obsolete APIs, or unsafe
+  global/raw ownership contracts.
+- `deferred-design`: a safe wrapper is desirable but needs a documented lifetime or type design.
+
+`--check` fails on generator drift, unclassified top-level functions, and stale policy entries. CI
+runs it after checking the vendored source revisions, so a cimgui/Dear ImGui update cannot silently
+add an unreviewed top-level safe API gap.
 
 Notes:
-- A function being "uncovered" does not automatically mean it should be wrapped: many uncovered
-  functions are intentionally sys-only (variadics, allocator hooks, debug helpers, etc.).
-- Conversely, a function being "covered" does not guarantee perfect ergonomics; it only means we
-  have a high-level reference point.
+- A policy decision is not permanent. Replace it with a rustdoc alias when a direct safe wrapper is
+  added, or update its rationale when the high-level design changes.
+- Direct `sys::ig*` usage is reported only as information. It is not proof of safe API coverage,
+  because an internal call may expose only a small subset of the public operation.
+- Namespaced APIs such as `ImFontAtlas`, `ImFontBaked`, `ImDrawList`, and `ImTextureData` are guarded
+  against generator drift but still need a manual safe-layer audit during upgrades.
+
+## Known deferred namespaced designs
+
+The current audit intentionally leaves these raw capabilities without a public safe wrapper:
+
+- `ImGui::GetFontBaked`, `ImFont::GetFontBaked`, and the `ImFontBaked` query methods need a
+  frame-bound `BakedFont` view. Upstream states that these pointers are valid only for the current
+  frame, and atlas mutation or density changes can replace the underlying cache.
+- `ImFontAtlas::{AddCustomRect,GetCustomRect,RemoveCustomRect}` need a typed rectangle ID, copy-out
+  snapshots for UV data that upstream may invalidate at any time, and an API that marks the affected
+  managed texture region for renderer upload after pixel writes.
+- `ImGuiListClipper::SeekCursorForItem` is useful only with the `INT_MAX` unknown-item-count mode. A
+  safe wrapper should model known versus unknown counts explicitly and permit the final seek only in
+  the correct post-step state.
+
+These are design tasks, not aliases to add mechanically. Obsolete functions such as
+`ImFontAtlas::ClearInputData` remain intentionally sys-only, while low-level font rendering already
+has safe draw-list equivalents.
 
 ## Avoiding duplicate wrappers (required)
 
@@ -66,4 +119,3 @@ the relevant crate(s) or examples in the same PR to keep the repository consiste
 For local, non-committed tracking, keep notes under `repo-ref/` (this folder is ignored by git in
 this repo). This is useful for scratch work and prioritization, but user-facing changes should be
 captured in `CHANGELOG.md`.
-

--- a/tools/api_surface_policy.json
+++ b/tools/api_surface_policy.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 2,
+  "scope": "ImGui",
+  "groups": [
+    {
+      "classification": "intentional-sys-only",
+      "name": "c-variadic-formatting",
+      "reason": "C variadic formatting is not type-safe; Rust string and non-variadic alternatives are exposed instead.",
+      "functions": [
+        "BulletTextV",
+        "DebugLog",
+        "DebugLogV",
+        "LabelTextV",
+        "LogText",
+        "LogTextV",
+        "SetItemTooltipV",
+        "SetTooltipV",
+        "TextColoredV",
+        "TextDisabledV",
+        "TextV",
+        "TextWrappedV",
+        "TreeNodeExV",
+        "TreeNodeV"
+      ]
+    },
+    {
+      "classification": "intentional-sys-only",
+      "name": "legacy-columns",
+      "reason": "The obsolete Columns API is intentionally excluded in favor of tables.",
+      "functions": [
+        "Columns",
+        "GetColumnIndex",
+        "GetColumnOffset",
+        "GetColumnWidth",
+        "GetColumnsCount",
+        "NextColumn",
+        "SetColumnOffset",
+        "SetColumnWidth"
+      ]
+    },
+    {
+      "classification": "intentional-sys-only",
+      "name": "low-level-global-hooks",
+      "reason": "These APIs expose process-global allocators, ABI checks, or context-owned raw draw-list internals.",
+      "functions": [
+        "DebugCheckVersionAndDataLayout",
+        "GetAllocatorFunctions",
+        "GetDrawListSharedData",
+        "SetAllocatorFunctions"
+      ]
+    },
+    {
+      "classification": "intentional-sys-only",
+      "name": "internal-allocation",
+      "reason": "Raw ImGui allocation is used internally where ownership is immediately recovered; it is not a safe public allocator contract.",
+      "functions": [
+        "MemAlloc",
+        "MemFree"
+      ]
+    },
+    {
+      "classification": "deferred-design",
+      "name": "font-baked-lifetime",
+      "reason": "A safe ImFontBaked wrapper must tie atlas mutation, density, and context-owned lifetimes together.",
+      "functions": [
+        "GetFontBaked"
+      ]
+    }
+  ]
+}

--- a/tools/api_surface_report.py
+++ b/tools/api_surface_report.py
@@ -1,21 +1,15 @@
-"""
-API surface report for dear-imgui-rs.
+"""Audit cimgui's public API against dear-imgui-rs safe API decisions.
 
-This script compares the public ImGui API surface (as seen by cimgui generator
-metadata) against the high-level crate implementation in `dear-imgui/src`.
+The audit has two independent layers:
 
-It is meant to:
-- identify candidate TODOs for high-level wrappers;
-- reduce accidental duplicate wrappers by making coverage visible.
+* a reviewable snapshot of every public ``imgui:*`` generator declaration,
+  including methods and overload signatures from all namespaces;
+* semantic coverage decisions for top-level ``ImGui`` functions, backed by a
+  rustdoc alias on a public safe Rust item or an explicit policy rationale.
 
-Notes:
-- We classify `imgui_internal:*` entries as internal and exclude them from the
-  public surface report by default.
-- Coverage is considered present if either:
-  - `dear-imgui/src` references the corresponding `sys::ig*` symbol, OR
-  - `dear-imgui/src` contains `#[doc(alias = "...")]` for the ImGui function name.
-  This intentionally over-approximates “coverage” to reduce false positives from
-  wrapper indirection and alternate implementations.
+Generator drift is expected during an upstream update, but it must be reviewed
+and committed explicitly with ``--update-snapshot``. Input/schema failures use
+exit code 2, while expected audit drift uses exit code 1.
 """
 
 from __future__ import annotations
@@ -25,143 +19,925 @@ import json
 import pathlib
 import re
 import sys
+import tomllib
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Any, Iterable, Sequence
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
-DEFS_JSON = REPO_ROOT / "dear-imgui-sys" / "third-party" / "cimgui" / "generator" / "output" / "definitions.json"
+DEFS_JSON = (
+    REPO_ROOT
+    / "dear-imgui-sys"
+    / "third-party"
+    / "cimgui"
+    / "generator"
+    / "output"
+    / "definitions.json"
+)
 DEAR_IMGUI_SRC = REPO_ROOT / "dear-imgui" / "src"
+MANIFEST_TOML = REPO_ROOT / "dear-imgui-sys" / "Cargo.toml"
+POLICY_JSON = REPO_ROOT / "tools" / "api_surface_policy.json"
+SNAPSHOT_JSON = REPO_ROOT / "tools" / "api_surface_snapshot.json"
+
+POLICY_CLASSIFICATIONS = frozenset({"intentional-sys-only", "deferred-design"})
+POLICY_KEYS = frozenset({"schema_version", "scope", "groups"})
+POLICY_GROUP_KEYS = frozenset({"classification", "name", "reason", "functions"})
+SNAPSHOT_KEYS = frozenset({"schema_version", "source_revisions", "declarations"})
+REVISION_KEYS = frozenset({"cimgui", "imgui"})
+DECLARATION_KEYS = frozenset(
+    {
+        "symbol",
+        "cimgui_name",
+        "namespace",
+        "struct",
+        "function",
+        "c_arguments",
+        "signature",
+        "return_type",
+        "arguments",
+        "defaults",
+        "traits",
+    }
+)
+DECLARATION_TRAITS = (
+    "constructor",
+    "conv",
+    "destructor",
+    "is_static_function",
+    "isvararg",
+    "manual",
+    "nonUDT",
+    "realdestructor",
+    "retref",
+    "templated",
+)
+REVISION_RE = re.compile(r"[0-9a-f]{40}")
+
+
+class InputError(ValueError):
+    """A malformed or unreadable audit input."""
 
 
 @dataclass(frozen=True)
-class PublicFunc:
+class PublicDeclaration:
+    symbol: str
+    cimgui_name: str
+    namespace: str
+    struct_name: str
     funcname: str
-    ov_cimguiname: str
-    location: str  # e.g. "imgui:533"
+    c_arguments: str
+    signature: str
+    return_type: str
+    arguments: tuple[tuple[tuple[str, Any], ...], ...]
+    defaults: tuple[tuple[str, Any], ...]
+    traits: tuple[tuple[str, Any], ...]
 
-
-def _load_public_imgui_funcs(defs_path: pathlib.Path) -> list[PublicFunc]:
-    obj = json.loads(defs_path.read_text(encoding="utf-8", errors="ignore"))
-    out: list[PublicFunc] = []
-    for overloads in obj.values():
-        if not isinstance(overloads, list):
-            continue
-        for o in overloads:
-            if o.get("namespace") != "ImGui":
-                continue
-            loc = str(o.get("location") or "")
-            if loc.startswith("imgui_internal:"):
-                continue
-            func = o.get("funcname")
-            ov = o.get("ov_cimguiname") or o.get("cimguiname")
-            if not func or not ov:
-                continue
-            out.append(PublicFunc(funcname=str(func), ov_cimguiname=str(ov), location=loc))
-    return out
-
-
-def _iter_rs_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
-    yield from root.rglob("*.rs")
-
-
-def _collect_sys_usages(rs_files: Iterable[pathlib.Path]) -> set[str]:
-    used: set[str] = set()
-    pat = re.compile(r"\b(?:crate::)?sys::(ig[A-Za-z0-9_]+)\b")
-    for p in rs_files:
-        t = p.read_text(encoding="utf-8", errors="ignore")
-        used.update(pat.findall(t))
-    return used
-
-
-def _collect_doc_aliases(rs_files: Iterable[pathlib.Path]) -> set[str]:
-    aliases: set[str] = set()
-    pat = re.compile(r'alias\s*=\s*"([^"]+)"')
-    for p in rs_files:
-        t = p.read_text(encoding="utf-8", errors="ignore")
-        aliases.update(pat.findall(t))
-    return aliases
+    def snapshot_value(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "cimgui_name": self.cimgui_name,
+            "namespace": self.namespace,
+            "struct": self.struct_name,
+            "function": self.funcname,
+            "c_arguments": self.c_arguments,
+            "signature": self.signature,
+            "return_type": self.return_type,
+            "arguments": [dict(argument) for argument in self.arguments],
+            "defaults": dict(self.defaults),
+            "traits": dict(self.traits),
+        }
 
 
 @dataclass(frozen=True)
 class PublicFuncGroup:
     funcname: str
-    ov_cimguinames: tuple[str, ...]
-    location: str  # representative location
+    declarations: tuple[PublicDeclaration, ...]
+
+    @property
+    def symbols(self) -> tuple[str, ...]:
+        return tuple(declaration.symbol for declaration in self.declarations)
 
 
-def _group_by_funcname(funcs: list[PublicFunc]) -> dict[str, PublicFuncGroup]:
-    by: dict[str, list[PublicFunc]] = {}
-    for f in funcs:
-        by.setdefault(f.funcname, []).append(f)
-
-    out: dict[str, PublicFuncGroup] = {}
-    for funcname, items in by.items():
-        items_sorted = sorted(items, key=lambda x: (x.ov_cimguiname, x.location))
-        rep = items_sorted[0]
-        syms = tuple(sorted({x.ov_cimguiname for x in items_sorted}))
-        out[funcname] = PublicFuncGroup(funcname=funcname, ov_cimguinames=syms, location=rep.location)
-    return dict(sorted(out.items(), key=lambda kv: kv[0]))
+@dataclass(frozen=True)
+class PolicyDecision:
+    classification: str
+    group: str
+    reason: str
 
 
-def _print_table(rows: list[tuple[str, str, str]]) -> None:
-    # Minimal markdown table to paste into issues/PRs.
-    print("| ImGui func | sys symbol | location |")
-    print("|---|---|---|")
-    for func, ov, loc in rows:
-        print(f"| `{func}` | `{ov}` | `{loc}` |")
+@dataclass(frozen=True)
+class SurfaceAudit:
+    aliased: frozenset[str]
+    policy_decided: frozenset[str]
+    unexpected: frozenset[str]
+    stale_policy: frozenset[str]
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--format", choices=["md", "plain"], default="plain")
-    ap.add_argument("--limit", type=int, default=200)
-    args = ap.parse_args()
+@dataclass(frozen=True)
+class SnapshotDrift:
+    revision_mismatches: tuple[str, ...]
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+    changed: tuple[str, ...]
 
-    public_funcs = _load_public_imgui_funcs(DEFS_JSON)
-    groups = _group_by_funcname(public_funcs)
+    def has_drift(self) -> bool:
+        return bool(
+            self.revision_mismatches or self.added or self.removed or self.changed
+        )
 
-    rs_files = list(_iter_rs_files(DEAR_IMGUI_SRC))
-    used_sys = _collect_sys_usages(rs_files)
-    aliases = _collect_doc_aliases(rs_files)
 
-    uncovered: list[PublicFuncGroup] = []
-    for funcname, g in groups.items():
-        if funcname in aliases:
+@dataclass(frozen=True)
+class _RustToken:
+    kind: str
+    value: str
+    start: int
+    end: int
+
+
+def _read_json(path: pathlib.Path, description: str) -> Any:
+    try:
+        text = path.read_text(encoding="utf-8")
+        return json.loads(text)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise InputError(f"failed to read {description} {path}: {error}") from error
+
+
+def _exact_keys(value: dict[str, Any], expected: frozenset[str], context: str) -> None:
+    actual = frozenset(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        details: list[str] = []
+        if missing:
+            details.append(f"missing keys: {', '.join(missing)}")
+        if unknown:
+            details.append(f"unknown keys: {', '.join(unknown)}")
+        raise InputError(f"{context} has invalid keys ({'; '.join(details)})")
+
+
+def _require_string(value: Any, context: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        qualifier = "a string" if allow_empty else "a non-empty string"
+        raise InputError(f"{context} must be {qualifier}")
+    return value
+
+
+def _normalize_cpp(value: str) -> str:
+    value = re.sub(r"\s+", " ", value.strip())
+    return re.sub(r"\s*([(),\[\]<>*&])\s*", r"\1", value)
+
+
+def _canonical_value(value: Any, context: str) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _normalize_cpp(value)
+    if isinstance(value, list):
+        return [_canonical_value(item, f"{context}[]") for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise InputError(f"{context} contains a non-string object key")
+        return {
+            key: _canonical_value(value[key], f"{context}.{key}")
+            for key in sorted(value)
+        }
+    raise InputError(f"{context} contains unsupported JSON value {type(value).__name__}")
+
+
+def _load_public_declarations(path: pathlib.Path) -> list[PublicDeclaration]:
+    obj = _read_json(path, "cimgui definitions")
+    if not isinstance(obj, dict) or not obj:
+        raise InputError("cimgui definitions must be a non-empty object")
+
+    declarations: list[PublicDeclaration] = []
+    seen_symbols: set[str] = set()
+    for family, overloads in obj.items():
+        if not isinstance(family, str) or not isinstance(overloads, list):
+            raise InputError("cimgui definitions must map string names to overload arrays")
+        for index, record in enumerate(overloads):
+            context = f"cimgui definition {family}[{index}]"
+            if not isinstance(record, dict):
+                raise InputError(f"{context} must be an object")
+            location = _require_string(
+                record.get("location"), f"{context}.location", allow_empty=True
+            )
+            if not location.startswith("imgui:"):
+                continue
+
+            required = {
+                "args",
+                "argsT",
+                "cimguiname",
+                "defaults",
+                "location",
+                "ov_cimguiname",
+                "signature",
+                "stname",
+            }
+            missing = sorted(required - set(record))
+            if missing:
+                raise InputError(f"{context} is missing keys: {', '.join(missing)}")
+
+            symbol = _require_string(record["ov_cimguiname"], f"{context}.ov_cimguiname")
+            if symbol in seen_symbols:
+                raise InputError(f"duplicate public cimgui symbol {symbol!r}")
+            seen_symbols.add(symbol)
+
+            arguments_raw = record["argsT"]
+            if not isinstance(arguments_raw, list):
+                raise InputError(f"{context}.argsT must be an array")
+            arguments: list[tuple[tuple[str, Any], ...]] = []
+            for arg_index, argument in enumerate(arguments_raw):
+                if not isinstance(argument, dict) or not all(
+                    isinstance(key, str) for key in argument
+                ):
+                    raise InputError(f"{context}.argsT[{arg_index}] must be an object")
+                canonical = _canonical_value(argument, f"{context}.argsT[{arg_index}]")
+                arguments.append(tuple(canonical.items()))
+
+            defaults_raw = record["defaults"]
+            if not isinstance(defaults_raw, dict) or not all(
+                isinstance(key, str) for key in defaults_raw
+            ):
+                raise InputError(f"{context}.defaults must be an object")
+            defaults = _canonical_value(defaults_raw, f"{context}.defaults")
+            traits = {
+                key: _canonical_value(record[key], f"{context}.{key}")
+                for key in DECLARATION_TRAITS
+                if key in record
+            }
+
+            declarations.append(
+                PublicDeclaration(
+                    symbol=symbol,
+                    cimgui_name=_require_string(
+                        record["cimguiname"], f"{context}.cimguiname"
+                    ),
+                    namespace=_require_string(
+                        record.get("namespace", ""),
+                        f"{context}.namespace",
+                        allow_empty=True,
+                    ),
+                    struct_name=_require_string(
+                        record["stname"], f"{context}.stname", allow_empty=True
+                    ),
+                    funcname=_require_string(
+                        record.get("funcname", ""),
+                        f"{context}.funcname",
+                        allow_empty=True,
+                    ),
+                    c_arguments=_normalize_cpp(
+                        _require_string(record["args"], f"{context}.args")
+                    ),
+                    signature=_normalize_cpp(
+                        _require_string(record["signature"], f"{context}.signature")
+                    ),
+                    return_type=_normalize_cpp(
+                        _require_string(
+                            record.get("ret", ""),
+                            f"{context}.ret",
+                            allow_empty=True,
+                        )
+                    ),
+                    arguments=tuple(arguments),
+                    defaults=tuple(defaults.items()),
+                    traits=tuple(sorted(traits.items())),
+                )
+            )
+
+    if not declarations:
+        raise InputError("cimgui definitions contain no public imgui declarations")
+    return sorted(declarations, key=lambda declaration: declaration.symbol)
+
+
+def _load_source_revisions(path: pathlib.Path) -> dict[str, str]:
+    try:
+        with path.open("rb") as manifest_file:
+            manifest = tomllib.load(manifest_file)
+        metadata = manifest["package"]["metadata"]["dear-imgui-sources"]
+        revisions = {
+            "cimgui": metadata["cimgui-revision"],
+            "imgui": metadata["imgui-revision"],
+        }
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, KeyError, TypeError) as error:
+        raise InputError(f"failed to read source revisions from {path}: {error}") from error
+
+    for name, revision in revisions.items():
+        if not isinstance(revision, str) or REVISION_RE.fullmatch(revision) is None:
+            raise InputError(f"{path} has invalid {name} revision {revision!r}")
+    return revisions
+
+
+def _snapshot_document(
+    declarations: Sequence[PublicDeclaration], revisions: dict[str, str]
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "source_revisions": revisions,
+        "declarations": [declaration.snapshot_value() for declaration in declarations],
+    }
+
+
+def _write_snapshot(
+    path: pathlib.Path,
+    declarations: Sequence[PublicDeclaration],
+    revisions: dict[str, str],
+) -> None:
+    document = _snapshot_document(declarations, revisions)
+    path.write_text(
+        json.dumps(document, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _load_snapshot(path: pathlib.Path) -> tuple[dict[str, str], list[dict[str, Any]]]:
+    obj = _read_json(path, "API surface snapshot")
+    if not isinstance(obj, dict):
+        raise InputError("API surface snapshot must be an object")
+    _exact_keys(obj, SNAPSHOT_KEYS, "API surface snapshot")
+    if isinstance(obj["schema_version"], bool) or obj["schema_version"] != 1:
+        raise InputError("API surface snapshot must use integer schema_version 1")
+
+    revisions = obj["source_revisions"]
+    if not isinstance(revisions, dict):
+        raise InputError("API surface snapshot source_revisions must be an object")
+    _exact_keys(revisions, REVISION_KEYS, "API surface snapshot source_revisions")
+    for name, revision in revisions.items():
+        if not isinstance(revision, str) or REVISION_RE.fullmatch(revision) is None:
+            raise InputError(f"API surface snapshot has invalid {name} revision")
+
+    values = obj["declarations"]
+    if not isinstance(values, list) or not values:
+        raise InputError("API surface snapshot declarations must be a non-empty array")
+    declarations: list[dict[str, Any]] = []
+    seen_symbols: set[str] = set()
+    for index, value in enumerate(values):
+        if not isinstance(value, dict):
+            raise InputError(f"API surface snapshot declaration {index} must be an object")
+        _exact_keys(value, DECLARATION_KEYS, f"API surface snapshot declaration {index}")
+        symbol = _require_string(value["symbol"], f"snapshot declaration {index}.symbol")
+        if symbol in seen_symbols:
+            raise InputError(f"API surface snapshot repeats symbol {symbol!r}")
+        seen_symbols.add(symbol)
+        for key in (
+            "cimgui_name",
+            "namespace",
+            "struct",
+            "function",
+            "c_arguments",
+            "signature",
+            "return_type",
+        ):
+            _require_string(
+                value[key],
+                f"snapshot declaration {index}.{key}",
+                allow_empty=key not in {"cimgui_name", "c_arguments", "signature"},
+            )
+        if not isinstance(value["arguments"], list) or not all(
+            isinstance(argument, dict) for argument in value["arguments"]
+        ):
+            raise InputError(
+                f"snapshot declaration {index}.arguments must be an array of objects"
+            )
+        if not isinstance(value["defaults"], dict) or not isinstance(value["traits"], dict):
+            raise InputError(
+                f"snapshot declaration {index}.defaults and traits must be objects"
+            )
+        _canonical_value(value["arguments"], f"snapshot declaration {index}.arguments")
+        _canonical_value(value["defaults"], f"snapshot declaration {index}.defaults")
+        _canonical_value(value["traits"], f"snapshot declaration {index}.traits")
+        declarations.append(value)
+    return dict(revisions), declarations
+
+
+def _compare_snapshot(
+    actual: Sequence[PublicDeclaration],
+    actual_revisions: dict[str, str],
+    expected_values: Sequence[dict[str, Any]],
+    expected_revisions: dict[str, str],
+) -> SnapshotDrift:
+    actual_by_symbol = {
+        declaration.symbol: declaration.snapshot_value() for declaration in actual
+    }
+    expected_by_symbol = {value["symbol"]: value for value in expected_values}
+    actual_symbols = set(actual_by_symbol)
+    expected_symbols = set(expected_by_symbol)
+    revision_mismatches = tuple(
+        f"{name}: audited={expected_revisions[name]} current={actual_revisions[name]}"
+        for name in sorted(REVISION_KEYS)
+        if expected_revisions[name] != actual_revisions[name]
+    )
+    return SnapshotDrift(
+        revision_mismatches=revision_mismatches,
+        added=tuple(sorted(actual_symbols - expected_symbols)),
+        removed=tuple(sorted(expected_symbols - actual_symbols)),
+        changed=tuple(
+            symbol
+            for symbol in sorted(actual_symbols & expected_symbols)
+            if actual_by_symbol[symbol] != expected_by_symbol[symbol]
+        ),
+    )
+
+
+def _iter_rs_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
+    yield from sorted(root.rglob("*.rs"))
+
+
+def _consume_quoted(source: str, start: int, quote: str) -> int:
+    index = start + 1
+    while index < len(source):
+        if source[index] == "\\":
+            index += 2
             continue
-        if set(g.ov_cimguinames) & used_sys:
+        if source[index] == quote:
+            return index + 1
+        index += 1
+    return len(source)
+
+
+def _raw_string_end(source: str, start: int) -> int | None:
+    index = start
+    if source.startswith("br", index) or source.startswith("rb", index):
+        index += 2
+    elif source.startswith("r", index):
+        index += 1
+    else:
+        return None
+    hashes = 0
+    while index < len(source) and source[index] == "#":
+        hashes += 1
+        index += 1
+    if index >= len(source) or source[index] != '"':
+        return None
+    terminator = '"' + ("#" * hashes)
+    end = source.find(terminator, index + 1)
+    return len(source) if end < 0 else end + len(terminator)
+
+
+def _decode_rust_string(literal: str) -> str:
+    prefix_len = 1 if literal.startswith("b\"") else 0
+    raw_start = prefix_len
+    if literal.startswith(("r", "br", "rb")):
+        marker = literal.find('"')
+        hashes = marker - raw_start - 1
+        if literal.startswith(("br", "rb")):
+            hashes -= 1
+        terminator_len = hashes + 1
+        return literal[marker + 1 : -terminator_len]
+    quoted = literal[prefix_len:]
+    quoted = re.sub(r"\\\r?\n[ \t]*", "", quoted)
+    try:
+        return json.loads(quoted)
+    except json.JSONDecodeError:
+        # Token boundaries are what matter for source reachability. Rust has a
+        # few escapes (for example ``\u{...}``) that JSON does not understand;
+        # doc aliases in this crate use ordinary quoted or raw strings.
+        return quoted[1:-1]
+
+
+def _tokenize_rust(source: str) -> list[_RustToken]:
+    tokens: list[_RustToken] = []
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char.isspace():
+            index += 1
             continue
-        uncovered.append(g)
+        if source.startswith("//", index):
+            newline = source.find("\n", index + 2)
+            index = len(source) if newline < 0 else newline + 1
+            continue
+        if source.startswith("/*", index):
+            depth = 1
+            cursor = index + 2
+            while cursor < len(source) and depth:
+                if source.startswith("/*", cursor):
+                    depth += 1
+                    cursor += 2
+                elif source.startswith("*/", cursor):
+                    depth -= 1
+                    cursor += 2
+                else:
+                    cursor += 1
+            index = cursor
+            continue
 
-    uncovered = uncovered[: max(0, args.limit)]
+        raw_end = _raw_string_end(source, index)
+        if raw_end is not None:
+            literal = source[index:raw_end]
+            tokens.append(_RustToken("string", _decode_rust_string(literal), index, raw_end))
+            index = raw_end
+            continue
+        if char == '"' or (char == "b" and index + 1 < len(source) and source[index + 1] == '"'):
+            quote_start = index + 1 if char == "b" else index
+            end = _consume_quoted(source, quote_start, '"')
+            literal = source[index:end]
+            tokens.append(_RustToken("string", _decode_rust_string(literal), index, end))
+            index = end
+            continue
+        if char == "'" and index + 2 < len(source):
+            is_simple_char = source[index + 2] == "'"
+            is_escaped_char = source[index + 1] == "\\"
+            if is_simple_char or is_escaped_char:
+                end = _consume_quoted(source, index, "'")
+                tokens.append(_RustToken("char", "", index, end))
+                index = end
+                continue
+        if char.isalpha() or char == "_":
+            end = index + 1
+            while end < len(source) and (source[end].isalnum() or source[end] == "_"):
+                end += 1
+            tokens.append(_RustToken("ident", source[index:end], index, end))
+            index = end
+            continue
+        tokens.append(_RustToken("punct", char, index, index + 1))
+        index += 1
+    return tokens
 
-    if args.format == "md":
-        rows: list[tuple[str, str, str]] = []
-        for g in uncovered:
-            sys_sym = g.ov_cimguinames[0] if g.ov_cimguinames else "?"
-            if len(g.ov_cimguinames) > 1:
-                sys_sym = f"{sys_sym} (+{len(g.ov_cimguinames)-1})"
-            rows.append((g.funcname, sys_sym, g.location))
-        _print_table(rows)
+
+def _matching_braces(tokens: Sequence[_RustToken]) -> dict[int, int]:
+    stack: list[int] = []
+    matches: dict[int, int] = {}
+    for index, token in enumerate(tokens):
+        if token.value == "{":
+            stack.append(index)
+        elif token.value == "}" and stack:
+            opening = stack.pop()
+            matches[opening] = index
+    return matches
+
+
+def _attribute_end(tokens: Sequence[_RustToken], start: int) -> int | None:
+    if start + 1 >= len(tokens) or tokens[start].value != "#" or tokens[start + 1].value != "[":
+        return None
+    depth = 1
+    index = start + 2
+    while index < len(tokens):
+        if tokens[index].value == "[":
+            depth += 1
+        elif tokens[index].value == "]":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    return None
+
+
+def _is_cfg_test(attribute: Sequence[_RustToken]) -> bool:
+    values = [token.value for token in attribute]
+    return values == ["cfg", "(", "test", ")"]
+
+
+def _is_doc_hidden(attribute: Sequence[_RustToken]) -> bool:
+    values = [token.value for token in attribute]
+    return values == ["doc", "(", "hidden", ")"]
+
+
+def _doc_aliases(attribute: Sequence[_RustToken]) -> set[str]:
+    if not attribute or attribute[0].value != "doc":
+        return set()
+    aliases: set[str] = set()
+    for index in range(1, len(attribute) - 2):
+        if (
+            attribute[index].value == "alias"
+            and attribute[index + 1].value == "="
+            and attribute[index + 2].kind == "string"
+        ):
+            aliases.add(attribute[index + 2].value)
+    return aliases
+
+
+def _private_module_ranges(tokens: Sequence[_RustToken]) -> list[tuple[int, int]]:
+    brace_matches = _matching_braces(tokens)
+    ranges: list[tuple[int, int]] = []
+    for index, token in enumerate(tokens):
+        if token.value != "mod":
+            continue
+        cursor = index + 1
+        while cursor < len(tokens) and tokens[cursor].value not in {"{", ";"}:
+            cursor += 1
+        if cursor >= len(tokens) or tokens[cursor].value != "{" or cursor not in brace_matches:
+            continue
+
+        header_start = index - 1
+        while header_start >= 0 and tokens[header_start].value not in {";", "{", "}"}:
+            header_start -= 1
+        header = tokens[header_start + 1 : index]
+        public = any(
+            header[pos].value == "pub"
+            and (pos + 1 >= len(header) or header[pos + 1].value != "(")
+            for pos in range(len(header))
+        )
+        cfg_test = False
+        attr_index = 0
+        while attr_index < len(header):
+            end = _attribute_end(header, attr_index)
+            if end is None:
+                attr_index += 1
+                continue
+            cfg_test |= _is_cfg_test(header[attr_index + 2 : end - 1])
+            attr_index = end
+        if not public or cfg_test:
+            ranges.append((tokens[cursor].start, tokens[brace_matches[cursor]].end))
+    return ranges
+
+
+def _inside_ranges(offset: int, ranges: Sequence[tuple[int, int]]) -> bool:
+    return any(start <= offset < end for start, end in ranges)
+
+
+def _collect_doc_aliases(rs_files: Iterable[pathlib.Path]) -> set[str]:
+    aliases: set[str] = set()
+    item_keywords = {"const", "enum", "fn", "macro", "mod", "static", "struct", "trait", "type", "union", "use"}
+    for path in rs_files:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            raise InputError(f"failed to read Rust source {path}: {error}") from error
+        tokens = _tokenize_rust(source)
+        private_ranges = _private_module_ranges(tokens)
+        index = 0
+        while index < len(tokens):
+            first_end = _attribute_end(tokens, index)
+            if first_end is None:
+                index += 1
+                continue
+
+            candidate_aliases: set[str] = set()
+            cfg_test = False
+            hidden = False
+            cursor = index
+            while True:
+                end = _attribute_end(tokens, cursor)
+                if end is None:
+                    break
+                attribute = tokens[cursor + 2 : end - 1]
+                candidate_aliases.update(_doc_aliases(attribute))
+                cfg_test |= _is_cfg_test(attribute)
+                hidden |= _is_doc_hidden(attribute)
+                cursor = end
+
+            if not candidate_aliases:
+                index = first_end
+                continue
+            if cfg_test or hidden or _inside_ranges(tokens[index].start, private_ranges):
+                index = cursor
+                continue
+            if cursor >= len(tokens) or tokens[cursor].value != "pub":
+                index = cursor
+                continue
+            cursor += 1
+            if cursor < len(tokens) and tokens[cursor].value == "(":
+                index = cursor
+                continue
+
+            modifiers: set[str] = set()
+            while cursor < len(tokens) and tokens[cursor].value not in item_keywords:
+                modifiers.add(tokens[cursor].value)
+                cursor += 1
+            if (
+                cursor < len(tokens)
+                and tokens[cursor].value in item_keywords
+                and "unsafe" not in modifiers
+            ):
+                aliases.update(candidate_aliases)
+            index = cursor + 1
+    return aliases
+
+
+def _collect_sys_usages(rs_files: Iterable[pathlib.Path]) -> set[str]:
+    used: set[str] = set()
+    pattern = re.compile(r"\b(?:crate::)?sys::(ig[A-Za-z0-9_]+)\b")
+    for path in rs_files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            raise InputError(f"failed to read Rust source {path}: {error}") from error
+        used.update(pattern.findall(text))
+    return used
+
+
+def _group_top_level_imgui(
+    declarations: Sequence[PublicDeclaration],
+) -> dict[str, PublicFuncGroup]:
+    grouped: dict[str, list[PublicDeclaration]] = {}
+    for declaration in declarations:
+        if declaration.namespace == "ImGui" and declaration.funcname:
+            grouped.setdefault(declaration.funcname, []).append(declaration)
+    return {
+        funcname: PublicFuncGroup(
+            funcname,
+            tuple(sorted(values, key=lambda declaration: declaration.symbol)),
+        )
+        for funcname, values in sorted(grouped.items())
+    }
+
+
+def _load_policy(path: pathlib.Path) -> dict[str, PolicyDecision]:
+    obj = _read_json(path, "API surface policy")
+    if not isinstance(obj, dict):
+        raise InputError("API surface policy must be an object")
+    _exact_keys(obj, POLICY_KEYS, "API surface policy")
+    if isinstance(obj["schema_version"], bool) or obj["schema_version"] != 2:
+        raise InputError("API surface policy must use integer schema_version 2")
+    if obj["scope"] != "ImGui":
+        raise InputError("API surface policy scope must be 'ImGui'")
+    groups = obj["groups"]
+    if not isinstance(groups, list):
+        raise InputError("API surface policy groups must be an array")
+
+    decisions: dict[str, PolicyDecision] = {}
+    group_names: set[str] = set()
+    for index, group in enumerate(groups):
+        context = f"API surface policy group {index}"
+        if not isinstance(group, dict):
+            raise InputError(f"{context} must be an object")
+        _exact_keys(group, POLICY_GROUP_KEYS, context)
+        classification = _require_string(group["classification"], f"{context}.classification")
+        name = _require_string(group["name"], f"{context}.name")
+        reason = _require_string(group["reason"], f"{context}.reason")
+        if classification not in POLICY_CLASSIFICATIONS:
+            expected = ", ".join(sorted(POLICY_CLASSIFICATIONS))
+            raise InputError(
+                f"{context} has classification {classification!r}; expected one of: {expected}"
+            )
+        if name in group_names:
+            raise InputError(f"API surface policy repeats group name {name!r}")
+        group_names.add(name)
+        functions = group["functions"]
+        if not isinstance(functions, list) or not functions:
+            raise InputError(f"{context}.functions must be a non-empty array")
+        if not all(isinstance(function, str) and function for function in functions):
+            raise InputError(f"{context}.functions must contain non-empty strings")
+        if len(functions) != len(set(functions)):
+            raise InputError(f"{context}.functions contains duplicates")
+        for function in functions:
+            if function in decisions:
+                previous = decisions[function]
+                raise InputError(
+                    f"API surface policy lists {function!r} in both "
+                    f"{previous.group!r} and {name!r}"
+                )
+            decisions[function] = PolicyDecision(classification, name, reason)
+    return decisions
+
+
+def _audit_surface(
+    groups: dict[str, PublicFuncGroup],
+    aliases: set[str],
+    policy: dict[str, PolicyDecision],
+) -> SurfaceAudit:
+    public = set(groups)
+    aliased = public & aliases
+    unaliased = public - aliased
+    policy_names = set(policy)
+    return SurfaceAudit(
+        aliased=frozenset(aliased),
+        policy_decided=frozenset(unaliased & policy_names),
+        unexpected=frozenset(unaliased - policy_names),
+        stale_policy=frozenset(policy_names - unaliased),
+    )
+
+
+def _sys_symbol(group: PublicFuncGroup) -> str:
+    symbol = group.symbols[0] if group.symbols else "?"
+    if len(group.symbols) > 1:
+        symbol = f"{symbol} (+{len(group.symbols) - 1})"
+    return symbol
+
+
+def _print_table(rows: list[tuple[PublicFuncGroup, PolicyDecision | None]]) -> None:
+    print("| ImGui func | sys symbol | classification | policy group |")
+    print("|---|---|---|---|")
+    for group, decision in rows:
+        classification = decision.classification if decision else "unexpected"
+        policy_group = decision.group if decision else "-"
+        print(
+            f"| `{group.funcname}` | `{_sys_symbol(group)}` | `{classification}` | "
+            f"`{policy_group}` |"
+        )
+
+
+def _print_snapshot_drift(drift: SnapshotDrift) -> None:
+    if drift.revision_mismatches:
+        print("API surface snapshot source revision drift:", file=sys.stderr)
+        for mismatch in drift.revision_mismatches:
+            print(f"- {mismatch}", file=sys.stderr)
+    for label, symbols in (
+        ("added", drift.added),
+        ("removed", drift.removed),
+        ("changed", drift.changed),
+    ):
+        if symbols:
+            print(f"API surface snapshot {label} declarations:", file=sys.stderr)
+            for symbol in symbols:
+                print(f"- {symbol}", file=sys.stderr)
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--format", choices=["md", "plain"], default="plain")
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--definitions", type=pathlib.Path, default=DEFS_JSON)
+    parser.add_argument("--rust-source", type=pathlib.Path, default=DEAR_IMGUI_SRC)
+    parser.add_argument("--manifest", type=pathlib.Path, default=MANIFEST_TOML)
+    parser.add_argument("--policy", type=pathlib.Path, default=POLICY_JSON)
+    parser.add_argument("--snapshot", type=pathlib.Path, default=SNAPSHOT_JSON)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail on generator drift or an unreviewed top-level ImGui function",
+    )
+    parser.add_argument(
+        "--update-snapshot",
+        action="store_true",
+        help="write the current reviewed generator surface and source revisions",
+    )
+    args = parser.parse_args(argv)
+    if args.check and args.update_snapshot:
+        parser.error("--check and --update-snapshot cannot be used together")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        declarations = _load_public_declarations(args.definitions)
+        revisions = _load_source_revisions(args.manifest)
+        if args.update_snapshot:
+            _write_snapshot(args.snapshot, declarations, revisions)
+            print(
+                f"Updated {args.snapshot} with {len(declarations)} public declarations."
+            )
+            return 0
+
+        expected_revisions, expected_declarations = _load_snapshot(args.snapshot)
+        drift = _compare_snapshot(
+            declarations,
+            revisions,
+            expected_declarations,
+            expected_revisions,
+        )
+        groups = _group_top_level_imgui(declarations)
+        rs_files = list(_iter_rs_files(args.rust_source))
+        aliases = _collect_doc_aliases(rs_files)
+        policy = _load_policy(args.policy)
+        audit = _audit_surface(groups, aliases, policy)
+    except InputError as error:
+        print(f"API surface input error: {error}", file=sys.stderr)
+        return 2
+
+    unaliased = [groups[name] for name in sorted(set(groups) - set(audit.aliased))]
+    shown = unaliased[: max(0, args.limit)]
+
+    if args.check:
+        print(f"Public generator declarations (all namespaces): {len(declarations)}")
+        print(f"Top-level ImGui funcnames: {len(groups)}")
+        print(f"Covered via public safe rustdoc aliases: {len(audit.aliased)}")
+        print(f"Classified via explicit policy: {len(audit.policy_decided)}")
+        if drift.has_drift():
+            _print_snapshot_drift(drift)
+        if audit.unexpected:
+            print("Unexpected missing safe API decisions:", file=sys.stderr)
+            for name in sorted(audit.unexpected):
+                print(f"- {name}", file=sys.stderr)
+        if audit.stale_policy:
+            print("Stale API surface policy entries:", file=sys.stderr)
+            for name in sorted(audit.stale_policy):
+                print(f"- {name}", file=sys.stderr)
+        if drift.has_drift() or audit.unexpected or audit.stale_policy:
+            return 1
+        print("API surface policy and generator snapshot checks passed.")
         return 0
 
-    covered_by_alias = len(set(groups) & aliases)
-    covered_by_sys = 0
-    for g in groups.values():
-        if set(g.ov_cimguinames) & used_sys:
-            covered_by_sys += 1
+    if args.format == "md":
+        _print_table([(group, policy.get(group.funcname)) for group in shown])
+        return 0
 
+    used_sys = _collect_sys_usages(rs_files)
+    covered_by_sys = sum(
+        bool(set(group.symbols) & used_sys) for group in groups.values()
+    )
     print(f"Repo root: {REPO_ROOT}")
-    print(f"Public ImGui funcnames: {len(groups)}")
-    print(f"Covered via doc aliases: {covered_by_alias}")
-    print(f"Covered via sys usage (any overload): {covered_by_sys}")
-    print(f"Uncovered (representative): {len(uncovered)} (limited to {args.limit})")
-    for g in uncovered:
-        sys_sym = g.ov_cimguinames[0] if g.ov_cimguinames else "?"
-        extra = ""
-        if len(g.ov_cimguinames) > 1:
-            extra = f" (+{len(g.ov_cimguinames)-1})"
-        print(f"- {g.funcname}  sys={sys_sym}{extra}  loc={g.location}")
+    print(f"Public generator declarations (all namespaces): {len(declarations)}")
+    print(f"Top-level ImGui funcnames: {len(groups)}")
+    print(f"Covered via public safe rustdoc aliases: {len(audit.aliased)}")
+    print(f"Classified via explicit policy: {len(audit.policy_decided)}")
+    print(f"Referenced via sys usage (informational): {covered_by_sys}")
+    print(f"Generator snapshot drift: {drift.has_drift()}")
+    print(f"Unexpected missing decisions: {len(audit.unexpected)}")
+    print(f"Stale policy entries: {len(audit.stale_policy)}")
+    print(f"Unaliased policy report: {len(unaliased)} (showing at most {args.limit})")
+    for group in shown:
+        decision = policy.get(group.funcname)
+        disposition = (
+            "unexpected"
+            if decision is None
+            else f"{decision.classification}/{decision.group}"
+        )
+        print(
+            f"- {group.funcname}  sys={_sys_symbol(group)}  policy={disposition}"
+        )
     return 0
 
 

--- a/tools/api_surface_snapshot.json
+++ b/tools/api_surface_snapshot.json
@@ -1,0 +1,17453 @@
+{
+  "schema_version": 1,
+  "source_revisions": {
+    "cimgui": "1261b231939fc210032f30c4ee8a8f0440372237",
+    "imgui": "b61e56346a92cfcaf1f43a545ca37b0b32239654"
+  },
+  "declarations": [
+    {
+      "symbol": "ImColor_HSV",
+      "cimgui_name": "ImColor_HSV",
+      "namespace": "ImColor",
+      "struct": "ImColor",
+      "function": "HSV",
+      "c_arguments": "(float h,float s,float v,float a)",
+      "signature": "(float,float,float,float)",
+      "return_type": "ImColor_c",
+      "arguments": [
+        {
+          "name": "h",
+          "type": "float"
+        },
+        {
+          "name": "s",
+          "type": "float"
+        },
+        {
+          "name": "v",
+          "type": "float"
+        },
+        {
+          "name": "a",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "a": "1.0f"
+      },
+      "traits": {
+        "conv": "ImColor",
+        "is_static_function": true,
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "ImColor_ImColor_Float",
+      "cimgui_name": "ImColor_ImColor",
+      "namespace": "ImColor",
+      "struct": "ImColor",
+      "function": "ImColor",
+      "c_arguments": "(float r,float g,float b,float a)",
+      "signature": "(float,float,float,float)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "r",
+          "type": "float"
+        },
+        {
+          "name": "g",
+          "type": "float"
+        },
+        {
+          "name": "b",
+          "type": "float"
+        },
+        {
+          "name": "a",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "a": "1.0f"
+      },
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImColor_ImColor_Int",
+      "cimgui_name": "ImColor_ImColor",
+      "namespace": "ImColor",
+      "struct": "ImColor",
+      "function": "ImColor",
+      "c_arguments": "(int r,int g,int b,int a)",
+      "signature": "(int,int,int,int)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "r",
+          "type": "int"
+        },
+        {
+          "name": "g",
+          "type": "int"
+        },
+        {
+          "name": "b",
+          "type": "int"
+        },
+        {
+          "name": "a",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "a": "255"
+      },
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImColor_ImColor_Nil",
+      "cimgui_name": "ImColor_ImColor",
+      "namespace": "ImColor",
+      "struct": "ImColor",
+      "function": "ImColor",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImColor_ImColor_U32",
+      "cimgui_name": "ImColor_ImColor",
+      "namespace": "ImColor",
+      "struct": "ImColor",
+      "function": "ImColor",
+      "c_arguments": "(ImU32 rgba)",
+      "signature": "(ImU32)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "rgba",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImColor_ImColor_Vec4",
+      "cimgui_name": "ImColor_ImColor",
+      "namespace": "ImColor",
+      "struct": "ImColor",
+      "function": "ImColor",
+      "c_arguments": "(const ImVec4_c col)",
+      "signature": "(const ImVec4)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "col",
+          "type": "const ImVec4"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImColor_SetHSV",
+      "cimgui_name": "ImColor_SetHSV",
+      "namespace": "ImColor",
+      "struct": "ImColor",
+      "function": "SetHSV",
+      "c_arguments": "(ImColor*self,float h,float s,float v,float a)",
+      "signature": "(float,float,float,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImColor*"
+        },
+        {
+          "name": "h",
+          "type": "float"
+        },
+        {
+          "name": "s",
+          "type": "float"
+        },
+        {
+          "name": "v",
+          "type": "float"
+        },
+        {
+          "name": "a",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "a": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImColor_destroy",
+      "cimgui_name": "ImColor_destroy",
+      "namespace": "",
+      "struct": "ImColor",
+      "function": "",
+      "c_arguments": "(ImColor*self)",
+      "signature": "(ImColor*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImColor*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawCmd_GetTexID",
+      "cimgui_name": "ImDrawCmd_GetTexID",
+      "namespace": "ImDrawCmd",
+      "struct": "ImDrawCmd",
+      "function": "GetTexID",
+      "c_arguments": "(ImDrawCmd*self)",
+      "signature": "()const",
+      "return_type": "ImTextureID",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawCmd*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawCmd_ImDrawCmd",
+      "cimgui_name": "ImDrawCmd_ImDrawCmd",
+      "namespace": "ImDrawCmd",
+      "struct": "ImDrawCmd",
+      "function": "ImDrawCmd",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawCmd_destroy",
+      "cimgui_name": "ImDrawCmd_destroy",
+      "namespace": "",
+      "struct": "ImDrawCmd",
+      "function": "",
+      "c_arguments": "(ImDrawCmd*self)",
+      "signature": "(ImDrawCmd*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawCmd*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawData_AddDrawList",
+      "cimgui_name": "ImDrawData_AddDrawList",
+      "namespace": "ImDrawData",
+      "struct": "ImDrawData",
+      "function": "AddDrawList",
+      "c_arguments": "(ImDrawData*self,ImDrawList*draw_list)",
+      "signature": "(ImDrawList*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawData*"
+        },
+        {
+          "name": "draw_list",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawData_Clear",
+      "cimgui_name": "ImDrawData_Clear",
+      "namespace": "ImDrawData",
+      "struct": "ImDrawData",
+      "function": "Clear",
+      "c_arguments": "(ImDrawData*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawData_DeIndexAllBuffers",
+      "cimgui_name": "ImDrawData_DeIndexAllBuffers",
+      "namespace": "ImDrawData",
+      "struct": "ImDrawData",
+      "function": "DeIndexAllBuffers",
+      "c_arguments": "(ImDrawData*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawData_ImDrawData",
+      "cimgui_name": "ImDrawData_ImDrawData",
+      "namespace": "ImDrawData",
+      "struct": "ImDrawData",
+      "function": "ImDrawData",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawData_ScaleClipRects",
+      "cimgui_name": "ImDrawData_ScaleClipRects",
+      "namespace": "ImDrawData",
+      "struct": "ImDrawData",
+      "function": "ScaleClipRects",
+      "c_arguments": "(ImDrawData*self,const ImVec2_c fb_scale)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawData*"
+        },
+        {
+          "name": "fb_scale",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawData_destroy",
+      "cimgui_name": "ImDrawData_destroy",
+      "namespace": "",
+      "struct": "ImDrawData",
+      "function": "",
+      "c_arguments": "(ImDrawData*self)",
+      "signature": "(ImDrawData*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawListSplitter_Clear",
+      "cimgui_name": "ImDrawListSplitter_Clear",
+      "namespace": "ImDrawListSplitter",
+      "struct": "ImDrawListSplitter",
+      "function": "Clear",
+      "c_arguments": "(ImDrawListSplitter*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawListSplitter*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawListSplitter_ClearFreeMemory",
+      "cimgui_name": "ImDrawListSplitter_ClearFreeMemory",
+      "namespace": "ImDrawListSplitter",
+      "struct": "ImDrawListSplitter",
+      "function": "ClearFreeMemory",
+      "c_arguments": "(ImDrawListSplitter*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawListSplitter*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawListSplitter_ImDrawListSplitter",
+      "cimgui_name": "ImDrawListSplitter_ImDrawListSplitter",
+      "namespace": "ImDrawListSplitter",
+      "struct": "ImDrawListSplitter",
+      "function": "ImDrawListSplitter",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawListSplitter_Merge",
+      "cimgui_name": "ImDrawListSplitter_Merge",
+      "namespace": "ImDrawListSplitter",
+      "struct": "ImDrawListSplitter",
+      "function": "Merge",
+      "c_arguments": "(ImDrawListSplitter*self,ImDrawList*draw_list)",
+      "signature": "(ImDrawList*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawListSplitter*"
+        },
+        {
+          "name": "draw_list",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawListSplitter_SetCurrentChannel",
+      "cimgui_name": "ImDrawListSplitter_SetCurrentChannel",
+      "namespace": "ImDrawListSplitter",
+      "struct": "ImDrawListSplitter",
+      "function": "SetCurrentChannel",
+      "c_arguments": "(ImDrawListSplitter*self,ImDrawList*draw_list,int channel_idx)",
+      "signature": "(ImDrawList*,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawListSplitter*"
+        },
+        {
+          "name": "draw_list",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "channel_idx",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawListSplitter_Split",
+      "cimgui_name": "ImDrawListSplitter_Split",
+      "namespace": "ImDrawListSplitter",
+      "struct": "ImDrawListSplitter",
+      "function": "Split",
+      "c_arguments": "(ImDrawListSplitter*self,ImDrawList*draw_list,int count)",
+      "signature": "(ImDrawList*,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawListSplitter*"
+        },
+        {
+          "name": "draw_list",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "count",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawListSplitter_destroy",
+      "cimgui_name": "ImDrawListSplitter_destroy",
+      "namespace": "",
+      "struct": "ImDrawListSplitter",
+      "function": "",
+      "c_arguments": "(ImDrawListSplitter*self)",
+      "signature": "(ImDrawListSplitter*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawListSplitter*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawList_AddBezierCubic",
+      "cimgui_name": "ImDrawList_AddBezierCubic",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddBezierCubic",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p1,const ImVec2_c p2,const ImVec2_c p3,const ImVec2_c p4,ImU32 col,float thickness,int num_segments)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32,float,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p4",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddBezierQuadratic",
+      "cimgui_name": "ImDrawList_AddBezierQuadratic",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddBezierQuadratic",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p1,const ImVec2_c p2,const ImVec2_c p3,ImU32 col,float thickness,int num_segments)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,ImU32,float,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddCallback",
+      "cimgui_name": "ImDrawList_AddCallback",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddCallback",
+      "c_arguments": "(ImDrawList*self,ImDrawCallback callback,void*userdata,size_t userdata_size)",
+      "signature": "(ImDrawCallback,void*,size_t)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "callback",
+          "type": "ImDrawCallback"
+        },
+        {
+          "name": "userdata",
+          "type": "void*"
+        },
+        {
+          "name": "userdata_size",
+          "type": "size_t"
+        }
+      ],
+      "defaults": {
+        "userdata": "NULL",
+        "userdata_size": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddCircle",
+      "cimgui_name": "ImDrawList_AddCircle",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddCircle",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,ImU32 col,int num_segments,float thickness)",
+      "signature": "(const ImVec2,float,ImU32,int,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0",
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddCircleFilled",
+      "cimgui_name": "ImDrawList_AddCircleFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddCircleFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,ImU32 col,int num_segments)",
+      "signature": "(const ImVec2,float,ImU32,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddConcavePolyFilled",
+      "cimgui_name": "ImDrawList_AddConcavePolyFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddConcavePolyFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c*points,int num_points,ImU32 col)",
+      "signature": "(const ImVec2*,int,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "points",
+          "type": "const ImVec2*"
+        },
+        {
+          "name": "num_points",
+          "type": "int"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddConvexPolyFilled",
+      "cimgui_name": "ImDrawList_AddConvexPolyFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddConvexPolyFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c*points,int num_points,ImU32 col)",
+      "signature": "(const ImVec2*,int,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "points",
+          "type": "const ImVec2*"
+        },
+        {
+          "name": "num_points",
+          "type": "int"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddDrawCmd",
+      "cimgui_name": "ImDrawList_AddDrawCmd",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddDrawCmd",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddEllipse",
+      "cimgui_name": "ImDrawList_AddEllipse",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddEllipse",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,const ImVec2_c radius,ImU32 col,float rot,int num_segments,float thickness)",
+      "signature": "(const ImVec2,const ImVec2,ImU32,float,int,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "rot",
+          "type": "float"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0",
+        "rot": "0.0f",
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddEllipseFilled",
+      "cimgui_name": "ImDrawList_AddEllipseFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddEllipseFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,const ImVec2_c radius,ImU32 col,float rot,int num_segments)",
+      "signature": "(const ImVec2,const ImVec2,ImU32,float,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "rot",
+          "type": "float"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0",
+        "rot": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddImage",
+      "cimgui_name": "ImDrawList_AddImage",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddImage",
+      "c_arguments": "(ImDrawList*self,ImTextureRef_c tex_ref,const ImVec2_c p_min,const ImVec2_c p_max,const ImVec2_c uv_min,const ImVec2_c uv_max,ImU32 col)",
+      "signature": "(ImTextureRef,const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        },
+        {
+          "name": "p_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {
+        "col": "4294967295",
+        "uv_max": "ImVec2(1,1)",
+        "uv_min": "ImVec2(0,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddImageQuad",
+      "cimgui_name": "ImDrawList_AddImageQuad",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddImageQuad",
+      "c_arguments": "(ImDrawList*self,ImTextureRef_c tex_ref,const ImVec2_c p1,const ImVec2_c p2,const ImVec2_c p3,const ImVec2_c p4,const ImVec2_c uv1,const ImVec2_c uv2,const ImVec2_c uv3,const ImVec2_c uv4,ImU32 col)",
+      "signature": "(ImTextureRef,const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p4",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv4",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {
+        "col": "4294967295",
+        "uv1": "ImVec2(0,0)",
+        "uv2": "ImVec2(1,0)",
+        "uv3": "ImVec2(1,1)",
+        "uv4": "ImVec2(0,1)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddImageRounded",
+      "cimgui_name": "ImDrawList_AddImageRounded",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddImageRounded",
+      "c_arguments": "(ImDrawList*self,ImTextureRef_c tex_ref,const ImVec2_c p_min,const ImVec2_c p_max,const ImVec2_c uv_min,const ImVec2_c uv_max,ImU32 col,float rounding,ImDrawFlags flags)",
+      "signature": "(ImTextureRef,const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32,float,ImDrawFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        },
+        {
+          "name": "p_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "rounding",
+          "type": "float"
+        },
+        {
+          "name": "flags",
+          "type": "ImDrawFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddLine",
+      "cimgui_name": "ImDrawList_AddLine",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddLine",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p1,const ImVec2_c p2,ImU32 col,float thickness)",
+      "signature": "(const ImVec2,const ImVec2,ImU32,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddLineH",
+      "cimgui_name": "ImDrawList_AddLineH",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddLineH",
+      "c_arguments": "(ImDrawList*self,float min_x,float max_x,float y,ImU32 col,float thickness)",
+      "signature": "(float,float,float,ImU32,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "min_x",
+          "type": "float"
+        },
+        {
+          "name": "max_x",
+          "type": "float"
+        },
+        {
+          "name": "y",
+          "type": "float"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddLineV",
+      "cimgui_name": "ImDrawList_AddLineV",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddLineV",
+      "c_arguments": "(ImDrawList*self,float x,float min_y,float max_y,ImU32 col,float thickness)",
+      "signature": "(float,float,float,ImU32,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "x",
+          "type": "float"
+        },
+        {
+          "name": "min_y",
+          "type": "float"
+        },
+        {
+          "name": "max_y",
+          "type": "float"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddNgon",
+      "cimgui_name": "ImDrawList_AddNgon",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddNgon",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,ImU32 col,int num_segments,float thickness)",
+      "signature": "(const ImVec2,float,ImU32,int,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddNgonFilled",
+      "cimgui_name": "ImDrawList_AddNgonFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddNgonFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,ImU32 col,int num_segments)",
+      "signature": "(const ImVec2,float,ImU32,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddPolyline",
+      "cimgui_name": "ImDrawList_AddPolyline",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddPolyline",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c*points,int num_points,ImU32 col,float thickness,ImDrawFlags flags)",
+      "signature": "(const ImVec2*,int,ImU32,float,ImDrawFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "points",
+          "type": "const ImVec2*"
+        },
+        {
+          "name": "num_points",
+          "type": "int"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        },
+        {
+          "name": "flags",
+          "type": "ImDrawFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddQuad",
+      "cimgui_name": "ImDrawList_AddQuad",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddQuad",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p1,const ImVec2_c p2,const ImVec2_c p3,const ImVec2_c p4,ImU32 col,float thickness)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p4",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddQuadFilled",
+      "cimgui_name": "ImDrawList_AddQuadFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddQuadFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p1,const ImVec2_c p2,const ImVec2_c p3,const ImVec2_c p4,ImU32 col)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p4",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddRect",
+      "cimgui_name": "ImDrawList_AddRect",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddRect",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p_min,const ImVec2_c p_max,ImU32 col,float rounding,float thickness,ImDrawFlags flags)",
+      "signature": "(const ImVec2,const ImVec2,ImU32,float,float,ImDrawFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "rounding",
+          "type": "float"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        },
+        {
+          "name": "flags",
+          "type": "ImDrawFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "rounding": "0.0f",
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddRectFilled",
+      "cimgui_name": "ImDrawList_AddRectFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddRectFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p_min,const ImVec2_c p_max,ImU32 col,float rounding,ImDrawFlags flags)",
+      "signature": "(const ImVec2,const ImVec2,ImU32,float,ImDrawFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "rounding",
+          "type": "float"
+        },
+        {
+          "name": "flags",
+          "type": "ImDrawFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "rounding": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddRectFilledMultiColor",
+      "cimgui_name": "ImDrawList_AddRectFilledMultiColor",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddRectFilledMultiColor",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p_min,const ImVec2_c p_max,ImU32 col_upr_left,ImU32 col_upr_right,ImU32 col_bot_right,ImU32 col_bot_left)",
+      "signature": "(const ImVec2,const ImVec2,ImU32,ImU32,ImU32,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col_upr_left",
+          "type": "ImU32"
+        },
+        {
+          "name": "col_upr_right",
+          "type": "ImU32"
+        },
+        {
+          "name": "col_bot_right",
+          "type": "ImU32"
+        },
+        {
+          "name": "col_bot_left",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddText_FontPtr",
+      "cimgui_name": "ImDrawList_AddText",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddText",
+      "c_arguments": "(ImDrawList*self,ImFont*font,float font_size,const ImVec2_c pos,ImU32 col,const char*text_begin,const char*text_end,float wrap_width,const ImVec4*cpu_fine_clip_rect)",
+      "signature": "(ImFont*,float,const ImVec2,ImU32,const char*,const char*,float,const ImVec4*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "font",
+          "type": "ImFont*"
+        },
+        {
+          "name": "font_size",
+          "type": "float"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "text_begin",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        },
+        {
+          "name": "wrap_width",
+          "type": "float"
+        },
+        {
+          "name": "cpu_fine_clip_rect",
+          "type": "const ImVec4*"
+        }
+      ],
+      "defaults": {
+        "cpu_fine_clip_rect": "NULL",
+        "text_end": "NULL",
+        "wrap_width": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddText_Vec2",
+      "cimgui_name": "ImDrawList_AddText",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddText",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c pos,ImU32 col,const char*text_begin,const char*text_end)",
+      "signature": "(const ImVec2,ImU32,const char*,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "text_begin",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "text_end": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddTriangle",
+      "cimgui_name": "ImDrawList_AddTriangle",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddTriangle",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p1,const ImVec2_c p2,const ImVec2_c p3,ImU32 col,float thickness)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,ImU32,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_AddTriangleFilled",
+      "cimgui_name": "ImDrawList_AddTriangleFilled",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "AddTriangleFilled",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p1,const ImVec2_c p2,const ImVec2_c p3,ImU32 col)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_ChannelsMerge",
+      "cimgui_name": "ImDrawList_ChannelsMerge",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "ChannelsMerge",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_ChannelsSetCurrent",
+      "cimgui_name": "ImDrawList_ChannelsSetCurrent",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "ChannelsSetCurrent",
+      "c_arguments": "(ImDrawList*self,int n)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "n",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_ChannelsSplit",
+      "cimgui_name": "ImDrawList_ChannelsSplit",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "ChannelsSplit",
+      "c_arguments": "(ImDrawList*self,int count)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "count",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_CloneOutput",
+      "cimgui_name": "ImDrawList_CloneOutput",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "CloneOutput",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()const",
+      "return_type": "ImDrawList*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_GetClipRectMax",
+      "cimgui_name": "ImDrawList_GetClipRectMax",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "GetClipRectMax",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()const",
+      "return_type": "ImVec2_c",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "ImDrawList_GetClipRectMin",
+      "cimgui_name": "ImDrawList_GetClipRectMin",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "GetClipRectMin",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()const",
+      "return_type": "ImVec2_c",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "ImDrawList_ImDrawList",
+      "cimgui_name": "ImDrawList_ImDrawList",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "ImDrawList",
+      "c_arguments": "(ImDrawListSharedData*shared_data)",
+      "signature": "(ImDrawListSharedData*)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "shared_data",
+          "type": "ImDrawListSharedData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImDrawList_PathArcTo",
+      "cimgui_name": "ImDrawList_PathArcTo",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathArcTo",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,float a_min,float a_max,int num_segments)",
+      "signature": "(const ImVec2,float,float,float,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "a_min",
+          "type": "float"
+        },
+        {
+          "name": "a_max",
+          "type": "float"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathArcToFast",
+      "cimgui_name": "ImDrawList_PathArcToFast",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathArcToFast",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,int a_min_of_12,int a_max_of_12)",
+      "signature": "(const ImVec2,float,int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "a_min_of_12",
+          "type": "int"
+        },
+        {
+          "name": "a_max_of_12",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathBezierCubicCurveTo",
+      "cimgui_name": "ImDrawList_PathBezierCubicCurveTo",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathBezierCubicCurveTo",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p2,const ImVec2_c p3,const ImVec2_c p4,int num_segments)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p4",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathBezierQuadraticCurveTo",
+      "cimgui_name": "ImDrawList_PathBezierQuadraticCurveTo",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathBezierQuadraticCurveTo",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c p2,const ImVec2_c p3,int num_segments)",
+      "signature": "(const ImVec2,const ImVec2,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "p2",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "p3",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathClear",
+      "cimgui_name": "ImDrawList_PathClear",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathClear",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathEllipticalArcTo",
+      "cimgui_name": "ImDrawList_PathEllipticalArcTo",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathEllipticalArcTo",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,const ImVec2_c radius,float rot,float a_min,float a_max,int num_segments)",
+      "signature": "(const ImVec2,const ImVec2,float,float,float,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "rot",
+          "type": "float"
+        },
+        {
+          "name": "a_min",
+          "type": "float"
+        },
+        {
+          "name": "a_max",
+          "type": "float"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "num_segments": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathFillConcave",
+      "cimgui_name": "ImDrawList_PathFillConcave",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathFillConcave",
+      "c_arguments": "(ImDrawList*self,ImU32 col)",
+      "signature": "(ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathFillConvex",
+      "cimgui_name": "ImDrawList_PathFillConvex",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathFillConvex",
+      "c_arguments": "(ImDrawList*self,ImU32 col)",
+      "signature": "(ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathLineTo",
+      "cimgui_name": "ImDrawList_PathLineTo",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathLineTo",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c pos)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathLineToMergeDuplicate",
+      "cimgui_name": "ImDrawList_PathLineToMergeDuplicate",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathLineToMergeDuplicate",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c pos)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathRect",
+      "cimgui_name": "ImDrawList_PathRect",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathRect",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c rect_min,const ImVec2_c rect_max,float rounding,ImDrawFlags flags)",
+      "signature": "(const ImVec2,const ImVec2,float,ImDrawFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "rect_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "rect_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "rounding",
+          "type": "float"
+        },
+        {
+          "name": "flags",
+          "type": "ImDrawFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "rounding": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PathStroke",
+      "cimgui_name": "ImDrawList_PathStroke",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PathStroke",
+      "c_arguments": "(ImDrawList*self,ImU32 col,float thickness,ImDrawFlags flags)",
+      "signature": "(ImU32,float,ImDrawFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "thickness",
+          "type": "float"
+        },
+        {
+          "name": "flags",
+          "type": "ImDrawFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "thickness": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PopClipRect",
+      "cimgui_name": "ImDrawList_PopClipRect",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PopClipRect",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PopTexture",
+      "cimgui_name": "ImDrawList_PopTexture",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PopTexture",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimQuadUV",
+      "cimgui_name": "ImDrawList_PrimQuadUV",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimQuadUV",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c a,const ImVec2_c b,const ImVec2_c c,const ImVec2_c d,const ImVec2_c uv_a,const ImVec2_c uv_b,const ImVec2_c uv_c,const ImVec2_c uv_d,ImU32 col)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "a",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "b",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "c",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "d",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_a",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_b",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_c",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_d",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimRect",
+      "cimgui_name": "ImDrawList_PrimRect",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimRect",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c a,const ImVec2_c b,ImU32 col)",
+      "signature": "(const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "a",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "b",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimRectUV",
+      "cimgui_name": "ImDrawList_PrimRectUV",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimRectUV",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c a,const ImVec2_c b,const ImVec2_c uv_a,const ImVec2_c uv_b,ImU32 col)",
+      "signature": "(const ImVec2,const ImVec2,const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "a",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "b",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_a",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv_b",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimReserve",
+      "cimgui_name": "ImDrawList_PrimReserve",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimReserve",
+      "c_arguments": "(ImDrawList*self,int idx_count,int vtx_count)",
+      "signature": "(int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "idx_count",
+          "type": "int"
+        },
+        {
+          "name": "vtx_count",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimUnreserve",
+      "cimgui_name": "ImDrawList_PrimUnreserve",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimUnreserve",
+      "c_arguments": "(ImDrawList*self,int idx_count,int vtx_count)",
+      "signature": "(int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "idx_count",
+          "type": "int"
+        },
+        {
+          "name": "vtx_count",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimVtx",
+      "cimgui_name": "ImDrawList_PrimVtx",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimVtx",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c pos,const ImVec2_c uv,ImU32 col)",
+      "signature": "(const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimWriteIdx",
+      "cimgui_name": "ImDrawList_PrimWriteIdx",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimWriteIdx",
+      "c_arguments": "(ImDrawList*self,ImDrawIdx idx)",
+      "signature": "(ImDrawIdx)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "idx",
+          "type": "ImDrawIdx"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PrimWriteVtx",
+      "cimgui_name": "ImDrawList_PrimWriteVtx",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PrimWriteVtx",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c pos,const ImVec2_c uv,ImU32 col)",
+      "signature": "(const ImVec2,const ImVec2,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PushClipRect",
+      "cimgui_name": "ImDrawList_PushClipRect",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PushClipRect",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c clip_rect_min,const ImVec2_c clip_rect_max,bool intersect_with_current_clip_rect)",
+      "signature": "(const ImVec2,const ImVec2,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "clip_rect_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "clip_rect_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "intersect_with_current_clip_rect",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "intersect_with_current_clip_rect": "false"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PushClipRectFullScreen",
+      "cimgui_name": "ImDrawList_PushClipRectFullScreen",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PushClipRectFullScreen",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_PushTexture",
+      "cimgui_name": "ImDrawList_PushTexture",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "PushTexture",
+      "c_arguments": "(ImDrawList*self,ImTextureRef_c tex_ref)",
+      "signature": "(ImTextureRef)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__CalcCircleAutoSegmentCount",
+      "cimgui_name": "ImDrawList__CalcCircleAutoSegmentCount",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_CalcCircleAutoSegmentCount",
+      "c_arguments": "(ImDrawList*self,float radius)",
+      "signature": "(float)const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__ClearFreeMemory",
+      "cimgui_name": "ImDrawList__ClearFreeMemory",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_ClearFreeMemory",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__OnChangedClipRect",
+      "cimgui_name": "ImDrawList__OnChangedClipRect",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_OnChangedClipRect",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__OnChangedTexture",
+      "cimgui_name": "ImDrawList__OnChangedTexture",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_OnChangedTexture",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__OnChangedVtxOffset",
+      "cimgui_name": "ImDrawList__OnChangedVtxOffset",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_OnChangedVtxOffset",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__PathArcToFastEx",
+      "cimgui_name": "ImDrawList__PathArcToFastEx",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_PathArcToFastEx",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,int a_min_sample,int a_max_sample,int a_step)",
+      "signature": "(const ImVec2,float,int,int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "a_min_sample",
+          "type": "int"
+        },
+        {
+          "name": "a_max_sample",
+          "type": "int"
+        },
+        {
+          "name": "a_step",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__PathArcToN",
+      "cimgui_name": "ImDrawList__PathArcToN",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_PathArcToN",
+      "c_arguments": "(ImDrawList*self,const ImVec2_c center,float radius,float a_min,float a_max,int num_segments)",
+      "signature": "(const ImVec2,float,float,float,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "center",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "a_min",
+          "type": "float"
+        },
+        {
+          "name": "a_max",
+          "type": "float"
+        },
+        {
+          "name": "num_segments",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__PopUnusedDrawCmd",
+      "cimgui_name": "ImDrawList__PopUnusedDrawCmd",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_PopUnusedDrawCmd",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__ResetForNewFrame",
+      "cimgui_name": "ImDrawList__ResetForNewFrame",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_ResetForNewFrame",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__SetDrawListSharedData",
+      "cimgui_name": "ImDrawList__SetDrawListSharedData",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_SetDrawListSharedData",
+      "c_arguments": "(ImDrawList*self,ImDrawListSharedData*data)",
+      "signature": "(ImDrawListSharedData*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "data",
+          "type": "ImDrawListSharedData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__SetTexture",
+      "cimgui_name": "ImDrawList__SetTexture",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_SetTexture",
+      "c_arguments": "(ImDrawList*self,ImTextureRef_c tex_ref)",
+      "signature": "(ImTextureRef)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList__TryMergeDrawCmds",
+      "cimgui_name": "ImDrawList__TryMergeDrawCmds",
+      "namespace": "ImDrawList",
+      "struct": "ImDrawList",
+      "function": "_TryMergeDrawCmds",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImDrawList_destroy",
+      "cimgui_name": "ImDrawList_destroy",
+      "namespace": "",
+      "struct": "ImDrawList",
+      "function": "",
+      "c_arguments": "(ImDrawList*self)",
+      "signature": "(ImDrawList*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImDrawList*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true
+      }
+    },
+    {
+      "symbol": "ImFontAtlasRect_ImFontAtlasRect",
+      "cimgui_name": "ImFontAtlasRect_ImFontAtlasRect",
+      "namespace": "ImFontAtlasRect",
+      "struct": "ImFontAtlasRect",
+      "function": "ImFontAtlasRect",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImFontAtlasRect_destroy",
+      "cimgui_name": "ImFontAtlasRect_destroy",
+      "namespace": "",
+      "struct": "ImFontAtlasRect",
+      "function": "",
+      "c_arguments": "(ImFontAtlasRect*self)",
+      "signature": "(ImFontAtlasRect*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlasRect*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImFontAtlas_AddCustomRect",
+      "cimgui_name": "ImFontAtlas_AddCustomRect",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddCustomRect",
+      "c_arguments": "(ImFontAtlas*self,int width,int height,ImFontAtlasRect*out_r)",
+      "signature": "(int,int,ImFontAtlasRect*)",
+      "return_type": "ImFontAtlasRectId",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "out_r",
+          "type": "ImFontAtlasRect*"
+        }
+      ],
+      "defaults": {
+        "out_r": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFont",
+      "cimgui_name": "ImFontAtlas_AddFont",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFont",
+      "c_arguments": "(ImFontAtlas*self,const ImFontConfig*font_cfg)",
+      "signature": "(const ImFontConfig*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFontDefault",
+      "cimgui_name": "ImFontAtlas_AddFontDefault",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFontDefault",
+      "c_arguments": "(ImFontAtlas*self,const ImFontConfig*font_cfg)",
+      "signature": "(const ImFontConfig*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        }
+      ],
+      "defaults": {
+        "font_cfg": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFontDefaultBitmap",
+      "cimgui_name": "ImFontAtlas_AddFontDefaultBitmap",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFontDefaultBitmap",
+      "c_arguments": "(ImFontAtlas*self,const ImFontConfig*font_cfg)",
+      "signature": "(const ImFontConfig*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        }
+      ],
+      "defaults": {
+        "font_cfg": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFontDefaultVector",
+      "cimgui_name": "ImFontAtlas_AddFontDefaultVector",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFontDefaultVector",
+      "c_arguments": "(ImFontAtlas*self,const ImFontConfig*font_cfg)",
+      "signature": "(const ImFontConfig*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        }
+      ],
+      "defaults": {
+        "font_cfg": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFontFromFileTTF",
+      "cimgui_name": "ImFontAtlas_AddFontFromFileTTF",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFontFromFileTTF",
+      "c_arguments": "(ImFontAtlas*self,const char*filename,float size_pixels,const ImFontConfig*font_cfg,const ImWchar*glyph_ranges)",
+      "signature": "(const char*,float,const ImFontConfig*,const ImWchar*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "filename",
+          "type": "const char*"
+        },
+        {
+          "name": "size_pixels",
+          "type": "float"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        },
+        {
+          "name": "glyph_ranges",
+          "type": "const ImWchar*"
+        }
+      ],
+      "defaults": {
+        "font_cfg": "NULL",
+        "glyph_ranges": "NULL",
+        "size_pixels": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFontFromMemoryCompressedBase85TTF",
+      "cimgui_name": "ImFontAtlas_AddFontFromMemoryCompressedBase85TTF",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFontFromMemoryCompressedBase85TTF",
+      "c_arguments": "(ImFontAtlas*self,const char*compressed_font_data_base85,float size_pixels,const ImFontConfig*font_cfg,const ImWchar*glyph_ranges)",
+      "signature": "(const char*,float,const ImFontConfig*,const ImWchar*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "compressed_font_data_base85",
+          "type": "const char*"
+        },
+        {
+          "name": "size_pixels",
+          "type": "float"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        },
+        {
+          "name": "glyph_ranges",
+          "type": "const ImWchar*"
+        }
+      ],
+      "defaults": {
+        "font_cfg": "NULL",
+        "glyph_ranges": "NULL",
+        "size_pixels": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFontFromMemoryCompressedTTF",
+      "cimgui_name": "ImFontAtlas_AddFontFromMemoryCompressedTTF",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFontFromMemoryCompressedTTF",
+      "c_arguments": "(ImFontAtlas*self,const void*compressed_font_data,int compressed_font_data_size,float size_pixels,const ImFontConfig*font_cfg,const ImWchar*glyph_ranges)",
+      "signature": "(const void*,int,float,const ImFontConfig*,const ImWchar*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "compressed_font_data",
+          "type": "const void*"
+        },
+        {
+          "name": "compressed_font_data_size",
+          "type": "int"
+        },
+        {
+          "name": "size_pixels",
+          "type": "float"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        },
+        {
+          "name": "glyph_ranges",
+          "type": "const ImWchar*"
+        }
+      ],
+      "defaults": {
+        "font_cfg": "NULL",
+        "glyph_ranges": "NULL",
+        "size_pixels": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_AddFontFromMemoryTTF",
+      "cimgui_name": "ImFontAtlas_AddFontFromMemoryTTF",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "AddFontFromMemoryTTF",
+      "c_arguments": "(ImFontAtlas*self,void*font_data,int font_data_size,float size_pixels,const ImFontConfig*font_cfg,const ImWchar*glyph_ranges)",
+      "signature": "(void*,int,float,const ImFontConfig*,const ImWchar*)",
+      "return_type": "ImFont*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "font_data",
+          "type": "void*"
+        },
+        {
+          "name": "font_data_size",
+          "type": "int"
+        },
+        {
+          "name": "size_pixels",
+          "type": "float"
+        },
+        {
+          "name": "font_cfg",
+          "type": "const ImFontConfig*"
+        },
+        {
+          "name": "glyph_ranges",
+          "type": "const ImWchar*"
+        }
+      ],
+      "defaults": {
+        "font_cfg": "NULL",
+        "glyph_ranges": "NULL",
+        "size_pixels": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_Clear",
+      "cimgui_name": "ImFontAtlas_Clear",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "Clear",
+      "c_arguments": "(ImFontAtlas*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_ClearFonts",
+      "cimgui_name": "ImFontAtlas_ClearFonts",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "ClearFonts",
+      "c_arguments": "(ImFontAtlas*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_ClearInputData",
+      "cimgui_name": "ImFontAtlas_ClearInputData",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "ClearInputData",
+      "c_arguments": "(ImFontAtlas*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_ClearTexData",
+      "cimgui_name": "ImFontAtlas_ClearTexData",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "ClearTexData",
+      "c_arguments": "(ImFontAtlas*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_CompactCache",
+      "cimgui_name": "ImFontAtlas_CompactCache",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "CompactCache",
+      "c_arguments": "(ImFontAtlas*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_GetCustomRect",
+      "cimgui_name": "ImFontAtlas_GetCustomRect",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "GetCustomRect",
+      "c_arguments": "(ImFontAtlas*self,ImFontAtlasRectId id,ImFontAtlasRect*out_r)",
+      "signature": "(ImFontAtlasRectId,ImFontAtlasRect*)const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "id",
+          "type": "ImFontAtlasRectId"
+        },
+        {
+          "name": "out_r",
+          "type": "ImFontAtlasRect*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_GetGlyphRangesDefault",
+      "cimgui_name": "ImFontAtlas_GetGlyphRangesDefault",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "GetGlyphRangesDefault",
+      "c_arguments": "(ImFontAtlas*self)",
+      "signature": "()",
+      "return_type": "const ImWchar*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_ImFontAtlas",
+      "cimgui_name": "ImFontAtlas_ImFontAtlas",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "ImFontAtlas",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImFontAtlas_RemoveCustomRect",
+      "cimgui_name": "ImFontAtlas_RemoveCustomRect",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "RemoveCustomRect",
+      "c_arguments": "(ImFontAtlas*self,ImFontAtlasRectId id)",
+      "signature": "(ImFontAtlasRectId)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "id",
+          "type": "ImFontAtlasRectId"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_RemoveFont",
+      "cimgui_name": "ImFontAtlas_RemoveFont",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "RemoveFont",
+      "c_arguments": "(ImFontAtlas*self,ImFont*font)",
+      "signature": "(ImFont*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "font",
+          "type": "ImFont*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_SetFontLoader",
+      "cimgui_name": "ImFontAtlas_SetFontLoader",
+      "namespace": "ImFontAtlas",
+      "struct": "ImFontAtlas",
+      "function": "SetFontLoader",
+      "c_arguments": "(ImFontAtlas*self,const ImFontLoader*font_loader)",
+      "signature": "(const ImFontLoader*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        },
+        {
+          "name": "font_loader",
+          "type": "const ImFontLoader*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontAtlas_destroy",
+      "cimgui_name": "ImFontAtlas_destroy",
+      "namespace": "",
+      "struct": "ImFontAtlas",
+      "function": "",
+      "c_arguments": "(ImFontAtlas*self)",
+      "signature": "(ImFontAtlas*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true
+      }
+    },
+    {
+      "symbol": "ImFontBaked_ClearOutputData",
+      "cimgui_name": "ImFontBaked_ClearOutputData",
+      "namespace": "ImFontBaked",
+      "struct": "ImFontBaked",
+      "function": "ClearOutputData",
+      "c_arguments": "(ImFontBaked*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontBaked*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontBaked_FindGlyph",
+      "cimgui_name": "ImFontBaked_FindGlyph",
+      "namespace": "ImFontBaked",
+      "struct": "ImFontBaked",
+      "function": "FindGlyph",
+      "c_arguments": "(ImFontBaked*self,ImWchar c)",
+      "signature": "(ImWchar)",
+      "return_type": "ImFontGlyph*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontBaked*"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontBaked_FindGlyphNoFallback",
+      "cimgui_name": "ImFontBaked_FindGlyphNoFallback",
+      "namespace": "ImFontBaked",
+      "struct": "ImFontBaked",
+      "function": "FindGlyphNoFallback",
+      "c_arguments": "(ImFontBaked*self,ImWchar c)",
+      "signature": "(ImWchar)",
+      "return_type": "ImFontGlyph*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontBaked*"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontBaked_GetCharAdvance",
+      "cimgui_name": "ImFontBaked_GetCharAdvance",
+      "namespace": "ImFontBaked",
+      "struct": "ImFontBaked",
+      "function": "GetCharAdvance",
+      "c_arguments": "(ImFontBaked*self,ImWchar c)",
+      "signature": "(ImWchar)",
+      "return_type": "float",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontBaked*"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontBaked_ImFontBaked",
+      "cimgui_name": "ImFontBaked_ImFontBaked",
+      "namespace": "ImFontBaked",
+      "struct": "ImFontBaked",
+      "function": "ImFontBaked",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImFontBaked_IsGlyphLoaded",
+      "cimgui_name": "ImFontBaked_IsGlyphLoaded",
+      "namespace": "ImFontBaked",
+      "struct": "ImFontBaked",
+      "function": "IsGlyphLoaded",
+      "c_arguments": "(ImFontBaked*self,ImWchar c)",
+      "signature": "(ImWchar)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontBaked*"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontBaked_destroy",
+      "cimgui_name": "ImFontBaked_destroy",
+      "namespace": "",
+      "struct": "ImFontBaked",
+      "function": "",
+      "c_arguments": "(ImFontBaked*self)",
+      "signature": "(ImFontBaked*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontBaked*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImFontConfig_ImFontConfig",
+      "cimgui_name": "ImFontConfig_ImFontConfig",
+      "namespace": "ImFontConfig",
+      "struct": "ImFontConfig",
+      "function": "ImFontConfig",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImFontConfig_destroy",
+      "cimgui_name": "ImFontConfig_destroy",
+      "namespace": "",
+      "struct": "ImFontConfig",
+      "function": "",
+      "c_arguments": "(ImFontConfig*self)",
+      "signature": "(ImFontConfig*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontConfig*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_AddChar",
+      "cimgui_name": "ImFontGlyphRangesBuilder_AddChar",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "AddChar",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self,ImWchar c)",
+      "signature": "(ImWchar)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_AddRanges",
+      "cimgui_name": "ImFontGlyphRangesBuilder_AddRanges",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "AddRanges",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self,const ImWchar*ranges)",
+      "signature": "(const ImWchar*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        },
+        {
+          "name": "ranges",
+          "type": "const ImWchar*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_AddText",
+      "cimgui_name": "ImFontGlyphRangesBuilder_AddText",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "AddText",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self,const char*text,const char*text_end)",
+      "signature": "(const char*,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        },
+        {
+          "name": "text",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "text_end": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_BuildRanges",
+      "cimgui_name": "ImFontGlyphRangesBuilder_BuildRanges",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "BuildRanges",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self,ImVector_ImWchar*out_ranges)",
+      "signature": "(ImVector_ImWchar*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        },
+        {
+          "name": "out_ranges",
+          "template_orig": "ImVector<ImWchar>*out_ranges",
+          "type": "ImVector_ImWchar*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_Clear",
+      "cimgui_name": "ImFontGlyphRangesBuilder_Clear",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "Clear",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_GetBit",
+      "cimgui_name": "ImFontGlyphRangesBuilder_GetBit",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "GetBit",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self,size_t n)",
+      "signature": "(size_t)const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        },
+        {
+          "name": "n",
+          "type": "size_t"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_ImFontGlyphRangesBuilder",
+      "cimgui_name": "ImFontGlyphRangesBuilder_ImFontGlyphRangesBuilder",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "ImFontGlyphRangesBuilder",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_SetBit",
+      "cimgui_name": "ImFontGlyphRangesBuilder_SetBit",
+      "namespace": "ImFontGlyphRangesBuilder",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "SetBit",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self,size_t n)",
+      "signature": "(size_t)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        },
+        {
+          "name": "n",
+          "type": "size_t"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFontGlyphRangesBuilder_destroy",
+      "cimgui_name": "ImFontGlyphRangesBuilder_destroy",
+      "namespace": "",
+      "struct": "ImFontGlyphRangesBuilder",
+      "function": "",
+      "c_arguments": "(ImFontGlyphRangesBuilder*self)",
+      "signature": "(ImFontGlyphRangesBuilder*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyphRangesBuilder*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImFontGlyph_ImFontGlyph",
+      "cimgui_name": "ImFontGlyph_ImFontGlyph",
+      "namespace": "ImFontGlyph",
+      "struct": "ImFontGlyph",
+      "function": "ImFontGlyph",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImFontGlyph_destroy",
+      "cimgui_name": "ImFontGlyph_destroy",
+      "namespace": "",
+      "struct": "ImFontGlyph",
+      "function": "",
+      "c_arguments": "(ImFontGlyph*self)",
+      "signature": "(ImFontGlyph*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFontGlyph*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImFont_AddRemapChar",
+      "cimgui_name": "ImFont_AddRemapChar",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "AddRemapChar",
+      "c_arguments": "(ImFont*self,ImWchar from_codepoint,ImWchar to_codepoint)",
+      "signature": "(ImWchar,ImWchar)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "from_codepoint",
+          "type": "ImWchar"
+        },
+        {
+          "name": "to_codepoint",
+          "type": "ImWchar"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_CalcTextSizeA",
+      "cimgui_name": "ImFont_CalcTextSizeA",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "CalcTextSizeA",
+      "c_arguments": "(ImFont*self,float size,float max_width,float wrap_width,const char*text_begin,const char*text_end,const char**out_remaining)",
+      "signature": "(float,float,float,const char*,const char*,const char**)",
+      "return_type": "ImVec2_c",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "size",
+          "type": "float"
+        },
+        {
+          "name": "max_width",
+          "type": "float"
+        },
+        {
+          "name": "wrap_width",
+          "type": "float"
+        },
+        {
+          "name": "text_begin",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        },
+        {
+          "name": "out_remaining",
+          "type": "const char**"
+        }
+      ],
+      "defaults": {
+        "out_remaining": "NULL",
+        "text_end": "NULL"
+      },
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "ImFont_CalcWordWrapPosition",
+      "cimgui_name": "ImFont_CalcWordWrapPosition",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "CalcWordWrapPosition",
+      "c_arguments": "(ImFont*self,float size,const char*text,const char*text_end,float wrap_width)",
+      "signature": "(float,const char*,const char*,float)",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "size",
+          "type": "float"
+        },
+        {
+          "name": "text",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        },
+        {
+          "name": "wrap_width",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_ClearOutputData",
+      "cimgui_name": "ImFont_ClearOutputData",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "ClearOutputData",
+      "c_arguments": "(ImFont*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_GetDebugName",
+      "cimgui_name": "ImFont_GetDebugName",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "GetDebugName",
+      "c_arguments": "(ImFont*self)",
+      "signature": "()const",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_GetFontBaked",
+      "cimgui_name": "ImFont_GetFontBaked",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "GetFontBaked",
+      "c_arguments": "(ImFont*self,float font_size,float density)",
+      "signature": "(float,float)",
+      "return_type": "ImFontBaked*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "font_size",
+          "type": "float"
+        },
+        {
+          "name": "density",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "density": "-1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_ImFont",
+      "cimgui_name": "ImFont_ImFont",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "ImFont",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImFont_IsGlyphInFont",
+      "cimgui_name": "ImFont_IsGlyphInFont",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "IsGlyphInFont",
+      "c_arguments": "(ImFont*self,ImWchar c)",
+      "signature": "(ImWchar)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_IsGlyphRangeUnused",
+      "cimgui_name": "ImFont_IsGlyphRangeUnused",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "IsGlyphRangeUnused",
+      "c_arguments": "(ImFont*self,unsigned int c_begin,unsigned int c_last)",
+      "signature": "(unsigned int,unsigned int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "c_begin",
+          "type": "unsigned int"
+        },
+        {
+          "name": "c_last",
+          "type": "unsigned int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_IsLoaded",
+      "cimgui_name": "ImFont_IsLoaded",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "IsLoaded",
+      "c_arguments": "(ImFont*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_RenderChar",
+      "cimgui_name": "ImFont_RenderChar",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "RenderChar",
+      "c_arguments": "(ImFont*self,ImDrawList*draw_list,float size,const ImVec2_c pos,ImU32 col,ImWchar c,const ImVec4*cpu_fine_clip)",
+      "signature": "(ImDrawList*,float,const ImVec2,ImU32,ImWchar,const ImVec4*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "draw_list",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "size",
+          "type": "float"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar"
+        },
+        {
+          "name": "cpu_fine_clip",
+          "type": "const ImVec4*"
+        }
+      ],
+      "defaults": {
+        "cpu_fine_clip": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_RenderText",
+      "cimgui_name": "ImFont_RenderText",
+      "namespace": "ImFont",
+      "struct": "ImFont",
+      "function": "RenderText",
+      "c_arguments": "(ImFont*self,ImDrawList*draw_list,float size,const ImVec2_c pos,ImU32 col,const ImVec4_c clip_rect,const char*text_begin,const char*text_end,float wrap_width,ImDrawTextFlags flags)",
+      "signature": "(ImDrawList*,float,const ImVec2,ImU32,const ImVec4,const char*,const char*,float,ImDrawTextFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        },
+        {
+          "name": "draw_list",
+          "type": "ImDrawList*"
+        },
+        {
+          "name": "size",
+          "type": "float"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "clip_rect",
+          "type": "const ImVec4"
+        },
+        {
+          "name": "text_begin",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        },
+        {
+          "name": "wrap_width",
+          "type": "float"
+        },
+        {
+          "name": "flags",
+          "type": "ImDrawTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "wrap_width": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImFont_destroy",
+      "cimgui_name": "ImFont_destroy",
+      "namespace": "",
+      "struct": "ImFont",
+      "function": "",
+      "c_arguments": "(ImFont*self)",
+      "signature": "(ImFont*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImFont*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiIO_AddFocusEvent",
+      "cimgui_name": "ImGuiIO_AddFocusEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddFocusEvent",
+      "c_arguments": "(ImGuiIO*self,bool focused)",
+      "signature": "(bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "focused",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddInputCharacter",
+      "cimgui_name": "ImGuiIO_AddInputCharacter",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddInputCharacter",
+      "c_arguments": "(ImGuiIO*self,unsigned int c)",
+      "signature": "(unsigned int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "c",
+          "type": "unsigned int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddInputCharacterUTF16",
+      "cimgui_name": "ImGuiIO_AddInputCharacterUTF16",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddInputCharacterUTF16",
+      "c_arguments": "(ImGuiIO*self,ImWchar16 c)",
+      "signature": "(ImWchar16)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "c",
+          "type": "ImWchar16"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddInputCharactersUTF8",
+      "cimgui_name": "ImGuiIO_AddInputCharactersUTF8",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddInputCharactersUTF8",
+      "c_arguments": "(ImGuiIO*self,const char*str)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "str",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddKeyAnalogEvent",
+      "cimgui_name": "ImGuiIO_AddKeyAnalogEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddKeyAnalogEvent",
+      "c_arguments": "(ImGuiIO*self,ImGuiKey key,bool down,float v)",
+      "signature": "(ImGuiKey,bool,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        },
+        {
+          "name": "down",
+          "type": "bool"
+        },
+        {
+          "name": "v",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddKeyEvent",
+      "cimgui_name": "ImGuiIO_AddKeyEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddKeyEvent",
+      "c_arguments": "(ImGuiIO*self,ImGuiKey key,bool down)",
+      "signature": "(ImGuiKey,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        },
+        {
+          "name": "down",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddMouseButtonEvent",
+      "cimgui_name": "ImGuiIO_AddMouseButtonEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddMouseButtonEvent",
+      "c_arguments": "(ImGuiIO*self,int button,bool down)",
+      "signature": "(int,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "button",
+          "type": "int"
+        },
+        {
+          "name": "down",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddMousePosEvent",
+      "cimgui_name": "ImGuiIO_AddMousePosEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddMousePosEvent",
+      "c_arguments": "(ImGuiIO*self,float x,float y)",
+      "signature": "(float,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "x",
+          "type": "float"
+        },
+        {
+          "name": "y",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddMouseSourceEvent",
+      "cimgui_name": "ImGuiIO_AddMouseSourceEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddMouseSourceEvent",
+      "c_arguments": "(ImGuiIO*self,ImGuiMouseSource source)",
+      "signature": "(ImGuiMouseSource)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "source",
+          "type": "ImGuiMouseSource"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddMouseViewportEvent",
+      "cimgui_name": "ImGuiIO_AddMouseViewportEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddMouseViewportEvent",
+      "c_arguments": "(ImGuiIO*self,ImGuiID id)",
+      "signature": "(ImGuiID)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "id",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_AddMouseWheelEvent",
+      "cimgui_name": "ImGuiIO_AddMouseWheelEvent",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "AddMouseWheelEvent",
+      "c_arguments": "(ImGuiIO*self,float wheel_x,float wheel_y)",
+      "signature": "(float,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "wheel_x",
+          "type": "float"
+        },
+        {
+          "name": "wheel_y",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_ClearEventsQueue",
+      "cimgui_name": "ImGuiIO_ClearEventsQueue",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "ClearEventsQueue",
+      "c_arguments": "(ImGuiIO*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_ClearInputKeys",
+      "cimgui_name": "ImGuiIO_ClearInputKeys",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "ClearInputKeys",
+      "c_arguments": "(ImGuiIO*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_ClearInputMouse",
+      "cimgui_name": "ImGuiIO_ClearInputMouse",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "ClearInputMouse",
+      "c_arguments": "(ImGuiIO*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_ImGuiIO",
+      "cimgui_name": "ImGuiIO_ImGuiIO",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "ImGuiIO",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiIO_SetAppAcceptingEvents",
+      "cimgui_name": "ImGuiIO_SetAppAcceptingEvents",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "SetAppAcceptingEvents",
+      "c_arguments": "(ImGuiIO*self,bool accepting_events)",
+      "signature": "(bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "accepting_events",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_SetKeyEventNativeData",
+      "cimgui_name": "ImGuiIO_SetKeyEventNativeData",
+      "namespace": "ImGuiIO",
+      "struct": "ImGuiIO",
+      "function": "SetKeyEventNativeData",
+      "c_arguments": "(ImGuiIO*self,ImGuiKey key,int native_keycode,int native_scancode,int native_legacy_index)",
+      "signature": "(ImGuiKey,int,int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        },
+        {
+          "name": "native_keycode",
+          "type": "int"
+        },
+        {
+          "name": "native_scancode",
+          "type": "int"
+        },
+        {
+          "name": "native_legacy_index",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "native_legacy_index": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiIO_destroy",
+      "cimgui_name": "ImGuiIO_destroy",
+      "namespace": "",
+      "struct": "ImGuiIO",
+      "function": "",
+      "c_arguments": "(ImGuiIO*self)",
+      "signature": "(ImGuiIO*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_ClearSelection",
+      "cimgui_name": "ImGuiInputTextCallbackData_ClearSelection",
+      "namespace": "ImGuiInputTextCallbackData",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "ClearSelection",
+      "c_arguments": "(ImGuiInputTextCallbackData*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiInputTextCallbackData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_DeleteChars",
+      "cimgui_name": "ImGuiInputTextCallbackData_DeleteChars",
+      "namespace": "ImGuiInputTextCallbackData",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "DeleteChars",
+      "c_arguments": "(ImGuiInputTextCallbackData*self,int pos,int bytes_count)",
+      "signature": "(int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiInputTextCallbackData*"
+        },
+        {
+          "name": "pos",
+          "type": "int"
+        },
+        {
+          "name": "bytes_count",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_HasSelection",
+      "cimgui_name": "ImGuiInputTextCallbackData_HasSelection",
+      "namespace": "ImGuiInputTextCallbackData",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "HasSelection",
+      "c_arguments": "(ImGuiInputTextCallbackData*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiInputTextCallbackData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_ImGuiInputTextCallbackData",
+      "cimgui_name": "ImGuiInputTextCallbackData_ImGuiInputTextCallbackData",
+      "namespace": "ImGuiInputTextCallbackData",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "ImGuiInputTextCallbackData",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_InsertChars",
+      "cimgui_name": "ImGuiInputTextCallbackData_InsertChars",
+      "namespace": "ImGuiInputTextCallbackData",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "InsertChars",
+      "c_arguments": "(ImGuiInputTextCallbackData*self,int pos,const char*text,const char*text_end)",
+      "signature": "(int,const char*,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiInputTextCallbackData*"
+        },
+        {
+          "name": "pos",
+          "type": "int"
+        },
+        {
+          "name": "text",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "text_end": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_SelectAll",
+      "cimgui_name": "ImGuiInputTextCallbackData_SelectAll",
+      "namespace": "ImGuiInputTextCallbackData",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "SelectAll",
+      "c_arguments": "(ImGuiInputTextCallbackData*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiInputTextCallbackData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_SetSelection",
+      "cimgui_name": "ImGuiInputTextCallbackData_SetSelection",
+      "namespace": "ImGuiInputTextCallbackData",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "SetSelection",
+      "c_arguments": "(ImGuiInputTextCallbackData*self,int s,int e)",
+      "signature": "(int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiInputTextCallbackData*"
+        },
+        {
+          "name": "s",
+          "type": "int"
+        },
+        {
+          "name": "e",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiInputTextCallbackData_destroy",
+      "cimgui_name": "ImGuiInputTextCallbackData_destroy",
+      "namespace": "",
+      "struct": "ImGuiInputTextCallbackData",
+      "function": "",
+      "c_arguments": "(ImGuiInputTextCallbackData*self)",
+      "signature": "(ImGuiInputTextCallbackData*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiInputTextCallbackData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiListClipper_Begin",
+      "cimgui_name": "ImGuiListClipper_Begin",
+      "namespace": "ImGuiListClipper",
+      "struct": "ImGuiListClipper",
+      "function": "Begin",
+      "c_arguments": "(ImGuiListClipper*self,int items_count,float items_height)",
+      "signature": "(int,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiListClipper*"
+        },
+        {
+          "name": "items_count",
+          "type": "int"
+        },
+        {
+          "name": "items_height",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "items_height": "-1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiListClipper_End",
+      "cimgui_name": "ImGuiListClipper_End",
+      "namespace": "ImGuiListClipper",
+      "struct": "ImGuiListClipper",
+      "function": "End",
+      "c_arguments": "(ImGuiListClipper*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiListClipper*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiListClipper_ImGuiListClipper",
+      "cimgui_name": "ImGuiListClipper_ImGuiListClipper",
+      "namespace": "ImGuiListClipper",
+      "struct": "ImGuiListClipper",
+      "function": "ImGuiListClipper",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiListClipper_IncludeItemByIndex",
+      "cimgui_name": "ImGuiListClipper_IncludeItemByIndex",
+      "namespace": "ImGuiListClipper",
+      "struct": "ImGuiListClipper",
+      "function": "IncludeItemByIndex",
+      "c_arguments": "(ImGuiListClipper*self,int item_index)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiListClipper*"
+        },
+        {
+          "name": "item_index",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiListClipper_IncludeItemsByIndex",
+      "cimgui_name": "ImGuiListClipper_IncludeItemsByIndex",
+      "namespace": "ImGuiListClipper",
+      "struct": "ImGuiListClipper",
+      "function": "IncludeItemsByIndex",
+      "c_arguments": "(ImGuiListClipper*self,int item_begin,int item_end)",
+      "signature": "(int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiListClipper*"
+        },
+        {
+          "name": "item_begin",
+          "type": "int"
+        },
+        {
+          "name": "item_end",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiListClipper_SeekCursorForItem",
+      "cimgui_name": "ImGuiListClipper_SeekCursorForItem",
+      "namespace": "ImGuiListClipper",
+      "struct": "ImGuiListClipper",
+      "function": "SeekCursorForItem",
+      "c_arguments": "(ImGuiListClipper*self,int item_index)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiListClipper*"
+        },
+        {
+          "name": "item_index",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiListClipper_Step",
+      "cimgui_name": "ImGuiListClipper_Step",
+      "namespace": "ImGuiListClipper",
+      "struct": "ImGuiListClipper",
+      "function": "Step",
+      "c_arguments": "(ImGuiListClipper*self)",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiListClipper*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiListClipper_destroy",
+      "cimgui_name": "ImGuiListClipper_destroy",
+      "namespace": "",
+      "struct": "ImGuiListClipper",
+      "function": "",
+      "c_arguments": "(ImGuiListClipper*self)",
+      "signature": "(ImGuiListClipper*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiListClipper*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiOnceUponAFrame_ImGuiOnceUponAFrame",
+      "cimgui_name": "ImGuiOnceUponAFrame_ImGuiOnceUponAFrame",
+      "namespace": "ImGuiOnceUponAFrame",
+      "struct": "ImGuiOnceUponAFrame",
+      "function": "ImGuiOnceUponAFrame",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiOnceUponAFrame_destroy",
+      "cimgui_name": "ImGuiOnceUponAFrame_destroy",
+      "namespace": "",
+      "struct": "ImGuiOnceUponAFrame",
+      "function": "",
+      "c_arguments": "(ImGuiOnceUponAFrame*self)",
+      "signature": "(ImGuiOnceUponAFrame*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiOnceUponAFrame*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPayload_Clear",
+      "cimgui_name": "ImGuiPayload_Clear",
+      "namespace": "ImGuiPayload",
+      "struct": "ImGuiPayload",
+      "function": "Clear",
+      "c_arguments": "(ImGuiPayload*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPayload*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiPayload_ImGuiPayload",
+      "cimgui_name": "ImGuiPayload_ImGuiPayload",
+      "namespace": "ImGuiPayload",
+      "struct": "ImGuiPayload",
+      "function": "ImGuiPayload",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPayload_IsDataType",
+      "cimgui_name": "ImGuiPayload_IsDataType",
+      "namespace": "ImGuiPayload",
+      "struct": "ImGuiPayload",
+      "function": "IsDataType",
+      "c_arguments": "(ImGuiPayload*self,const char*type)",
+      "signature": "(const char*)const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPayload*"
+        },
+        {
+          "name": "type",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiPayload_IsDelivery",
+      "cimgui_name": "ImGuiPayload_IsDelivery",
+      "namespace": "ImGuiPayload",
+      "struct": "ImGuiPayload",
+      "function": "IsDelivery",
+      "c_arguments": "(ImGuiPayload*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPayload*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiPayload_IsPreview",
+      "cimgui_name": "ImGuiPayload_IsPreview",
+      "namespace": "ImGuiPayload",
+      "struct": "ImGuiPayload",
+      "function": "IsPreview",
+      "c_arguments": "(ImGuiPayload*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPayload*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiPayload_destroy",
+      "cimgui_name": "ImGuiPayload_destroy",
+      "namespace": "",
+      "struct": "ImGuiPayload",
+      "function": "",
+      "c_arguments": "(ImGuiPayload*self)",
+      "signature": "(ImGuiPayload*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPayload*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPlatformIO_ClearPlatformHandlers",
+      "cimgui_name": "ImGuiPlatformIO_ClearPlatformHandlers",
+      "namespace": "ImGuiPlatformIO",
+      "struct": "ImGuiPlatformIO",
+      "function": "ClearPlatformHandlers",
+      "c_arguments": "(ImGuiPlatformIO*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPlatformIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiPlatformIO_ClearRendererHandlers",
+      "cimgui_name": "ImGuiPlatformIO_ClearRendererHandlers",
+      "namespace": "ImGuiPlatformIO",
+      "struct": "ImGuiPlatformIO",
+      "function": "ClearRendererHandlers",
+      "c_arguments": "(ImGuiPlatformIO*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPlatformIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiPlatformIO_ImGuiPlatformIO",
+      "cimgui_name": "ImGuiPlatformIO_ImGuiPlatformIO",
+      "namespace": "ImGuiPlatformIO",
+      "struct": "ImGuiPlatformIO",
+      "function": "ImGuiPlatformIO",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPlatformIO_destroy",
+      "cimgui_name": "ImGuiPlatformIO_destroy",
+      "namespace": "",
+      "struct": "ImGuiPlatformIO",
+      "function": "",
+      "c_arguments": "(ImGuiPlatformIO*self)",
+      "signature": "(ImGuiPlatformIO*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPlatformIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPlatformImeData_ImGuiPlatformImeData",
+      "cimgui_name": "ImGuiPlatformImeData_ImGuiPlatformImeData",
+      "namespace": "ImGuiPlatformImeData",
+      "struct": "ImGuiPlatformImeData",
+      "function": "ImGuiPlatformImeData",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPlatformImeData_destroy",
+      "cimgui_name": "ImGuiPlatformImeData_destroy",
+      "namespace": "",
+      "struct": "ImGuiPlatformImeData",
+      "function": "",
+      "c_arguments": "(ImGuiPlatformImeData*self)",
+      "signature": "(ImGuiPlatformImeData*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPlatformImeData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPlatformMonitor_ImGuiPlatformMonitor",
+      "cimgui_name": "ImGuiPlatformMonitor_ImGuiPlatformMonitor",
+      "namespace": "ImGuiPlatformMonitor",
+      "struct": "ImGuiPlatformMonitor",
+      "function": "ImGuiPlatformMonitor",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiPlatformMonitor_destroy",
+      "cimgui_name": "ImGuiPlatformMonitor_destroy",
+      "namespace": "",
+      "struct": "ImGuiPlatformMonitor",
+      "function": "",
+      "c_arguments": "(ImGuiPlatformMonitor*self)",
+      "signature": "(ImGuiPlatformMonitor*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiPlatformMonitor*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_ApplyRequests",
+      "cimgui_name": "ImGuiSelectionBasicStorage_ApplyRequests",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "ApplyRequests",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self,ImGuiMultiSelectIO*ms_io)",
+      "signature": "(ImGuiMultiSelectIO*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        },
+        {
+          "name": "ms_io",
+          "type": "ImGuiMultiSelectIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_Clear",
+      "cimgui_name": "ImGuiSelectionBasicStorage_Clear",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "Clear",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_Contains",
+      "cimgui_name": "ImGuiSelectionBasicStorage_Contains",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "Contains",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self,ImGuiID id)",
+      "signature": "(ImGuiID)const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        },
+        {
+          "name": "id",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_GetNextSelectedItem",
+      "cimgui_name": "ImGuiSelectionBasicStorage_GetNextSelectedItem",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "GetNextSelectedItem",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self,void**opaque_it,ImGuiID*out_id)",
+      "signature": "(void**,ImGuiID*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        },
+        {
+          "name": "opaque_it",
+          "type": "void**"
+        },
+        {
+          "name": "out_id",
+          "type": "ImGuiID*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_GetStorageIdFromIndex",
+      "cimgui_name": "ImGuiSelectionBasicStorage_GetStorageIdFromIndex",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "GetStorageIdFromIndex",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self,int idx)",
+      "signature": "(int)",
+      "return_type": "ImGuiID",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        },
+        {
+          "name": "idx",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_ImGuiSelectionBasicStorage",
+      "cimgui_name": "ImGuiSelectionBasicStorage_ImGuiSelectionBasicStorage",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "ImGuiSelectionBasicStorage",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_SetItemSelected",
+      "cimgui_name": "ImGuiSelectionBasicStorage_SetItemSelected",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "SetItemSelected",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self,ImGuiID id,bool selected)",
+      "signature": "(ImGuiID,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        },
+        {
+          "name": "id",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "selected",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_Swap",
+      "cimgui_name": "ImGuiSelectionBasicStorage_Swap",
+      "namespace": "ImGuiSelectionBasicStorage",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "Swap",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self,ImGuiSelectionBasicStorage*r)",
+      "signature": "(ImGuiSelectionBasicStorage*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        },
+        {
+          "name": "r",
+          "reftoptr": true,
+          "type": "ImGuiSelectionBasicStorage*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionBasicStorage_destroy",
+      "cimgui_name": "ImGuiSelectionBasicStorage_destroy",
+      "namespace": "",
+      "struct": "ImGuiSelectionBasicStorage",
+      "function": "",
+      "c_arguments": "(ImGuiSelectionBasicStorage*self)",
+      "signature": "(ImGuiSelectionBasicStorage*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionBasicStorage*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiSelectionExternalStorage_ApplyRequests",
+      "cimgui_name": "ImGuiSelectionExternalStorage_ApplyRequests",
+      "namespace": "ImGuiSelectionExternalStorage",
+      "struct": "ImGuiSelectionExternalStorage",
+      "function": "ApplyRequests",
+      "c_arguments": "(ImGuiSelectionExternalStorage*self,ImGuiMultiSelectIO*ms_io)",
+      "signature": "(ImGuiMultiSelectIO*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionExternalStorage*"
+        },
+        {
+          "name": "ms_io",
+          "type": "ImGuiMultiSelectIO*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiSelectionExternalStorage_ImGuiSelectionExternalStorage",
+      "cimgui_name": "ImGuiSelectionExternalStorage_ImGuiSelectionExternalStorage",
+      "namespace": "ImGuiSelectionExternalStorage",
+      "struct": "ImGuiSelectionExternalStorage",
+      "function": "ImGuiSelectionExternalStorage",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiSelectionExternalStorage_destroy",
+      "cimgui_name": "ImGuiSelectionExternalStorage_destroy",
+      "namespace": "",
+      "struct": "ImGuiSelectionExternalStorage",
+      "function": "",
+      "c_arguments": "(ImGuiSelectionExternalStorage*self)",
+      "signature": "(ImGuiSelectionExternalStorage*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiSelectionExternalStorage*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiStoragePair_ImGuiStoragePair_Float",
+      "cimgui_name": "ImGuiStoragePair_ImGuiStoragePair",
+      "namespace": "ImGuiStoragePair",
+      "struct": "ImGuiStoragePair",
+      "function": "ImGuiStoragePair",
+      "c_arguments": "(ImGuiID _key,float _val)",
+      "signature": "(ImGuiID,float)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "_key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "_val",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiStoragePair_ImGuiStoragePair_Int",
+      "cimgui_name": "ImGuiStoragePair_ImGuiStoragePair",
+      "namespace": "ImGuiStoragePair",
+      "struct": "ImGuiStoragePair",
+      "function": "ImGuiStoragePair",
+      "c_arguments": "(ImGuiID _key,int _val)",
+      "signature": "(ImGuiID,int)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "_key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "_val",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiStoragePair_ImGuiStoragePair_Ptr",
+      "cimgui_name": "ImGuiStoragePair_ImGuiStoragePair",
+      "namespace": "ImGuiStoragePair",
+      "struct": "ImGuiStoragePair",
+      "function": "ImGuiStoragePair",
+      "c_arguments": "(ImGuiID _key,void*_val)",
+      "signature": "(ImGuiID,void*)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "_key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "_val",
+          "type": "void*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiStoragePair_destroy",
+      "cimgui_name": "ImGuiStoragePair_destroy",
+      "namespace": "",
+      "struct": "ImGuiStoragePair",
+      "function": "",
+      "c_arguments": "(ImGuiStoragePair*self)",
+      "signature": "(ImGuiStoragePair*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStoragePair*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiStorage_BuildSortByKey",
+      "cimgui_name": "ImGuiStorage_BuildSortByKey",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "BuildSortByKey",
+      "c_arguments": "(ImGuiStorage*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_Clear",
+      "cimgui_name": "ImGuiStorage_Clear",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "Clear",
+      "c_arguments": "(ImGuiStorage*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetBool",
+      "cimgui_name": "ImGuiStorage_GetBool",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetBool",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,bool default_val)",
+      "signature": "(ImGuiID,bool)const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "default_val",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "default_val": "false"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetBoolRef",
+      "cimgui_name": "ImGuiStorage_GetBoolRef",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetBoolRef",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,bool default_val)",
+      "signature": "(ImGuiID,bool)",
+      "return_type": "bool*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "default_val",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "default_val": "false"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetFloat",
+      "cimgui_name": "ImGuiStorage_GetFloat",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetFloat",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,float default_val)",
+      "signature": "(ImGuiID,float)const",
+      "return_type": "float",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "default_val",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "default_val": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetFloatRef",
+      "cimgui_name": "ImGuiStorage_GetFloatRef",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetFloatRef",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,float default_val)",
+      "signature": "(ImGuiID,float)",
+      "return_type": "float*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "default_val",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "default_val": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetInt",
+      "cimgui_name": "ImGuiStorage_GetInt",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetInt",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,int default_val)",
+      "signature": "(ImGuiID,int)const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "default_val",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "default_val": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetIntRef",
+      "cimgui_name": "ImGuiStorage_GetIntRef",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetIntRef",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,int default_val)",
+      "signature": "(ImGuiID,int)",
+      "return_type": "int*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "default_val",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "default_val": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetVoidPtr",
+      "cimgui_name": "ImGuiStorage_GetVoidPtr",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetVoidPtr",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key)",
+      "signature": "(ImGuiID)const",
+      "return_type": "void*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_GetVoidPtrRef",
+      "cimgui_name": "ImGuiStorage_GetVoidPtrRef",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "GetVoidPtrRef",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,void*default_val)",
+      "signature": "(ImGuiID,void*)",
+      "return_type": "void**",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "default_val",
+          "type": "void*"
+        }
+      ],
+      "defaults": {
+        "default_val": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_SetAllInt",
+      "cimgui_name": "ImGuiStorage_SetAllInt",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "SetAllInt",
+      "c_arguments": "(ImGuiStorage*self,int val)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "val",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_SetBool",
+      "cimgui_name": "ImGuiStorage_SetBool",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "SetBool",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,bool val)",
+      "signature": "(ImGuiID,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "val",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_SetFloat",
+      "cimgui_name": "ImGuiStorage_SetFloat",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "SetFloat",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,float val)",
+      "signature": "(ImGuiID,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "val",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_SetInt",
+      "cimgui_name": "ImGuiStorage_SetInt",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "SetInt",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,int val)",
+      "signature": "(ImGuiID,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "val",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStorage_SetVoidPtr",
+      "cimgui_name": "ImGuiStorage_SetVoidPtr",
+      "namespace": "ImGuiStorage",
+      "struct": "ImGuiStorage",
+      "function": "SetVoidPtr",
+      "c_arguments": "(ImGuiStorage*self,ImGuiID key,void*val)",
+      "signature": "(ImGuiID,void*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStorage*"
+        },
+        {
+          "name": "key",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "val",
+          "type": "void*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStyle_ImGuiStyle",
+      "cimgui_name": "ImGuiStyle_ImGuiStyle",
+      "namespace": "ImGuiStyle",
+      "struct": "ImGuiStyle",
+      "function": "ImGuiStyle",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiStyle_ScaleAllSizes",
+      "cimgui_name": "ImGuiStyle_ScaleAllSizes",
+      "namespace": "ImGuiStyle",
+      "struct": "ImGuiStyle",
+      "function": "ScaleAllSizes",
+      "c_arguments": "(ImGuiStyle*self,float scale_factor)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStyle*"
+        },
+        {
+          "name": "scale_factor",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiStyle_destroy",
+      "cimgui_name": "ImGuiStyle_destroy",
+      "namespace": "",
+      "struct": "ImGuiStyle",
+      "function": "",
+      "c_arguments": "(ImGuiStyle*self)",
+      "signature": "(ImGuiStyle*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiStyle*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTableColumnSortSpecs_ImGuiTableColumnSortSpecs",
+      "cimgui_name": "ImGuiTableColumnSortSpecs_ImGuiTableColumnSortSpecs",
+      "namespace": "ImGuiTableColumnSortSpecs",
+      "struct": "ImGuiTableColumnSortSpecs",
+      "function": "ImGuiTableColumnSortSpecs",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTableColumnSortSpecs_destroy",
+      "cimgui_name": "ImGuiTableColumnSortSpecs_destroy",
+      "namespace": "",
+      "struct": "ImGuiTableColumnSortSpecs",
+      "function": "",
+      "c_arguments": "(ImGuiTableColumnSortSpecs*self)",
+      "signature": "(ImGuiTableColumnSortSpecs*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTableColumnSortSpecs*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTableSortSpecs_ImGuiTableSortSpecs",
+      "cimgui_name": "ImGuiTableSortSpecs_ImGuiTableSortSpecs",
+      "namespace": "ImGuiTableSortSpecs",
+      "struct": "ImGuiTableSortSpecs",
+      "function": "ImGuiTableSortSpecs",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTableSortSpecs_destroy",
+      "cimgui_name": "ImGuiTableSortSpecs_destroy",
+      "namespace": "",
+      "struct": "ImGuiTableSortSpecs",
+      "function": "",
+      "c_arguments": "(ImGuiTableSortSpecs*self)",
+      "signature": "(ImGuiTableSortSpecs*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTableSortSpecs*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextBuffer_ImGuiTextBuffer",
+      "cimgui_name": "ImGuiTextBuffer_ImGuiTextBuffer",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "ImGuiTextBuffer",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextBuffer_append",
+      "cimgui_name": "ImGuiTextBuffer_append",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "append",
+      "c_arguments": "(ImGuiTextBuffer*self,const char*str,const char*str_end)",
+      "signature": "(const char*,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        },
+        {
+          "name": "str",
+          "type": "const char*"
+        },
+        {
+          "name": "str_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "str_end": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_appendf",
+      "cimgui_name": "ImGuiTextBuffer_appendf",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "appendf",
+      "c_arguments": "(ImGuiTextBuffer*self,const char*fmt,...)",
+      "signature": "(ImGuiTextBuffer*,const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)",
+        "manual": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextBuffer_appendfv",
+      "cimgui_name": "ImGuiTextBuffer_appendfv",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "appendfv",
+      "c_arguments": "(ImGuiTextBuffer*self,const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_begin",
+      "cimgui_name": "ImGuiTextBuffer_begin",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "begin",
+      "c_arguments": "(ImGuiTextBuffer*self)",
+      "signature": "()const",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_c_str",
+      "cimgui_name": "ImGuiTextBuffer_c_str",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "c_str",
+      "c_arguments": "(ImGuiTextBuffer*self)",
+      "signature": "()const",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_clear",
+      "cimgui_name": "ImGuiTextBuffer_clear",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "clear",
+      "c_arguments": "(ImGuiTextBuffer*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_destroy",
+      "cimgui_name": "ImGuiTextBuffer_destroy",
+      "namespace": "",
+      "struct": "ImGuiTextBuffer",
+      "function": "",
+      "c_arguments": "(ImGuiTextBuffer*self)",
+      "signature": "(ImGuiTextBuffer*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextBuffer_empty",
+      "cimgui_name": "ImGuiTextBuffer_empty",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "empty",
+      "c_arguments": "(ImGuiTextBuffer*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_end",
+      "cimgui_name": "ImGuiTextBuffer_end",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "end",
+      "c_arguments": "(ImGuiTextBuffer*self)",
+      "signature": "()const",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_reserve",
+      "cimgui_name": "ImGuiTextBuffer_reserve",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "reserve",
+      "c_arguments": "(ImGuiTextBuffer*self,int capacity)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        },
+        {
+          "name": "capacity",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_resize",
+      "cimgui_name": "ImGuiTextBuffer_resize",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "resize",
+      "c_arguments": "(ImGuiTextBuffer*self,int size)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        },
+        {
+          "name": "size",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextBuffer_size",
+      "cimgui_name": "ImGuiTextBuffer_size",
+      "namespace": "ImGuiTextBuffer",
+      "struct": "ImGuiTextBuffer",
+      "function": "size",
+      "c_arguments": "(ImGuiTextBuffer*self)",
+      "signature": "()const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextBuffer*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextFilter_Build",
+      "cimgui_name": "ImGuiTextFilter_Build",
+      "namespace": "ImGuiTextFilter",
+      "struct": "ImGuiTextFilter",
+      "function": "Build",
+      "c_arguments": "(ImGuiTextFilter*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextFilter*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextFilter_Clear",
+      "cimgui_name": "ImGuiTextFilter_Clear",
+      "namespace": "ImGuiTextFilter",
+      "struct": "ImGuiTextFilter",
+      "function": "Clear",
+      "c_arguments": "(ImGuiTextFilter*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextFilter*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextFilter_Draw",
+      "cimgui_name": "ImGuiTextFilter_Draw",
+      "namespace": "ImGuiTextFilter",
+      "struct": "ImGuiTextFilter",
+      "function": "Draw",
+      "c_arguments": "(ImGuiTextFilter*self,const char*label,float width)",
+      "signature": "(const char*,float)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextFilter*"
+        },
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "width",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "label": "\"Filter(inc,-exc)\"",
+        "width": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextFilter_ImGuiTextFilter",
+      "cimgui_name": "ImGuiTextFilter_ImGuiTextFilter",
+      "namespace": "ImGuiTextFilter",
+      "struct": "ImGuiTextFilter",
+      "function": "ImGuiTextFilter",
+      "c_arguments": "(const char*default_filter)",
+      "signature": "(const char*)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "default_filter",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "default_filter": "\"\""
+      },
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextFilter_IsActive",
+      "cimgui_name": "ImGuiTextFilter_IsActive",
+      "namespace": "ImGuiTextFilter",
+      "struct": "ImGuiTextFilter",
+      "function": "IsActive",
+      "c_arguments": "(ImGuiTextFilter*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextFilter*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextFilter_PassFilter",
+      "cimgui_name": "ImGuiTextFilter_PassFilter",
+      "namespace": "ImGuiTextFilter",
+      "struct": "ImGuiTextFilter",
+      "function": "PassFilter",
+      "c_arguments": "(ImGuiTextFilter*self,const char*text,const char*text_end)",
+      "signature": "(const char*,const char*)const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextFilter*"
+        },
+        {
+          "name": "text",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "text_end": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextFilter_destroy",
+      "cimgui_name": "ImGuiTextFilter_destroy",
+      "namespace": "",
+      "struct": "ImGuiTextFilter",
+      "function": "",
+      "c_arguments": "(ImGuiTextFilter*self)",
+      "signature": "(ImGuiTextFilter*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextFilter*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextRange_ImGuiTextRange_Nil",
+      "cimgui_name": "ImGuiTextRange_ImGuiTextRange",
+      "namespace": "ImGuiTextFilter::ImGuiTextRange",
+      "struct": "ImGuiTextRange",
+      "function": "ImGuiTextRange",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextRange_ImGuiTextRange_Str",
+      "cimgui_name": "ImGuiTextRange_ImGuiTextRange",
+      "namespace": "ImGuiTextFilter::ImGuiTextRange",
+      "struct": "ImGuiTextRange",
+      "function": "ImGuiTextRange",
+      "c_arguments": "(const char*_b,const char*_e)",
+      "signature": "(const char*,const char*)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "_b",
+          "type": "const char*"
+        },
+        {
+          "name": "_e",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextRange_destroy",
+      "cimgui_name": "ImGuiTextRange_destroy",
+      "namespace": "",
+      "struct": "ImGuiTextRange",
+      "function": "",
+      "c_arguments": "(ImGuiTextRange*self)",
+      "signature": "(ImGuiTextRange*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextRange*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiTextRange_empty",
+      "cimgui_name": "ImGuiTextRange_empty",
+      "namespace": "ImGuiTextFilter::ImGuiTextRange",
+      "struct": "ImGuiTextRange",
+      "function": "empty",
+      "c_arguments": "(ImGuiTextRange*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextRange*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiTextRange_split",
+      "cimgui_name": "ImGuiTextRange_split",
+      "namespace": "ImGuiTextFilter::ImGuiTextRange",
+      "struct": "ImGuiTextRange",
+      "function": "split",
+      "c_arguments": "(ImGuiTextRange*self,char separator,ImVector_ImGuiTextRange*out)",
+      "signature": "(char,ImVector_ImGuiTextRange*)const",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiTextRange*"
+        },
+        {
+          "name": "separator",
+          "type": "char"
+        },
+        {
+          "name": "out",
+          "template_orig": "ImVector<ImGuiTextRange>*out",
+          "type": "ImVector_ImGuiTextRange*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiViewport_GetCenter",
+      "cimgui_name": "ImGuiViewport_GetCenter",
+      "namespace": "ImGuiViewport",
+      "struct": "ImGuiViewport",
+      "function": "GetCenter",
+      "c_arguments": "(ImGuiViewport*self)",
+      "signature": "()const",
+      "return_type": "ImVec2_c",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiViewport*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "ImGuiViewport_GetDebugName",
+      "cimgui_name": "ImGuiViewport_GetDebugName",
+      "namespace": "ImGuiViewport",
+      "struct": "ImGuiViewport",
+      "function": "GetDebugName",
+      "c_arguments": "(ImGuiViewport*self)",
+      "signature": "()const",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiViewport*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImGuiViewport_GetWorkCenter",
+      "cimgui_name": "ImGuiViewport_GetWorkCenter",
+      "namespace": "ImGuiViewport",
+      "struct": "ImGuiViewport",
+      "function": "GetWorkCenter",
+      "c_arguments": "(ImGuiViewport*self)",
+      "signature": "()const",
+      "return_type": "ImVec2_c",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiViewport*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "ImGuiViewport_ImGuiViewport",
+      "cimgui_name": "ImGuiViewport_ImGuiViewport",
+      "namespace": "ImGuiViewport",
+      "struct": "ImGuiViewport",
+      "function": "ImGuiViewport",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiViewport_destroy",
+      "cimgui_name": "ImGuiViewport_destroy",
+      "namespace": "",
+      "struct": "ImGuiViewport",
+      "function": "",
+      "c_arguments": "(ImGuiViewport*self)",
+      "signature": "(ImGuiViewport*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiViewport*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiWindowClass_ImGuiWindowClass",
+      "cimgui_name": "ImGuiWindowClass_ImGuiWindowClass",
+      "namespace": "ImGuiWindowClass",
+      "struct": "ImGuiWindowClass",
+      "function": "ImGuiWindowClass",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImGuiWindowClass_destroy",
+      "cimgui_name": "ImGuiWindowClass_destroy",
+      "namespace": "",
+      "struct": "ImGuiWindowClass",
+      "function": "",
+      "c_arguments": "(ImGuiWindowClass*self)",
+      "signature": "(ImGuiWindowClass*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImGuiWindowClass*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImTextureData_Create",
+      "cimgui_name": "ImTextureData_Create",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "Create",
+      "c_arguments": "(ImTextureData*self,ImTextureFormat format,int w,int h)",
+      "signature": "(ImTextureFormat,int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        },
+        {
+          "name": "format",
+          "type": "ImTextureFormat"
+        },
+        {
+          "name": "w",
+          "type": "int"
+        },
+        {
+          "name": "h",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_DestroyPixels",
+      "cimgui_name": "ImTextureData_DestroyPixels",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "DestroyPixels",
+      "c_arguments": "(ImTextureData*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_GetPitch",
+      "cimgui_name": "ImTextureData_GetPitch",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "GetPitch",
+      "c_arguments": "(ImTextureData*self)",
+      "signature": "()const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_GetPixels",
+      "cimgui_name": "ImTextureData_GetPixels",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "GetPixels",
+      "c_arguments": "(ImTextureData*self)",
+      "signature": "()",
+      "return_type": "void*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_GetPixelsAt",
+      "cimgui_name": "ImTextureData_GetPixelsAt",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "GetPixelsAt",
+      "c_arguments": "(ImTextureData*self,int x,int y)",
+      "signature": "(int,int)",
+      "return_type": "void*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        },
+        {
+          "name": "x",
+          "type": "int"
+        },
+        {
+          "name": "y",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_GetSizeInBytes",
+      "cimgui_name": "ImTextureData_GetSizeInBytes",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "GetSizeInBytes",
+      "c_arguments": "(ImTextureData*self)",
+      "signature": "()const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_GetTexID",
+      "cimgui_name": "ImTextureData_GetTexID",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "GetTexID",
+      "c_arguments": "(ImTextureData*self)",
+      "signature": "()const",
+      "return_type": "ImTextureID",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_GetTexRef",
+      "cimgui_name": "ImTextureData_GetTexRef",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "GetTexRef",
+      "c_arguments": "(ImTextureData*self)",
+      "signature": "()",
+      "return_type": "ImTextureRef_c",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "conv": "ImTextureRef",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "ImTextureData_ImTextureData",
+      "cimgui_name": "ImTextureData_ImTextureData",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "ImTextureData",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImTextureData_SetStatus",
+      "cimgui_name": "ImTextureData_SetStatus",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "SetStatus",
+      "c_arguments": "(ImTextureData*self,ImTextureStatus status)",
+      "signature": "(ImTextureStatus)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        },
+        {
+          "name": "status",
+          "type": "ImTextureStatus"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_SetTexID",
+      "cimgui_name": "ImTextureData_SetTexID",
+      "namespace": "ImTextureData",
+      "struct": "ImTextureData",
+      "function": "SetTexID",
+      "c_arguments": "(ImTextureData*self,ImTextureID tex_id)",
+      "signature": "(ImTextureID)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        },
+        {
+          "name": "tex_id",
+          "type": "ImTextureID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureData_destroy",
+      "cimgui_name": "ImTextureData_destroy",
+      "namespace": "",
+      "struct": "ImTextureData",
+      "function": "",
+      "c_arguments": "(ImTextureData*self)",
+      "signature": "(ImTextureData*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureData*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true
+      }
+    },
+    {
+      "symbol": "ImTextureRef_GetTexID",
+      "cimgui_name": "ImTextureRef_GetTexID",
+      "namespace": "ImTextureRef",
+      "struct": "ImTextureRef",
+      "function": "GetTexID",
+      "c_arguments": "(ImTextureRef*self)",
+      "signature": "()const",
+      "return_type": "ImTextureID",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureRef*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "ImTextureRef_ImTextureRef_Nil",
+      "cimgui_name": "ImTextureRef_ImTextureRef",
+      "namespace": "ImTextureRef",
+      "struct": "ImTextureRef",
+      "function": "ImTextureRef",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImTextureRef_ImTextureRef_TextureID",
+      "cimgui_name": "ImTextureRef_ImTextureRef",
+      "namespace": "ImTextureRef",
+      "struct": "ImTextureRef",
+      "function": "ImTextureRef",
+      "c_arguments": "(ImTextureID tex_id)",
+      "signature": "(ImTextureID)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "tex_id",
+          "type": "ImTextureID"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImTextureRef_destroy",
+      "cimgui_name": "ImTextureRef_destroy",
+      "namespace": "",
+      "struct": "ImTextureRef",
+      "function": "",
+      "c_arguments": "(ImTextureRef*self)",
+      "signature": "(ImTextureRef*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImTextureRef*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImVec2_ImVec2_Float",
+      "cimgui_name": "ImVec2_ImVec2",
+      "namespace": "ImVec2",
+      "struct": "ImVec2",
+      "function": "ImVec2",
+      "c_arguments": "(float _x,float _y)",
+      "signature": "(float,float)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "_x",
+          "type": "float"
+        },
+        {
+          "name": "_y",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImVec2_ImVec2_Nil",
+      "cimgui_name": "ImVec2_ImVec2",
+      "namespace": "ImVec2",
+      "struct": "ImVec2",
+      "function": "ImVec2",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImVec2_destroy",
+      "cimgui_name": "ImVec2_destroy",
+      "namespace": "",
+      "struct": "ImVec2",
+      "function": "",
+      "c_arguments": "(ImVec2*self)",
+      "signature": "(ImVec2*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVec2*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImVec4_ImVec4_Float",
+      "cimgui_name": "ImVec4_ImVec4",
+      "namespace": "ImVec4",
+      "struct": "ImVec4",
+      "function": "ImVec4",
+      "c_arguments": "(float _x,float _y,float _z,float _w)",
+      "signature": "(float,float,float,float)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "_x",
+          "type": "float"
+        },
+        {
+          "name": "_y",
+          "type": "float"
+        },
+        {
+          "name": "_z",
+          "type": "float"
+        },
+        {
+          "name": "_w",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImVec4_ImVec4_Nil",
+      "cimgui_name": "ImVec4_ImVec4",
+      "namespace": "ImVec4",
+      "struct": "ImVec4",
+      "function": "ImVec4",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true
+      }
+    },
+    {
+      "symbol": "ImVec4_destroy",
+      "cimgui_name": "ImVec4_destroy",
+      "namespace": "",
+      "struct": "ImVec4",
+      "function": "",
+      "c_arguments": "(ImVec4*self)",
+      "signature": "(ImVec4*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVec4*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true
+      }
+    },
+    {
+      "symbol": "ImVector_ImVector_Nil",
+      "cimgui_name": "ImVector_ImVector",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "ImVector",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "constructor": true,
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_ImVector_Vector_T_",
+      "cimgui_name": "ImVector_ImVector",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "ImVector",
+      "c_arguments": "(const ImVector_T src)",
+      "signature": "(const ImVector_T)",
+      "return_type": "",
+      "arguments": [
+        {
+          "name": "src",
+          "template_orig": "const ImVector<T>&src",
+          "type": "const ImVector_T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "constructor": true,
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector__grow_capacity",
+      "cimgui_name": "ImVector__grow_capacity",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "_grow_capacity",
+      "c_arguments": "(ImVector*self,int sz)",
+      "signature": "(int)const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "sz",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_back_Nil",
+      "cimgui_name": "ImVector_back",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "back",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "retref": "&",
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_back__const",
+      "cimgui_name": "ImVector_back",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "back",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "const T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "retref": "&",
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_begin_Nil",
+      "cimgui_name": "ImVector_begin",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "begin",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_begin__const",
+      "cimgui_name": "ImVector_begin",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "begin",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "const T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_capacity",
+      "cimgui_name": "ImVector_capacity",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "capacity",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_clear",
+      "cimgui_name": "ImVector_clear",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "clear",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_clear_delete",
+      "cimgui_name": "ImVector_clear_delete",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "clear_delete",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_clear_destruct",
+      "cimgui_name": "ImVector_clear_destruct",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "clear_destruct",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_contains",
+      "cimgui_name": "ImVector_contains",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "contains",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_destroy",
+      "cimgui_name": "ImVector_destroy",
+      "namespace": "",
+      "struct": "ImVector",
+      "function": "",
+      "c_arguments": "(ImVector*self)",
+      "signature": "(ImVector*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "destructor": true,
+        "realdestructor": true,
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_empty",
+      "cimgui_name": "ImVector_empty",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "empty",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_end_Nil",
+      "cimgui_name": "ImVector_end",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "end",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_end__const",
+      "cimgui_name": "ImVector_end",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "end",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "const T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_erase_Nil",
+      "cimgui_name": "ImVector_erase",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "erase",
+      "c_arguments": "(ImVector*self,const T*it)",
+      "signature": "(const T*)",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "it",
+          "type": "const T*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_erase_TPtr",
+      "cimgui_name": "ImVector_erase",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "erase",
+      "c_arguments": "(ImVector*self,const T*it,const T*it_last)",
+      "signature": "(const T*,const T*)",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "it",
+          "type": "const T*"
+        },
+        {
+          "name": "it_last",
+          "type": "const T*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_erase_unsorted",
+      "cimgui_name": "ImVector_erase_unsorted",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "erase_unsorted",
+      "c_arguments": "(ImVector*self,const T*it)",
+      "signature": "(const T*)",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "it",
+          "type": "const T*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_find_Nil",
+      "cimgui_name": "ImVector_find",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "find",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_find__const",
+      "cimgui_name": "ImVector_find",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "find",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)const",
+      "return_type": "const T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_find_erase",
+      "cimgui_name": "ImVector_find_erase",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "find_erase",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_find_erase_unsorted",
+      "cimgui_name": "ImVector_find_erase_unsorted",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "find_erase_unsorted",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_find_index",
+      "cimgui_name": "ImVector_find_index",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "find_index",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_front_Nil",
+      "cimgui_name": "ImVector_front",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "front",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "retref": "&",
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_front__const",
+      "cimgui_name": "ImVector_front",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "front",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "const T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "retref": "&",
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_index_from_ptr",
+      "cimgui_name": "ImVector_index_from_ptr",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "index_from_ptr",
+      "c_arguments": "(ImVector*self,const T*it)",
+      "signature": "(const T*)const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "it",
+          "type": "const T*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_insert",
+      "cimgui_name": "ImVector_insert",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "insert",
+      "c_arguments": "(ImVector*self,const T*it,const T v)",
+      "signature": "(const T*,const T)",
+      "return_type": "T*",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "it",
+          "type": "const T*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_max_size",
+      "cimgui_name": "ImVector_max_size",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "max_size",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_pop_back",
+      "cimgui_name": "ImVector_pop_back",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "pop_back",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_push_back",
+      "cimgui_name": "ImVector_push_back",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "push_back",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_push_front",
+      "cimgui_name": "ImVector_push_front",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "push_front",
+      "c_arguments": "(ImVector*self,const T v)",
+      "signature": "(const T)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_reserve",
+      "cimgui_name": "ImVector_reserve",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "reserve",
+      "c_arguments": "(ImVector*self,int new_capacity)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "new_capacity",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_reserve_discard",
+      "cimgui_name": "ImVector_reserve_discard",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "reserve_discard",
+      "c_arguments": "(ImVector*self,int new_capacity)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "new_capacity",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_resize_Nil",
+      "cimgui_name": "ImVector_resize",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "resize",
+      "c_arguments": "(ImVector*self,int new_size)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "new_size",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_resize_T",
+      "cimgui_name": "ImVector_resize",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "resize",
+      "c_arguments": "(ImVector*self,int new_size,const T v)",
+      "signature": "(int,const T)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "new_size",
+          "type": "int"
+        },
+        {
+          "name": "v",
+          "type": "const T"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_shrink",
+      "cimgui_name": "ImVector_shrink",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "shrink",
+      "c_arguments": "(ImVector*self,int new_size)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "new_size",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_size",
+      "cimgui_name": "ImVector_size",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "size",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_size_in_bytes",
+      "cimgui_name": "ImVector_size_in_bytes",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "size_in_bytes",
+      "c_arguments": "(ImVector*self)",
+      "signature": "()const",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "ImVector_swap",
+      "cimgui_name": "ImVector_swap",
+      "namespace": "ImVector",
+      "struct": "ImVector",
+      "function": "swap",
+      "c_arguments": "(ImVector*self,ImVector_T*rhs)",
+      "signature": "(ImVector_T*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "self",
+          "type": "ImVector*"
+        },
+        {
+          "name": "rhs",
+          "reftoptr": true,
+          "template_orig": "ImVector<T>&rhs",
+          "type": "ImVector_T*"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "templated": true
+      }
+    },
+    {
+      "symbol": "igAcceptDragDropPayload",
+      "cimgui_name": "igAcceptDragDropPayload",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "AcceptDragDropPayload",
+      "c_arguments": "(const char*type,ImGuiDragDropFlags flags)",
+      "signature": "(const char*,ImGuiDragDropFlags)",
+      "return_type": "const ImGuiPayload*",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiDragDropFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igAlignTextToFramePadding",
+      "cimgui_name": "igAlignTextToFramePadding",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "AlignTextToFramePadding",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igArrowButton",
+      "cimgui_name": "igArrowButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ArrowButton",
+      "c_arguments": "(const char*str_id,ImGuiDir dir)",
+      "signature": "(const char*,ImGuiDir)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "dir",
+          "type": "ImGuiDir"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBegin",
+      "cimgui_name": "igBegin",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Begin",
+      "c_arguments": "(const char*name,bool*p_open,ImGuiWindowFlags flags)",
+      "signature": "(const char*,bool*,ImGuiWindowFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "const char*"
+        },
+        {
+          "name": "p_open",
+          "type": "bool*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiWindowFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginChild_ID",
+      "cimgui_name": "igBeginChild",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginChild",
+      "c_arguments": "(ImGuiID id,const ImVec2_c size,ImGuiChildFlags child_flags,ImGuiWindowFlags window_flags)",
+      "signature": "(ImGuiID,const ImVec2,ImGuiChildFlags,ImGuiWindowFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "id",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "child_flags",
+          "type": "ImGuiChildFlags"
+        },
+        {
+          "name": "window_flags",
+          "type": "ImGuiWindowFlags"
+        }
+      ],
+      "defaults": {
+        "child_flags": "0",
+        "size": "ImVec2(0,0)",
+        "window_flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginChild_Str",
+      "cimgui_name": "igBeginChild",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginChild",
+      "c_arguments": "(const char*str_id,const ImVec2_c size,ImGuiChildFlags child_flags,ImGuiWindowFlags window_flags)",
+      "signature": "(const char*,const ImVec2,ImGuiChildFlags,ImGuiWindowFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "child_flags",
+          "type": "ImGuiChildFlags"
+        },
+        {
+          "name": "window_flags",
+          "type": "ImGuiWindowFlags"
+        }
+      ],
+      "defaults": {
+        "child_flags": "0",
+        "size": "ImVec2(0,0)",
+        "window_flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginCombo",
+      "cimgui_name": "igBeginCombo",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginCombo",
+      "c_arguments": "(const char*label,const char*preview_value,ImGuiComboFlags flags)",
+      "signature": "(const char*,const char*,ImGuiComboFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "preview_value",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiComboFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginDisabled",
+      "cimgui_name": "igBeginDisabled",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginDisabled",
+      "c_arguments": "(bool disabled)",
+      "signature": "(bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "disabled",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "disabled": "true"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginDragDropSource",
+      "cimgui_name": "igBeginDragDropSource",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginDragDropSource",
+      "c_arguments": "(ImGuiDragDropFlags flags)",
+      "signature": "(ImGuiDragDropFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "flags",
+          "type": "ImGuiDragDropFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginDragDropTarget",
+      "cimgui_name": "igBeginDragDropTarget",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginDragDropTarget",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginGroup",
+      "cimgui_name": "igBeginGroup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginGroup",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginItemTooltip",
+      "cimgui_name": "igBeginItemTooltip",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginItemTooltip",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginListBox",
+      "cimgui_name": "igBeginListBox",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginListBox",
+      "c_arguments": "(const char*label,const ImVec2_c size)",
+      "signature": "(const char*,const ImVec2)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {
+        "size": "ImVec2(0,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginMainMenuBar",
+      "cimgui_name": "igBeginMainMenuBar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginMainMenuBar",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginMenu",
+      "cimgui_name": "igBeginMenu",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginMenu",
+      "c_arguments": "(const char*label,bool enabled)",
+      "signature": "(const char*,bool)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "enabled": "true"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginMenuBar",
+      "cimgui_name": "igBeginMenuBar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginMenuBar",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginMultiSelect",
+      "cimgui_name": "igBeginMultiSelect",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginMultiSelect",
+      "c_arguments": "(ImGuiMultiSelectFlags flags,int selection_size,int items_count)",
+      "signature": "(ImGuiMultiSelectFlags,int,int)",
+      "return_type": "ImGuiMultiSelectIO*",
+      "arguments": [
+        {
+          "name": "flags",
+          "type": "ImGuiMultiSelectFlags"
+        },
+        {
+          "name": "selection_size",
+          "type": "int"
+        },
+        {
+          "name": "items_count",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "items_count": "-1",
+        "selection_size": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginPopup",
+      "cimgui_name": "igBeginPopup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginPopup",
+      "c_arguments": "(const char*str_id,ImGuiWindowFlags flags)",
+      "signature": "(const char*,ImGuiWindowFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiWindowFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginPopupContextItem",
+      "cimgui_name": "igBeginPopupContextItem",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginPopupContextItem",
+      "c_arguments": "(const char*str_id,ImGuiPopupFlags popup_flags)",
+      "signature": "(const char*,ImGuiPopupFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "popup_flags",
+          "type": "ImGuiPopupFlags"
+        }
+      ],
+      "defaults": {
+        "popup_flags": "0",
+        "str_id": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginPopupContextVoid",
+      "cimgui_name": "igBeginPopupContextVoid",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginPopupContextVoid",
+      "c_arguments": "(const char*str_id,ImGuiPopupFlags popup_flags)",
+      "signature": "(const char*,ImGuiPopupFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "popup_flags",
+          "type": "ImGuiPopupFlags"
+        }
+      ],
+      "defaults": {
+        "popup_flags": "0",
+        "str_id": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginPopupContextWindow",
+      "cimgui_name": "igBeginPopupContextWindow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginPopupContextWindow",
+      "c_arguments": "(const char*str_id,ImGuiPopupFlags popup_flags)",
+      "signature": "(const char*,ImGuiPopupFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "popup_flags",
+          "type": "ImGuiPopupFlags"
+        }
+      ],
+      "defaults": {
+        "popup_flags": "0",
+        "str_id": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginPopupModal",
+      "cimgui_name": "igBeginPopupModal",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginPopupModal",
+      "c_arguments": "(const char*name,bool*p_open,ImGuiWindowFlags flags)",
+      "signature": "(const char*,bool*,ImGuiWindowFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "const char*"
+        },
+        {
+          "name": "p_open",
+          "type": "bool*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiWindowFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginTabBar",
+      "cimgui_name": "igBeginTabBar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginTabBar",
+      "c_arguments": "(const char*str_id,ImGuiTabBarFlags flags)",
+      "signature": "(const char*,ImGuiTabBarFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTabBarFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginTabItem",
+      "cimgui_name": "igBeginTabItem",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginTabItem",
+      "c_arguments": "(const char*label,bool*p_open,ImGuiTabItemFlags flags)",
+      "signature": "(const char*,bool*,ImGuiTabItemFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "p_open",
+          "type": "bool*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTabItemFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginTable",
+      "cimgui_name": "igBeginTable",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginTable",
+      "c_arguments": "(const char*str_id,int columns,ImGuiTableFlags flags,const ImVec2_c outer_size,float inner_width)",
+      "signature": "(const char*,int,ImGuiTableFlags,const ImVec2,float)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "columns",
+          "type": "int"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTableFlags"
+        },
+        {
+          "name": "outer_size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "inner_width",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "inner_width": "0.0f",
+        "outer_size": "ImVec2(0.0f,0.0f)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igBeginTooltip",
+      "cimgui_name": "igBeginTooltip",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BeginTooltip",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBullet",
+      "cimgui_name": "igBullet",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Bullet",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igBulletText",
+      "cimgui_name": "igBulletText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BulletText",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igBulletTextV",
+      "cimgui_name": "igBulletTextV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "BulletTextV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igButton",
+      "cimgui_name": "igButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Button",
+      "c_arguments": "(const char*label,const ImVec2_c size)",
+      "signature": "(const char*,const ImVec2)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {
+        "size": "ImVec2(0,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igCalcItemWidth",
+      "cimgui_name": "igCalcItemWidth",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CalcItemWidth",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igCalcTextSize",
+      "cimgui_name": "igCalcTextSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CalcTextSize",
+      "c_arguments": "(const char*text,const char*text_end,bool hide_text_after_double_hash,float wrap_width)",
+      "signature": "(const char*,const char*,bool,float)",
+      "return_type": "ImVec2_c",
+      "arguments": [
+        {
+          "name": "text",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        },
+        {
+          "name": "hide_text_after_double_hash",
+          "type": "bool"
+        },
+        {
+          "name": "wrap_width",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "hide_text_after_double_hash": "false",
+        "text_end": "NULL",
+        "wrap_width": "-1.0f"
+      },
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igCheckbox",
+      "cimgui_name": "igCheckbox",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Checkbox",
+      "c_arguments": "(const char*label,bool*v)",
+      "signature": "(const char*,bool*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "bool*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igCheckboxFlags_IntPtr",
+      "cimgui_name": "igCheckboxFlags",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CheckboxFlags",
+      "c_arguments": "(const char*label,int*flags,int flags_value)",
+      "signature": "(const char*,int*,int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "int*"
+        },
+        {
+          "name": "flags_value",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igCheckboxFlags_UintPtr",
+      "cimgui_name": "igCheckboxFlags",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CheckboxFlags",
+      "c_arguments": "(const char*label,unsigned int*flags,unsigned int flags_value)",
+      "signature": "(const char*,unsigned int*,unsigned int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "unsigned int*"
+        },
+        {
+          "name": "flags_value",
+          "type": "unsigned int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igCloseCurrentPopup",
+      "cimgui_name": "igCloseCurrentPopup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CloseCurrentPopup",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igCollapsingHeader_BoolPtr",
+      "cimgui_name": "igCollapsingHeader",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CollapsingHeader",
+      "c_arguments": "(const char*label,bool*p_visible,ImGuiTreeNodeFlags flags)",
+      "signature": "(const char*,bool*,ImGuiTreeNodeFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "p_visible",
+          "type": "bool*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTreeNodeFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igCollapsingHeader_TreeNodeFlags",
+      "cimgui_name": "igCollapsingHeader",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CollapsingHeader",
+      "c_arguments": "(const char*label,ImGuiTreeNodeFlags flags)",
+      "signature": "(const char*,ImGuiTreeNodeFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTreeNodeFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igColorButton",
+      "cimgui_name": "igColorButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorButton",
+      "c_arguments": "(const char*desc_id,const ImVec4_c col,ImGuiColorEditFlags flags,const ImVec2_c size)",
+      "signature": "(const char*,const ImVec4,ImGuiColorEditFlags,const ImVec2)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "desc_id",
+          "type": "const char*"
+        },
+        {
+          "name": "col",
+          "type": "const ImVec4"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiColorEditFlags"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "size": "ImVec2(0,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igColorConvertFloat4ToU32",
+      "cimgui_name": "igColorConvertFloat4ToU32",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorConvertFloat4ToU32",
+      "c_arguments": "(const ImVec4_c in)",
+      "signature": "(const ImVec4)",
+      "return_type": "ImU32",
+      "arguments": [
+        {
+          "name": "in",
+          "type": "const ImVec4"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igColorConvertHSVtoRGB",
+      "cimgui_name": "igColorConvertHSVtoRGB",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorConvertHSVtoRGB",
+      "c_arguments": "(float h,float s,float v,float*out_r,float*out_g,float*out_b)",
+      "signature": "(float,float,float,float*,float*,float*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "h",
+          "type": "float"
+        },
+        {
+          "name": "s",
+          "type": "float"
+        },
+        {
+          "name": "v",
+          "type": "float"
+        },
+        {
+          "name": "out_r",
+          "reftoptr": true,
+          "type": "float*"
+        },
+        {
+          "name": "out_g",
+          "reftoptr": true,
+          "type": "float*"
+        },
+        {
+          "name": "out_b",
+          "reftoptr": true,
+          "type": "float*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igColorConvertRGBtoHSV",
+      "cimgui_name": "igColorConvertRGBtoHSV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorConvertRGBtoHSV",
+      "c_arguments": "(float r,float g,float b,float*out_h,float*out_s,float*out_v)",
+      "signature": "(float,float,float,float*,float*,float*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "r",
+          "type": "float"
+        },
+        {
+          "name": "g",
+          "type": "float"
+        },
+        {
+          "name": "b",
+          "type": "float"
+        },
+        {
+          "name": "out_h",
+          "reftoptr": true,
+          "type": "float*"
+        },
+        {
+          "name": "out_s",
+          "reftoptr": true,
+          "type": "float*"
+        },
+        {
+          "name": "out_v",
+          "reftoptr": true,
+          "type": "float*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igColorConvertU32ToFloat4",
+      "cimgui_name": "igColorConvertU32ToFloat4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorConvertU32ToFloat4",
+      "c_arguments": "(ImU32 in)",
+      "signature": "(ImU32)",
+      "return_type": "ImVec4_c",
+      "arguments": [
+        {
+          "name": "in",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec4",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igColorEdit3",
+      "cimgui_name": "igColorEdit3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorEdit3",
+      "c_arguments": "(const char*label,float col[3],ImGuiColorEditFlags flags)",
+      "signature": "(const char*,float[3],ImGuiColorEditFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "col",
+          "type": "float[3]"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiColorEditFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igColorEdit4",
+      "cimgui_name": "igColorEdit4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorEdit4",
+      "c_arguments": "(const char*label,float col[4],ImGuiColorEditFlags flags)",
+      "signature": "(const char*,float[4],ImGuiColorEditFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "col",
+          "type": "float[4]"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiColorEditFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igColorPicker3",
+      "cimgui_name": "igColorPicker3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorPicker3",
+      "c_arguments": "(const char*label,float col[3],ImGuiColorEditFlags flags)",
+      "signature": "(const char*,float[3],ImGuiColorEditFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "col",
+          "type": "float[3]"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiColorEditFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igColorPicker4",
+      "cimgui_name": "igColorPicker4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ColorPicker4",
+      "c_arguments": "(const char*label,float col[4],ImGuiColorEditFlags flags,const float*ref_col)",
+      "signature": "(const char*,float[4],ImGuiColorEditFlags,const float*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "col",
+          "type": "float[4]"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiColorEditFlags"
+        },
+        {
+          "name": "ref_col",
+          "type": "const float*"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "ref_col": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igColumns",
+      "cimgui_name": "igColumns",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Columns",
+      "c_arguments": "(int count,const char*id,bool borders)",
+      "signature": "(int,const char*,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "count",
+          "type": "int"
+        },
+        {
+          "name": "id",
+          "type": "const char*"
+        },
+        {
+          "name": "borders",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "borders": "true",
+        "count": "1",
+        "id": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igCombo_FnStrPtr",
+      "cimgui_name": "igCombo",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Combo",
+      "c_arguments": "(const char*label,int*current_item,const char*(*getter)(void*user_data,int idx),void*user_data,int items_count,int popup_max_height_in_items)",
+      "signature": "(const char*,int*,const char*(*)(void*,int),void*,int,int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "current_item",
+          "type": "int*"
+        },
+        {
+          "name": "getter",
+          "ret": "const char*",
+          "signature": "(void*user_data,int idx)",
+          "type": "const char*(*)(void*user_data,int idx)"
+        },
+        {
+          "name": "user_data",
+          "type": "void*"
+        },
+        {
+          "name": "items_count",
+          "type": "int"
+        },
+        {
+          "name": "popup_max_height_in_items",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "popup_max_height_in_items": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igCombo_Str",
+      "cimgui_name": "igCombo",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Combo",
+      "c_arguments": "(const char*label,int*current_item,const char*items_separated_by_zeros,int popup_max_height_in_items)",
+      "signature": "(const char*,int*,const char*,int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "current_item",
+          "type": "int*"
+        },
+        {
+          "name": "items_separated_by_zeros",
+          "type": "const char*"
+        },
+        {
+          "name": "popup_max_height_in_items",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "popup_max_height_in_items": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igCombo_Str_arr",
+      "cimgui_name": "igCombo",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Combo",
+      "c_arguments": "(const char*label,int*current_item,const char*const items[],int items_count,int popup_max_height_in_items)",
+      "signature": "(const char*,int*,const char*const[],int,int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "current_item",
+          "type": "int*"
+        },
+        {
+          "name": "items",
+          "type": "const char*const[]"
+        },
+        {
+          "name": "items_count",
+          "type": "int"
+        },
+        {
+          "name": "popup_max_height_in_items",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "popup_max_height_in_items": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igCreateContext",
+      "cimgui_name": "igCreateContext",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "CreateContext",
+      "c_arguments": "(ImFontAtlas*shared_font_atlas)",
+      "signature": "(ImFontAtlas*)",
+      "return_type": "ImGuiContext*",
+      "arguments": [
+        {
+          "name": "shared_font_atlas",
+          "type": "ImFontAtlas*"
+        }
+      ],
+      "defaults": {
+        "shared_font_atlas": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDebugCheckVersionAndDataLayout",
+      "cimgui_name": "igDebugCheckVersionAndDataLayout",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DebugCheckVersionAndDataLayout",
+      "c_arguments": "(const char*version_str,size_t sz_io,size_t sz_style,size_t sz_vec2,size_t sz_vec4,size_t sz_drawvert,size_t sz_drawidx)",
+      "signature": "(const char*,size_t,size_t,size_t,size_t,size_t,size_t)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "version_str",
+          "type": "const char*"
+        },
+        {
+          "name": "sz_io",
+          "type": "size_t"
+        },
+        {
+          "name": "sz_style",
+          "type": "size_t"
+        },
+        {
+          "name": "sz_vec2",
+          "type": "size_t"
+        },
+        {
+          "name": "sz_vec4",
+          "type": "size_t"
+        },
+        {
+          "name": "sz_drawvert",
+          "type": "size_t"
+        },
+        {
+          "name": "sz_drawidx",
+          "type": "size_t"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igDebugFlashStyleColor",
+      "cimgui_name": "igDebugFlashStyleColor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DebugFlashStyleColor",
+      "c_arguments": "(ImGuiCol idx)",
+      "signature": "(ImGuiCol)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiCol"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igDebugLog",
+      "cimgui_name": "igDebugLog",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DebugLog",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igDebugLogV",
+      "cimgui_name": "igDebugLogV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DebugLogV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igDebugStartItemPicker",
+      "cimgui_name": "igDebugStartItemPicker",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DebugStartItemPicker",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igDebugTextEncoding",
+      "cimgui_name": "igDebugTextEncoding",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DebugTextEncoding",
+      "c_arguments": "(const char*text)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "text",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igDestroyContext",
+      "cimgui_name": "igDestroyContext",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DestroyContext",
+      "c_arguments": "(ImGuiContext*ctx)",
+      "signature": "(ImGuiContext*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ctx",
+          "type": "ImGuiContext*"
+        }
+      ],
+      "defaults": {
+        "ctx": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDestroyPlatformWindows",
+      "cimgui_name": "igDestroyPlatformWindows",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DestroyPlatformWindows",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igDockSpace",
+      "cimgui_name": "igDockSpace",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DockSpace",
+      "c_arguments": "(ImGuiID dockspace_id,const ImVec2_c size,ImGuiDockNodeFlags flags,const ImGuiWindowClass*window_class)",
+      "signature": "(ImGuiID,const ImVec2,ImGuiDockNodeFlags,const ImGuiWindowClass*)",
+      "return_type": "ImGuiID",
+      "arguments": [
+        {
+          "name": "dockspace_id",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiDockNodeFlags"
+        },
+        {
+          "name": "window_class",
+          "type": "const ImGuiWindowClass*"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "size": "ImVec2(0,0)",
+        "window_class": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDockSpaceOverViewport",
+      "cimgui_name": "igDockSpaceOverViewport",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DockSpaceOverViewport",
+      "c_arguments": "(ImGuiID dockspace_id,const ImGuiViewport*viewport,ImGuiDockNodeFlags flags,const ImGuiWindowClass*window_class)",
+      "signature": "(ImGuiID,const ImGuiViewport*,ImGuiDockNodeFlags,const ImGuiWindowClass*)",
+      "return_type": "ImGuiID",
+      "arguments": [
+        {
+          "name": "dockspace_id",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "viewport",
+          "type": "const ImGuiViewport*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiDockNodeFlags"
+        },
+        {
+          "name": "window_class",
+          "type": "const ImGuiWindowClass*"
+        }
+      ],
+      "defaults": {
+        "dockspace_id": "0",
+        "flags": "0",
+        "viewport": "NULL",
+        "window_class": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragFloat",
+      "cimgui_name": "igDragFloat",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragFloat",
+      "c_arguments": "(const char*label,float*v,float v_speed,float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float*,float,float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float*"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\"",
+        "v_max": "0.0f",
+        "v_min": "0.0f",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragFloat2",
+      "cimgui_name": "igDragFloat2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragFloat2",
+      "c_arguments": "(const char*label,float v[2],float v_speed,float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float[2],float,float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[2]"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\"",
+        "v_max": "0.0f",
+        "v_min": "0.0f",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragFloat3",
+      "cimgui_name": "igDragFloat3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragFloat3",
+      "c_arguments": "(const char*label,float v[3],float v_speed,float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float[3],float,float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[3]"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\"",
+        "v_max": "0.0f",
+        "v_min": "0.0f",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragFloat4",
+      "cimgui_name": "igDragFloat4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragFloat4",
+      "c_arguments": "(const char*label,float v[4],float v_speed,float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float[4],float,float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[4]"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\"",
+        "v_max": "0.0f",
+        "v_min": "0.0f",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragFloatRange2",
+      "cimgui_name": "igDragFloatRange2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragFloatRange2",
+      "c_arguments": "(const char*label,float*v_current_min,float*v_current_max,float v_speed,float v_min,float v_max,const char*format,const char*format_max,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float*,float*,float,float,float,const char*,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v_current_min",
+          "type": "float*"
+        },
+        {
+          "name": "v_current_max",
+          "type": "float*"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "format_max",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\"",
+        "format_max": "NULL",
+        "v_max": "0.0f",
+        "v_min": "0.0f",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragInt",
+      "cimgui_name": "igDragInt",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragInt",
+      "c_arguments": "(const char*label,int*v,float v_speed,int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int*,float,int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int*"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\"",
+        "v_max": "0",
+        "v_min": "0",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragInt2",
+      "cimgui_name": "igDragInt2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragInt2",
+      "c_arguments": "(const char*label,int v[2],float v_speed,int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int[2],float,int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[2]"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\"",
+        "v_max": "0",
+        "v_min": "0",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragInt3",
+      "cimgui_name": "igDragInt3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragInt3",
+      "c_arguments": "(const char*label,int v[3],float v_speed,int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int[3],float,int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[3]"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\"",
+        "v_max": "0",
+        "v_min": "0",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragInt4",
+      "cimgui_name": "igDragInt4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragInt4",
+      "c_arguments": "(const char*label,int v[4],float v_speed,int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int[4],float,int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[4]"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\"",
+        "v_max": "0",
+        "v_min": "0",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragIntRange2",
+      "cimgui_name": "igDragIntRange2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragIntRange2",
+      "c_arguments": "(const char*label,int*v_current_min,int*v_current_max,float v_speed,int v_min,int v_max,const char*format,const char*format_max,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int*,int*,float,int,int,const char*,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v_current_min",
+          "type": "int*"
+        },
+        {
+          "name": "v_current_max",
+          "type": "int*"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "format_max",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\"",
+        "format_max": "NULL",
+        "v_max": "0",
+        "v_min": "0",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragScalar",
+      "cimgui_name": "igDragScalar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragScalar",
+      "c_arguments": "(const char*label,ImGuiDataType data_type,void*p_data,float v_speed,const void*p_min,const void*p_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,ImGuiDataType,void*,float,const void*,const void*,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "data_type",
+          "type": "ImGuiDataType"
+        },
+        {
+          "name": "p_data",
+          "type": "void*"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "p_min",
+          "type": "const void*"
+        },
+        {
+          "name": "p_max",
+          "type": "const void*"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "NULL",
+        "p_max": "NULL",
+        "p_min": "NULL",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDragScalarN",
+      "cimgui_name": "igDragScalarN",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "DragScalarN",
+      "c_arguments": "(const char*label,ImGuiDataType data_type,void*p_data,int components,float v_speed,const void*p_min,const void*p_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,ImGuiDataType,void*,int,float,const void*,const void*,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "data_type",
+          "type": "ImGuiDataType"
+        },
+        {
+          "name": "p_data",
+          "type": "void*"
+        },
+        {
+          "name": "components",
+          "type": "int"
+        },
+        {
+          "name": "v_speed",
+          "type": "float"
+        },
+        {
+          "name": "p_min",
+          "type": "const void*"
+        },
+        {
+          "name": "p_max",
+          "type": "const void*"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "NULL",
+        "p_max": "NULL",
+        "p_min": "NULL",
+        "v_speed": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igDummy",
+      "cimgui_name": "igDummy",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Dummy",
+      "c_arguments": "(const ImVec2_c size)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEnd",
+      "cimgui_name": "igEnd",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "End",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndChild",
+      "cimgui_name": "igEndChild",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndChild",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndCombo",
+      "cimgui_name": "igEndCombo",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndCombo",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndDisabled",
+      "cimgui_name": "igEndDisabled",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndDisabled",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndDragDropSource",
+      "cimgui_name": "igEndDragDropSource",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndDragDropSource",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndDragDropTarget",
+      "cimgui_name": "igEndDragDropTarget",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndDragDropTarget",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndFrame",
+      "cimgui_name": "igEndFrame",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndFrame",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndGroup",
+      "cimgui_name": "igEndGroup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndGroup",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndListBox",
+      "cimgui_name": "igEndListBox",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndListBox",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndMainMenuBar",
+      "cimgui_name": "igEndMainMenuBar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndMainMenuBar",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndMenu",
+      "cimgui_name": "igEndMenu",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndMenu",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndMenuBar",
+      "cimgui_name": "igEndMenuBar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndMenuBar",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndMultiSelect",
+      "cimgui_name": "igEndMultiSelect",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndMultiSelect",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiMultiSelectIO*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndPopup",
+      "cimgui_name": "igEndPopup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndPopup",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndTabBar",
+      "cimgui_name": "igEndTabBar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndTabBar",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndTabItem",
+      "cimgui_name": "igEndTabItem",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndTabItem",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndTable",
+      "cimgui_name": "igEndTable",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndTable",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igEndTooltip",
+      "cimgui_name": "igEndTooltip",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "EndTooltip",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igFindViewportByID",
+      "cimgui_name": "igFindViewportByID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "FindViewportByID",
+      "c_arguments": "(ImGuiID viewport_id)",
+      "signature": "(ImGuiID)",
+      "return_type": "ImGuiViewport*",
+      "arguments": [
+        {
+          "name": "viewport_id",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igFindViewportByPlatformHandle",
+      "cimgui_name": "igFindViewportByPlatformHandle",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "FindViewportByPlatformHandle",
+      "c_arguments": "(void*platform_handle)",
+      "signature": "(void*)",
+      "return_type": "ImGuiViewport*",
+      "arguments": [
+        {
+          "name": "platform_handle",
+          "type": "void*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetAllocatorFunctions",
+      "cimgui_name": "igGetAllocatorFunctions",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetAllocatorFunctions",
+      "c_arguments": "(ImGuiMemAllocFunc*p_alloc_func,ImGuiMemFreeFunc*p_free_func,void**p_user_data)",
+      "signature": "(ImGuiMemAllocFunc*,ImGuiMemFreeFunc*,void**)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "p_alloc_func",
+          "type": "ImGuiMemAllocFunc*"
+        },
+        {
+          "name": "p_free_func",
+          "type": "ImGuiMemFreeFunc*"
+        },
+        {
+          "name": "p_user_data",
+          "type": "void**"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetBackgroundDrawList",
+      "cimgui_name": "igGetBackgroundDrawList",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetBackgroundDrawList",
+      "c_arguments": "(ImGuiViewport*viewport)",
+      "signature": "(ImGuiViewport*)",
+      "return_type": "ImDrawList*",
+      "arguments": [
+        {
+          "name": "viewport",
+          "type": "ImGuiViewport*"
+        }
+      ],
+      "defaults": {
+        "viewport": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igGetClipboardText",
+      "cimgui_name": "igGetClipboardText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetClipboardText",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "const char*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetColorU32_Col",
+      "cimgui_name": "igGetColorU32",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetColorU32",
+      "c_arguments": "(ImGuiCol idx,float alpha_mul)",
+      "signature": "(ImGuiCol,float)",
+      "return_type": "ImU32",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiCol"
+        },
+        {
+          "name": "alpha_mul",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "alpha_mul": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igGetColorU32_U32",
+      "cimgui_name": "igGetColorU32",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetColorU32",
+      "c_arguments": "(ImU32 col,float alpha_mul)",
+      "signature": "(ImU32,float)",
+      "return_type": "ImU32",
+      "arguments": [
+        {
+          "name": "col",
+          "type": "ImU32"
+        },
+        {
+          "name": "alpha_mul",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "alpha_mul": "1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igGetColorU32_Vec4",
+      "cimgui_name": "igGetColorU32",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetColorU32",
+      "c_arguments": "(const ImVec4_c col)",
+      "signature": "(const ImVec4)",
+      "return_type": "ImU32",
+      "arguments": [
+        {
+          "name": "col",
+          "type": "const ImVec4"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetColumnIndex",
+      "cimgui_name": "igGetColumnIndex",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetColumnIndex",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "int",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetColumnOffset",
+      "cimgui_name": "igGetColumnOffset",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetColumnOffset",
+      "c_arguments": "(int column_index)",
+      "signature": "(int)",
+      "return_type": "float",
+      "arguments": [
+        {
+          "name": "column_index",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "column_index": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igGetColumnWidth",
+      "cimgui_name": "igGetColumnWidth",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetColumnWidth",
+      "c_arguments": "(int column_index)",
+      "signature": "(int)",
+      "return_type": "float",
+      "arguments": [
+        {
+          "name": "column_index",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "column_index": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igGetColumnsCount",
+      "cimgui_name": "igGetColumnsCount",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetColumnsCount",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "int",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetContentRegionAvail",
+      "cimgui_name": "igGetContentRegionAvail",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetContentRegionAvail",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetCurrentContext",
+      "cimgui_name": "igGetCurrentContext",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetCurrentContext",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiContext*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetCursorPos",
+      "cimgui_name": "igGetCursorPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetCursorPos",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetCursorPosX",
+      "cimgui_name": "igGetCursorPosX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetCursorPosX",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetCursorPosY",
+      "cimgui_name": "igGetCursorPosY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetCursorPosY",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetCursorScreenPos",
+      "cimgui_name": "igGetCursorScreenPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetCursorScreenPos",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetCursorStartPos",
+      "cimgui_name": "igGetCursorStartPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetCursorStartPos",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetDragDropPayload",
+      "cimgui_name": "igGetDragDropPayload",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetDragDropPayload",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "const ImGuiPayload*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetDrawData",
+      "cimgui_name": "igGetDrawData",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetDrawData",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImDrawData*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetDrawListSharedData",
+      "cimgui_name": "igGetDrawListSharedData",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetDrawListSharedData",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImDrawListSharedData*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetFont",
+      "cimgui_name": "igGetFont",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetFont",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImFont*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetFontBaked",
+      "cimgui_name": "igGetFontBaked",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetFontBaked",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImFontBaked*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetFontSize",
+      "cimgui_name": "igGetFontSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetFontSize",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetFontTexUvWhitePixel",
+      "cimgui_name": "igGetFontTexUvWhitePixel",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetFontTexUvWhitePixel",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetForegroundDrawList_ViewportPtr",
+      "cimgui_name": "igGetForegroundDrawList",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetForegroundDrawList",
+      "c_arguments": "(ImGuiViewport*viewport)",
+      "signature": "(ImGuiViewport*)",
+      "return_type": "ImDrawList*",
+      "arguments": [
+        {
+          "name": "viewport",
+          "type": "ImGuiViewport*"
+        }
+      ],
+      "defaults": {
+        "viewport": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igGetFrameCount",
+      "cimgui_name": "igGetFrameCount",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetFrameCount",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "int",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetFrameHeight",
+      "cimgui_name": "igGetFrameHeight",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetFrameHeight",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetFrameHeightWithSpacing",
+      "cimgui_name": "igGetFrameHeightWithSpacing",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetFrameHeightWithSpacing",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetID_Int",
+      "cimgui_name": "igGetID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetID",
+      "c_arguments": "(int int_id)",
+      "signature": "(int)",
+      "return_type": "ImGuiID",
+      "arguments": [
+        {
+          "name": "int_id",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetID_Ptr",
+      "cimgui_name": "igGetID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetID",
+      "c_arguments": "(const void*ptr_id)",
+      "signature": "(const void*)",
+      "return_type": "ImGuiID",
+      "arguments": [
+        {
+          "name": "ptr_id",
+          "type": "const void*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetID_Str",
+      "cimgui_name": "igGetID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetID",
+      "c_arguments": "(const char*str_id)",
+      "signature": "(const char*)",
+      "return_type": "ImGuiID",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetID_StrStr",
+      "cimgui_name": "igGetID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetID",
+      "c_arguments": "(const char*str_id_begin,const char*str_id_end)",
+      "signature": "(const char*,const char*)",
+      "return_type": "ImGuiID",
+      "arguments": [
+        {
+          "name": "str_id_begin",
+          "type": "const char*"
+        },
+        {
+          "name": "str_id_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetIO_Nil",
+      "cimgui_name": "igGetIO",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetIO",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiIO*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "retref": "&"
+      }
+    },
+    {
+      "symbol": "igGetItemFlags",
+      "cimgui_name": "igGetItemFlags",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetItemFlags",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiItemFlags",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetItemID",
+      "cimgui_name": "igGetItemID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetItemID",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiID",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetItemRectMax",
+      "cimgui_name": "igGetItemRectMax",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetItemRectMax",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetItemRectMin",
+      "cimgui_name": "igGetItemRectMin",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetItemRectMin",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetItemRectSize",
+      "cimgui_name": "igGetItemRectSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetItemRectSize",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetKeyName",
+      "cimgui_name": "igGetKeyName",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetKeyName",
+      "c_arguments": "(ImGuiKey key)",
+      "signature": "(ImGuiKey)",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetKeyPressedAmount",
+      "cimgui_name": "igGetKeyPressedAmount",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetKeyPressedAmount",
+      "c_arguments": "(ImGuiKey key,float repeat_delay,float rate)",
+      "signature": "(ImGuiKey,float,float)",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        },
+        {
+          "name": "repeat_delay",
+          "type": "float"
+        },
+        {
+          "name": "rate",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetMainViewport",
+      "cimgui_name": "igGetMainViewport",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetMainViewport",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiViewport*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetMouseClickedCount",
+      "cimgui_name": "igGetMouseClickedCount",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetMouseClickedCount",
+      "c_arguments": "(ImGuiMouseButton button)",
+      "signature": "(ImGuiMouseButton)",
+      "return_type": "int",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetMouseCursor",
+      "cimgui_name": "igGetMouseCursor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetMouseCursor",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiMouseCursor",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetMouseDragDelta",
+      "cimgui_name": "igGetMouseDragDelta",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetMouseDragDelta",
+      "c_arguments": "(ImGuiMouseButton button,float lock_threshold)",
+      "signature": "(ImGuiMouseButton,float)",
+      "return_type": "ImVec2_c",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        },
+        {
+          "name": "lock_threshold",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "button": "0",
+        "lock_threshold": "-1.0f"
+      },
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetMousePos",
+      "cimgui_name": "igGetMousePos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetMousePos",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetMousePosOnOpeningCurrentPopup",
+      "cimgui_name": "igGetMousePosOnOpeningCurrentPopup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetMousePosOnOpeningCurrentPopup",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetPlatformIO_Nil",
+      "cimgui_name": "igGetPlatformIO",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetPlatformIO",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiPlatformIO*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "retref": "&"
+      }
+    },
+    {
+      "symbol": "igGetScrollMaxX",
+      "cimgui_name": "igGetScrollMaxX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetScrollMaxX",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetScrollMaxY",
+      "cimgui_name": "igGetScrollMaxY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetScrollMaxY",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetScrollX",
+      "cimgui_name": "igGetScrollX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetScrollX",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetScrollY",
+      "cimgui_name": "igGetScrollY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetScrollY",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetStateStorage",
+      "cimgui_name": "igGetStateStorage",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetStateStorage",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiStorage*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetStyle",
+      "cimgui_name": "igGetStyle",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetStyle",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiStyle*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "retref": "&"
+      }
+    },
+    {
+      "symbol": "igGetStyleColorName",
+      "cimgui_name": "igGetStyleColorName",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetStyleColorName",
+      "c_arguments": "(ImGuiCol idx)",
+      "signature": "(ImGuiCol)",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiCol"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetStyleColorVec4",
+      "cimgui_name": "igGetStyleColorVec4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetStyleColorVec4",
+      "c_arguments": "(ImGuiCol idx)",
+      "signature": "(ImGuiCol)",
+      "return_type": "const ImVec4_c*",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiCol"
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "nonUDT": 2,
+        "retref": "&"
+      }
+    },
+    {
+      "symbol": "igGetTextLineHeight",
+      "cimgui_name": "igGetTextLineHeight",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetTextLineHeight",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetTextLineHeightWithSpacing",
+      "cimgui_name": "igGetTextLineHeightWithSpacing",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetTextLineHeightWithSpacing",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetTime",
+      "cimgui_name": "igGetTime",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetTime",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "double",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetTreeNodeToLabelSpacing",
+      "cimgui_name": "igGetTreeNodeToLabelSpacing",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetTreeNodeToLabelSpacing",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetVersion",
+      "cimgui_name": "igGetVersion",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetVersion",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "const char*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetWindowDockID",
+      "cimgui_name": "igGetWindowDockID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowDockID",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiID",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetWindowDpiScale",
+      "cimgui_name": "igGetWindowDpiScale",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowDpiScale",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetWindowDrawList",
+      "cimgui_name": "igGetWindowDrawList",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowDrawList",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImDrawList*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetWindowHeight",
+      "cimgui_name": "igGetWindowHeight",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowHeight",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetWindowPos",
+      "cimgui_name": "igGetWindowPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowPos",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetWindowSize",
+      "cimgui_name": "igGetWindowSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowSize",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImVec2_c",
+      "arguments": [],
+      "defaults": {},
+      "traits": {
+        "conv": "ImVec2",
+        "nonUDT": 1
+      }
+    },
+    {
+      "symbol": "igGetWindowViewport",
+      "cimgui_name": "igGetWindowViewport",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowViewport",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiViewport*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igGetWindowWidth",
+      "cimgui_name": "igGetWindowWidth",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "GetWindowWidth",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "float",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igImage",
+      "cimgui_name": "igImage",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Image",
+      "c_arguments": "(ImTextureRef_c tex_ref,const ImVec2_c image_size,const ImVec2_c uv0,const ImVec2_c uv1)",
+      "signature": "(ImTextureRef,const ImVec2,const ImVec2,const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        },
+        {
+          "name": "image_size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv0",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv1",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {
+        "uv0": "ImVec2(0,0)",
+        "uv1": "ImVec2(1,1)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igImageButton",
+      "cimgui_name": "igImageButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ImageButton",
+      "c_arguments": "(const char*str_id,ImTextureRef_c tex_ref,const ImVec2_c image_size,const ImVec2_c uv0,const ImVec2_c uv1,const ImVec4_c bg_col,const ImVec4_c tint_col)",
+      "signature": "(const char*,ImTextureRef,const ImVec2,const ImVec2,const ImVec2,const ImVec4,const ImVec4)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        },
+        {
+          "name": "image_size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv0",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "bg_col",
+          "type": "const ImVec4"
+        },
+        {
+          "name": "tint_col",
+          "type": "const ImVec4"
+        }
+      ],
+      "defaults": {
+        "bg_col": "ImVec4(0,0,0,0)",
+        "tint_col": "ImVec4(1,1,1,1)",
+        "uv0": "ImVec2(0,0)",
+        "uv1": "ImVec2(1,1)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igImageWithBg",
+      "cimgui_name": "igImageWithBg",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ImageWithBg",
+      "c_arguments": "(ImTextureRef_c tex_ref,const ImVec2_c image_size,const ImVec2_c uv0,const ImVec2_c uv1,const ImVec4_c bg_col,const ImVec4_c tint_col)",
+      "signature": "(ImTextureRef,const ImVec2,const ImVec2,const ImVec2,const ImVec4,const ImVec4)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "tex_ref",
+          "type": "ImTextureRef"
+        },
+        {
+          "name": "image_size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv0",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "uv1",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "bg_col",
+          "type": "const ImVec4"
+        },
+        {
+          "name": "tint_col",
+          "type": "const ImVec4"
+        }
+      ],
+      "defaults": {
+        "bg_col": "ImVec4(0,0,0,0)",
+        "tint_col": "ImVec4(1,1,1,1)",
+        "uv0": "ImVec2(0,0)",
+        "uv1": "ImVec2(1,1)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIndent",
+      "cimgui_name": "igIndent",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Indent",
+      "c_arguments": "(float indent_w)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "indent_w",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "indent_w": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputDouble",
+      "cimgui_name": "igInputDouble",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputDouble",
+      "c_arguments": "(const char*label,double*v,double step,double step_fast,const char*format,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,double*,double,double,const char*,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "double*"
+        },
+        {
+          "name": "step",
+          "type": "double"
+        },
+        {
+          "name": "step_fast",
+          "type": "double"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.6f\"",
+        "step": "0.0",
+        "step_fast": "0.0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputFloat",
+      "cimgui_name": "igInputFloat",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputFloat",
+      "c_arguments": "(const char*label,float*v,float step,float step_fast,const char*format,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,float*,float,float,const char*,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float*"
+        },
+        {
+          "name": "step",
+          "type": "float"
+        },
+        {
+          "name": "step_fast",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\"",
+        "step": "0.0f",
+        "step_fast": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputFloat2",
+      "cimgui_name": "igInputFloat2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputFloat2",
+      "c_arguments": "(const char*label,float v[2],const char*format,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,float[2],const char*,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[2]"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputFloat3",
+      "cimgui_name": "igInputFloat3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputFloat3",
+      "c_arguments": "(const char*label,float v[3],const char*format,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,float[3],const char*,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[3]"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputFloat4",
+      "cimgui_name": "igInputFloat4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputFloat4",
+      "c_arguments": "(const char*label,float v[4],const char*format,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,float[4],const char*,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[4]"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputInt",
+      "cimgui_name": "igInputInt",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputInt",
+      "c_arguments": "(const char*label,int*v,int step,int step_fast,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,int*,int,int,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int*"
+        },
+        {
+          "name": "step",
+          "type": "int"
+        },
+        {
+          "name": "step_fast",
+          "type": "int"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "step": "1",
+        "step_fast": "100"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputInt2",
+      "cimgui_name": "igInputInt2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputInt2",
+      "c_arguments": "(const char*label,int v[2],ImGuiInputTextFlags flags)",
+      "signature": "(const char*,int[2],ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[2]"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputInt3",
+      "cimgui_name": "igInputInt3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputInt3",
+      "c_arguments": "(const char*label,int v[3],ImGuiInputTextFlags flags)",
+      "signature": "(const char*,int[3],ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[3]"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputInt4",
+      "cimgui_name": "igInputInt4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputInt4",
+      "c_arguments": "(const char*label,int v[4],ImGuiInputTextFlags flags)",
+      "signature": "(const char*,int[4],ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[4]"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputScalar",
+      "cimgui_name": "igInputScalar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputScalar",
+      "c_arguments": "(const char*label,ImGuiDataType data_type,void*p_data,const void*p_step,const void*p_step_fast,const char*format,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,ImGuiDataType,void*,const void*,const void*,const char*,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "data_type",
+          "type": "ImGuiDataType"
+        },
+        {
+          "name": "p_data",
+          "type": "void*"
+        },
+        {
+          "name": "p_step",
+          "type": "const void*"
+        },
+        {
+          "name": "p_step_fast",
+          "type": "const void*"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "NULL",
+        "p_step": "NULL",
+        "p_step_fast": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputScalarN",
+      "cimgui_name": "igInputScalarN",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputScalarN",
+      "c_arguments": "(const char*label,ImGuiDataType data_type,void*p_data,int components,const void*p_step,const void*p_step_fast,const char*format,ImGuiInputTextFlags flags)",
+      "signature": "(const char*,ImGuiDataType,void*,int,const void*,const void*,const char*,ImGuiInputTextFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "data_type",
+          "type": "ImGuiDataType"
+        },
+        {
+          "name": "p_data",
+          "type": "void*"
+        },
+        {
+          "name": "components",
+          "type": "int"
+        },
+        {
+          "name": "p_step",
+          "type": "const void*"
+        },
+        {
+          "name": "p_step_fast",
+          "type": "const void*"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "NULL",
+        "p_step": "NULL",
+        "p_step_fast": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputText",
+      "cimgui_name": "igInputText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputText",
+      "c_arguments": "(const char*label,char*buf,size_t buf_size,ImGuiInputTextFlags flags,ImGuiInputTextCallback callback,void*user_data)",
+      "signature": "(const char*,char*,size_t,ImGuiInputTextFlags,ImGuiInputTextCallback,void*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "buf",
+          "type": "char*"
+        },
+        {
+          "name": "buf_size",
+          "type": "size_t"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        },
+        {
+          "name": "callback",
+          "type": "ImGuiInputTextCallback"
+        },
+        {
+          "name": "user_data",
+          "type": "void*"
+        }
+      ],
+      "defaults": {
+        "callback": "NULL",
+        "flags": "0",
+        "user_data": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputTextMultiline",
+      "cimgui_name": "igInputTextMultiline",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputTextMultiline",
+      "c_arguments": "(const char*label,char*buf,size_t buf_size,const ImVec2_c size,ImGuiInputTextFlags flags,ImGuiInputTextCallback callback,void*user_data)",
+      "signature": "(const char*,char*,size_t,const ImVec2,ImGuiInputTextFlags,ImGuiInputTextCallback,void*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "buf",
+          "type": "char*"
+        },
+        {
+          "name": "buf_size",
+          "type": "size_t"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        },
+        {
+          "name": "callback",
+          "type": "ImGuiInputTextCallback"
+        },
+        {
+          "name": "user_data",
+          "type": "void*"
+        }
+      ],
+      "defaults": {
+        "callback": "NULL",
+        "flags": "0",
+        "size": "ImVec2(0,0)",
+        "user_data": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInputTextWithHint",
+      "cimgui_name": "igInputTextWithHint",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InputTextWithHint",
+      "c_arguments": "(const char*label,const char*hint,char*buf,size_t buf_size,ImGuiInputTextFlags flags,ImGuiInputTextCallback callback,void*user_data)",
+      "signature": "(const char*,const char*,char*,size_t,ImGuiInputTextFlags,ImGuiInputTextCallback,void*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "hint",
+          "type": "const char*"
+        },
+        {
+          "name": "buf",
+          "type": "char*"
+        },
+        {
+          "name": "buf_size",
+          "type": "size_t"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputTextFlags"
+        },
+        {
+          "name": "callback",
+          "type": "ImGuiInputTextCallback"
+        },
+        {
+          "name": "user_data",
+          "type": "void*"
+        }
+      ],
+      "defaults": {
+        "callback": "NULL",
+        "flags": "0",
+        "user_data": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igInvisibleButton",
+      "cimgui_name": "igInvisibleButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "InvisibleButton",
+      "c_arguments": "(const char*str_id,const ImVec2_c size,ImGuiButtonFlags flags)",
+      "signature": "(const char*,const ImVec2,ImGuiButtonFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiButtonFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsAnyItemActive",
+      "cimgui_name": "igIsAnyItemActive",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsAnyItemActive",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsAnyItemFocused",
+      "cimgui_name": "igIsAnyItemFocused",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsAnyItemFocused",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsAnyItemHovered",
+      "cimgui_name": "igIsAnyItemHovered",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsAnyItemHovered",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsAnyMouseDown",
+      "cimgui_name": "igIsAnyMouseDown",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsAnyMouseDown",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemActivated",
+      "cimgui_name": "igIsItemActivated",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemActivated",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemActive",
+      "cimgui_name": "igIsItemActive",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemActive",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemClicked",
+      "cimgui_name": "igIsItemClicked",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemClicked",
+      "c_arguments": "(ImGuiMouseButton mouse_button)",
+      "signature": "(ImGuiMouseButton)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "mouse_button",
+          "type": "ImGuiMouseButton"
+        }
+      ],
+      "defaults": {
+        "mouse_button": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemDeactivated",
+      "cimgui_name": "igIsItemDeactivated",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemDeactivated",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemDeactivatedAfterEdit",
+      "cimgui_name": "igIsItemDeactivatedAfterEdit",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemDeactivatedAfterEdit",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemEdited",
+      "cimgui_name": "igIsItemEdited",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemEdited",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemFocused",
+      "cimgui_name": "igIsItemFocused",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemFocused",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemHovered",
+      "cimgui_name": "igIsItemHovered",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemHovered",
+      "c_arguments": "(ImGuiHoveredFlags flags)",
+      "signature": "(ImGuiHoveredFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "flags",
+          "type": "ImGuiHoveredFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemToggledOpen",
+      "cimgui_name": "igIsItemToggledOpen",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemToggledOpen",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemToggledSelection",
+      "cimgui_name": "igIsItemToggledSelection",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemToggledSelection",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsItemVisible",
+      "cimgui_name": "igIsItemVisible",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsItemVisible",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsKeyChordPressed_Nil",
+      "cimgui_name": "igIsKeyChordPressed",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsKeyChordPressed",
+      "c_arguments": "(ImGuiKeyChord key_chord)",
+      "signature": "(ImGuiKeyChord)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "key_chord",
+          "type": "ImGuiKeyChord"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsKeyDown_Nil",
+      "cimgui_name": "igIsKeyDown",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsKeyDown",
+      "c_arguments": "(ImGuiKey key)",
+      "signature": "(ImGuiKey)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsKeyPressed_Bool",
+      "cimgui_name": "igIsKeyPressed",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsKeyPressed",
+      "c_arguments": "(ImGuiKey key,bool repeat)",
+      "signature": "(ImGuiKey,bool)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        },
+        {
+          "name": "repeat",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "repeat": "true"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsKeyReleased_Nil",
+      "cimgui_name": "igIsKeyReleased",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsKeyReleased",
+      "c_arguments": "(ImGuiKey key)",
+      "signature": "(ImGuiKey)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMouseClicked_Bool",
+      "cimgui_name": "igIsMouseClicked",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMouseClicked",
+      "c_arguments": "(ImGuiMouseButton button,bool repeat)",
+      "signature": "(ImGuiMouseButton,bool)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        },
+        {
+          "name": "repeat",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "repeat": "false"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMouseDoubleClicked_Nil",
+      "cimgui_name": "igIsMouseDoubleClicked",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMouseDoubleClicked",
+      "c_arguments": "(ImGuiMouseButton button)",
+      "signature": "(ImGuiMouseButton)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMouseDown_Nil",
+      "cimgui_name": "igIsMouseDown",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMouseDown",
+      "c_arguments": "(ImGuiMouseButton button)",
+      "signature": "(ImGuiMouseButton)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMouseDragging",
+      "cimgui_name": "igIsMouseDragging",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMouseDragging",
+      "c_arguments": "(ImGuiMouseButton button,float lock_threshold)",
+      "signature": "(ImGuiMouseButton,float)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        },
+        {
+          "name": "lock_threshold",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "lock_threshold": "-1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMouseHoveringRect",
+      "cimgui_name": "igIsMouseHoveringRect",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMouseHoveringRect",
+      "c_arguments": "(const ImVec2_c r_min,const ImVec2_c r_max,bool clip)",
+      "signature": "(const ImVec2,const ImVec2,bool)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "r_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "r_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "clip",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "clip": "true"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMousePosValid",
+      "cimgui_name": "igIsMousePosValid",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMousePosValid",
+      "c_arguments": "(const ImVec2_c*mouse_pos)",
+      "signature": "(const ImVec2*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "mouse_pos",
+          "type": "const ImVec2*"
+        }
+      ],
+      "defaults": {
+        "mouse_pos": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMouseReleasedWithDelay",
+      "cimgui_name": "igIsMouseReleasedWithDelay",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMouseReleasedWithDelay",
+      "c_arguments": "(ImGuiMouseButton button,float delay)",
+      "signature": "(ImGuiMouseButton,float)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        },
+        {
+          "name": "delay",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsMouseReleased_Nil",
+      "cimgui_name": "igIsMouseReleased",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsMouseReleased",
+      "c_arguments": "(ImGuiMouseButton button)",
+      "signature": "(ImGuiMouseButton)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsPopupOpen_Str",
+      "cimgui_name": "igIsPopupOpen",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsPopupOpen",
+      "c_arguments": "(const char*str_id,ImGuiPopupFlags flags)",
+      "signature": "(const char*,ImGuiPopupFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiPopupFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsRectVisible_Nil",
+      "cimgui_name": "igIsRectVisible",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsRectVisible",
+      "c_arguments": "(const ImVec2_c size)",
+      "signature": "(const ImVec2)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsRectVisible_Vec2",
+      "cimgui_name": "igIsRectVisible",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsRectVisible",
+      "c_arguments": "(const ImVec2_c rect_min,const ImVec2_c rect_max)",
+      "signature": "(const ImVec2,const ImVec2)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "rect_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "rect_max",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsWindowAppearing",
+      "cimgui_name": "igIsWindowAppearing",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsWindowAppearing",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsWindowCollapsed",
+      "cimgui_name": "igIsWindowCollapsed",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsWindowCollapsed",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsWindowDocked",
+      "cimgui_name": "igIsWindowDocked",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsWindowDocked",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igIsWindowFocused",
+      "cimgui_name": "igIsWindowFocused",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsWindowFocused",
+      "c_arguments": "(ImGuiFocusedFlags flags)",
+      "signature": "(ImGuiFocusedFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "flags",
+          "type": "ImGuiFocusedFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igIsWindowHovered",
+      "cimgui_name": "igIsWindowHovered",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "IsWindowHovered",
+      "c_arguments": "(ImGuiHoveredFlags flags)",
+      "signature": "(ImGuiHoveredFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "flags",
+          "type": "ImGuiHoveredFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igLabelText",
+      "cimgui_name": "igLabelText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LabelText",
+      "c_arguments": "(const char*label,const char*fmt,...)",
+      "signature": "(const char*,const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igLabelTextV",
+      "cimgui_name": "igLabelTextV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LabelTextV",
+      "c_arguments": "(const char*label,const char*fmt,va_list args)",
+      "signature": "(const char*,const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igListBox_FnStrPtr",
+      "cimgui_name": "igListBox",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ListBox",
+      "c_arguments": "(const char*label,int*current_item,const char*(*getter)(void*user_data,int idx),void*user_data,int items_count,int height_in_items)",
+      "signature": "(const char*,int*,const char*(*)(void*,int),void*,int,int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "current_item",
+          "type": "int*"
+        },
+        {
+          "name": "getter",
+          "ret": "const char*",
+          "signature": "(void*user_data,int idx)",
+          "type": "const char*(*)(void*user_data,int idx)"
+        },
+        {
+          "name": "user_data",
+          "type": "void*"
+        },
+        {
+          "name": "items_count",
+          "type": "int"
+        },
+        {
+          "name": "height_in_items",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "height_in_items": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igListBox_Str_arr",
+      "cimgui_name": "igListBox",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ListBox",
+      "c_arguments": "(const char*label,int*current_item,const char*const items[],int items_count,int height_in_items)",
+      "signature": "(const char*,int*,const char*const[],int,int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "current_item",
+          "type": "int*"
+        },
+        {
+          "name": "items",
+          "type": "const char*const[]"
+        },
+        {
+          "name": "items_count",
+          "type": "int"
+        },
+        {
+          "name": "height_in_items",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "height_in_items": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igLoadIniSettingsFromDisk",
+      "cimgui_name": "igLoadIniSettingsFromDisk",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LoadIniSettingsFromDisk",
+      "c_arguments": "(const char*ini_filename)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ini_filename",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igLoadIniSettingsFromMemory",
+      "cimgui_name": "igLoadIniSettingsFromMemory",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LoadIniSettingsFromMemory",
+      "c_arguments": "(const char*ini_data,size_t ini_size)",
+      "signature": "(const char*,size_t)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ini_data",
+          "type": "const char*"
+        },
+        {
+          "name": "ini_size",
+          "type": "size_t"
+        }
+      ],
+      "defaults": {
+        "ini_size": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igLogButtons",
+      "cimgui_name": "igLogButtons",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LogButtons",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igLogFinish",
+      "cimgui_name": "igLogFinish",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LogFinish",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igLogText",
+      "cimgui_name": "igLogText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LogText",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igLogTextV",
+      "cimgui_name": "igLogTextV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LogTextV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igLogToClipboard",
+      "cimgui_name": "igLogToClipboard",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LogToClipboard",
+      "c_arguments": "(int auto_open_depth)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "auto_open_depth",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "auto_open_depth": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igLogToFile",
+      "cimgui_name": "igLogToFile",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LogToFile",
+      "c_arguments": "(int auto_open_depth,const char*filename)",
+      "signature": "(int,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "auto_open_depth",
+          "type": "int"
+        },
+        {
+          "name": "filename",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "auto_open_depth": "-1",
+        "filename": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igLogToTTY",
+      "cimgui_name": "igLogToTTY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "LogToTTY",
+      "c_arguments": "(int auto_open_depth)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "auto_open_depth",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "auto_open_depth": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igMemAlloc",
+      "cimgui_name": "igMemAlloc",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "MemAlloc",
+      "c_arguments": "(size_t size)",
+      "signature": "(size_t)",
+      "return_type": "void*",
+      "arguments": [
+        {
+          "name": "size",
+          "type": "size_t"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igMemFree",
+      "cimgui_name": "igMemFree",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "MemFree",
+      "c_arguments": "(void*ptr)",
+      "signature": "(void*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ptr",
+          "type": "void*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igMenuItem_Bool",
+      "cimgui_name": "igMenuItem",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "MenuItem",
+      "c_arguments": "(const char*label,const char*shortcut,bool selected,bool enabled)",
+      "signature": "(const char*,const char*,bool,bool)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "shortcut",
+          "type": "const char*"
+        },
+        {
+          "name": "selected",
+          "type": "bool"
+        },
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "enabled": "true",
+        "selected": "false",
+        "shortcut": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igMenuItem_BoolPtr",
+      "cimgui_name": "igMenuItem",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "MenuItem",
+      "c_arguments": "(const char*label,const char*shortcut,bool*p_selected,bool enabled)",
+      "signature": "(const char*,const char*,bool*,bool)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "shortcut",
+          "type": "const char*"
+        },
+        {
+          "name": "p_selected",
+          "type": "bool*"
+        },
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "defaults": {
+        "enabled": "true"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igNewFrame",
+      "cimgui_name": "igNewFrame",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "NewFrame",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igNewLine",
+      "cimgui_name": "igNewLine",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "NewLine",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igNextColumn",
+      "cimgui_name": "igNextColumn",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "NextColumn",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igOpenPopupOnItemClick",
+      "cimgui_name": "igOpenPopupOnItemClick",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "OpenPopupOnItemClick",
+      "c_arguments": "(const char*str_id,ImGuiPopupFlags popup_flags)",
+      "signature": "(const char*,ImGuiPopupFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "popup_flags",
+          "type": "ImGuiPopupFlags"
+        }
+      ],
+      "defaults": {
+        "popup_flags": "0",
+        "str_id": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igOpenPopup_ID",
+      "cimgui_name": "igOpenPopup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "OpenPopup",
+      "c_arguments": "(ImGuiID id,ImGuiPopupFlags popup_flags)",
+      "signature": "(ImGuiID,ImGuiPopupFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "id",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "popup_flags",
+          "type": "ImGuiPopupFlags"
+        }
+      ],
+      "defaults": {
+        "popup_flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igOpenPopup_Str",
+      "cimgui_name": "igOpenPopup",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "OpenPopup",
+      "c_arguments": "(const char*str_id,ImGuiPopupFlags popup_flags)",
+      "signature": "(const char*,ImGuiPopupFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "popup_flags",
+          "type": "ImGuiPopupFlags"
+        }
+      ],
+      "defaults": {
+        "popup_flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPlotHistogram_FloatPtr",
+      "cimgui_name": "igPlotHistogram",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PlotHistogram",
+      "c_arguments": "(const char*label,const float*values,int values_count,int values_offset,const char*overlay_text,float scale_min,float scale_max,ImVec2_c graph_size,int stride)",
+      "signature": "(const char*,const float*,int,int,const char*,float,float,ImVec2,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "values",
+          "type": "const float*"
+        },
+        {
+          "name": "values_count",
+          "type": "int"
+        },
+        {
+          "name": "values_offset",
+          "type": "int"
+        },
+        {
+          "name": "overlay_text",
+          "type": "const char*"
+        },
+        {
+          "name": "scale_min",
+          "type": "float"
+        },
+        {
+          "name": "scale_max",
+          "type": "float"
+        },
+        {
+          "name": "graph_size",
+          "type": "ImVec2"
+        },
+        {
+          "name": "stride",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "graph_size": "ImVec2(0,0)",
+        "overlay_text": "NULL",
+        "scale_max": "FLT_MAX",
+        "scale_min": "FLT_MAX",
+        "stride": "sizeof(float)",
+        "values_offset": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPlotHistogram_FnFloatPtr",
+      "cimgui_name": "igPlotHistogram",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PlotHistogram",
+      "c_arguments": "(const char*label,float(*values_getter)(void*data,int idx),void*data,int values_count,int values_offset,const char*overlay_text,float scale_min,float scale_max,ImVec2_c graph_size)",
+      "signature": "(const char*,float(*)(void*,int),void*,int,int,const char*,float,float,ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "values_getter",
+          "ret": "float",
+          "signature": "(void*data,int idx)",
+          "type": "float(*)(void*data,int idx)"
+        },
+        {
+          "name": "data",
+          "type": "void*"
+        },
+        {
+          "name": "values_count",
+          "type": "int"
+        },
+        {
+          "name": "values_offset",
+          "type": "int"
+        },
+        {
+          "name": "overlay_text",
+          "type": "const char*"
+        },
+        {
+          "name": "scale_min",
+          "type": "float"
+        },
+        {
+          "name": "scale_max",
+          "type": "float"
+        },
+        {
+          "name": "graph_size",
+          "type": "ImVec2"
+        }
+      ],
+      "defaults": {
+        "graph_size": "ImVec2(0,0)",
+        "overlay_text": "NULL",
+        "scale_max": "FLT_MAX",
+        "scale_min": "FLT_MAX",
+        "values_offset": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPlotLines_FloatPtr",
+      "cimgui_name": "igPlotLines",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PlotLines",
+      "c_arguments": "(const char*label,const float*values,int values_count,int values_offset,const char*overlay_text,float scale_min,float scale_max,ImVec2_c graph_size,int stride)",
+      "signature": "(const char*,const float*,int,int,const char*,float,float,ImVec2,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "values",
+          "type": "const float*"
+        },
+        {
+          "name": "values_count",
+          "type": "int"
+        },
+        {
+          "name": "values_offset",
+          "type": "int"
+        },
+        {
+          "name": "overlay_text",
+          "type": "const char*"
+        },
+        {
+          "name": "scale_min",
+          "type": "float"
+        },
+        {
+          "name": "scale_max",
+          "type": "float"
+        },
+        {
+          "name": "graph_size",
+          "type": "ImVec2"
+        },
+        {
+          "name": "stride",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "graph_size": "ImVec2(0,0)",
+        "overlay_text": "NULL",
+        "scale_max": "FLT_MAX",
+        "scale_min": "FLT_MAX",
+        "stride": "sizeof(float)",
+        "values_offset": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPlotLines_FnFloatPtr",
+      "cimgui_name": "igPlotLines",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PlotLines",
+      "c_arguments": "(const char*label,float(*values_getter)(void*data,int idx),void*data,int values_count,int values_offset,const char*overlay_text,float scale_min,float scale_max,ImVec2_c graph_size)",
+      "signature": "(const char*,float(*)(void*,int),void*,int,int,const char*,float,float,ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "values_getter",
+          "ret": "float",
+          "signature": "(void*data,int idx)",
+          "type": "float(*)(void*data,int idx)"
+        },
+        {
+          "name": "data",
+          "type": "void*"
+        },
+        {
+          "name": "values_count",
+          "type": "int"
+        },
+        {
+          "name": "values_offset",
+          "type": "int"
+        },
+        {
+          "name": "overlay_text",
+          "type": "const char*"
+        },
+        {
+          "name": "scale_min",
+          "type": "float"
+        },
+        {
+          "name": "scale_max",
+          "type": "float"
+        },
+        {
+          "name": "graph_size",
+          "type": "ImVec2"
+        }
+      ],
+      "defaults": {
+        "graph_size": "ImVec2(0,0)",
+        "overlay_text": "NULL",
+        "scale_max": "FLT_MAX",
+        "scale_min": "FLT_MAX",
+        "values_offset": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPopClipRect",
+      "cimgui_name": "igPopClipRect",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopClipRect",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPopFont",
+      "cimgui_name": "igPopFont",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopFont",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPopID",
+      "cimgui_name": "igPopID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopID",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPopItemFlag",
+      "cimgui_name": "igPopItemFlag",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopItemFlag",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPopItemWidth",
+      "cimgui_name": "igPopItemWidth",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopItemWidth",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPopStyleColor",
+      "cimgui_name": "igPopStyleColor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopStyleColor",
+      "c_arguments": "(int count)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "count",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "count": "1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPopStyleVar",
+      "cimgui_name": "igPopStyleVar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopStyleVar",
+      "c_arguments": "(int count)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "count",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "count": "1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPopTextWrapPos",
+      "cimgui_name": "igPopTextWrapPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PopTextWrapPos",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igProgressBar",
+      "cimgui_name": "igProgressBar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ProgressBar",
+      "c_arguments": "(float fraction,const ImVec2_c size_arg,const char*overlay)",
+      "signature": "(float,const ImVec2,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fraction",
+          "type": "float"
+        },
+        {
+          "name": "size_arg",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "overlay",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "overlay": "NULL",
+        "size_arg": "ImVec2(-FLT_MIN,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igPushClipRect",
+      "cimgui_name": "igPushClipRect",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushClipRect",
+      "c_arguments": "(const ImVec2_c clip_rect_min,const ImVec2_c clip_rect_max,bool intersect_with_current_clip_rect)",
+      "signature": "(const ImVec2,const ImVec2,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "clip_rect_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "clip_rect_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "intersect_with_current_clip_rect",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushFont",
+      "cimgui_name": "igPushFont",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushFont",
+      "c_arguments": "(ImFont*font,float font_size_base_unscaled)",
+      "signature": "(ImFont*,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "font",
+          "type": "ImFont*"
+        },
+        {
+          "name": "font_size_base_unscaled",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushID_Int",
+      "cimgui_name": "igPushID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushID",
+      "c_arguments": "(int int_id)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "int_id",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushID_Ptr",
+      "cimgui_name": "igPushID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushID",
+      "c_arguments": "(const void*ptr_id)",
+      "signature": "(const void*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ptr_id",
+          "type": "const void*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushID_Str",
+      "cimgui_name": "igPushID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushID",
+      "c_arguments": "(const char*str_id)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushID_StrStr",
+      "cimgui_name": "igPushID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushID",
+      "c_arguments": "(const char*str_id_begin,const char*str_id_end)",
+      "signature": "(const char*,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "str_id_begin",
+          "type": "const char*"
+        },
+        {
+          "name": "str_id_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushItemFlag",
+      "cimgui_name": "igPushItemFlag",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushItemFlag",
+      "c_arguments": "(ImGuiItemFlags option,bool enabled)",
+      "signature": "(ImGuiItemFlags,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "option",
+          "type": "ImGuiItemFlags"
+        },
+        {
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushItemWidth",
+      "cimgui_name": "igPushItemWidth",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushItemWidth",
+      "c_arguments": "(float item_width)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "item_width",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushStyleColor_U32",
+      "cimgui_name": "igPushStyleColor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushStyleColor",
+      "c_arguments": "(ImGuiCol idx,ImU32 col)",
+      "signature": "(ImGuiCol,ImU32)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiCol"
+        },
+        {
+          "name": "col",
+          "type": "ImU32"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushStyleColor_Vec4",
+      "cimgui_name": "igPushStyleColor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushStyleColor",
+      "c_arguments": "(ImGuiCol idx,const ImVec4_c col)",
+      "signature": "(ImGuiCol,const ImVec4)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiCol"
+        },
+        {
+          "name": "col",
+          "type": "const ImVec4"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushStyleVarX",
+      "cimgui_name": "igPushStyleVarX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushStyleVarX",
+      "c_arguments": "(ImGuiStyleVar idx,float val_x)",
+      "signature": "(ImGuiStyleVar,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiStyleVar"
+        },
+        {
+          "name": "val_x",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushStyleVarY",
+      "cimgui_name": "igPushStyleVarY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushStyleVarY",
+      "c_arguments": "(ImGuiStyleVar idx,float val_y)",
+      "signature": "(ImGuiStyleVar,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiStyleVar"
+        },
+        {
+          "name": "val_y",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushStyleVar_Float",
+      "cimgui_name": "igPushStyleVar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushStyleVar",
+      "c_arguments": "(ImGuiStyleVar idx,float val)",
+      "signature": "(ImGuiStyleVar,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiStyleVar"
+        },
+        {
+          "name": "val",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushStyleVar_Vec2",
+      "cimgui_name": "igPushStyleVar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushStyleVar",
+      "c_arguments": "(ImGuiStyleVar idx,const ImVec2_c val)",
+      "signature": "(ImGuiStyleVar,const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "idx",
+          "type": "ImGuiStyleVar"
+        },
+        {
+          "name": "val",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igPushTextWrapPos",
+      "cimgui_name": "igPushTextWrapPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "PushTextWrapPos",
+      "c_arguments": "(float wrap_local_pos_x)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "wrap_local_pos_x",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "wrap_local_pos_x": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igRadioButton_Bool",
+      "cimgui_name": "igRadioButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "RadioButton",
+      "c_arguments": "(const char*label,bool active)",
+      "signature": "(const char*,bool)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "active",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igRadioButton_IntPtr",
+      "cimgui_name": "igRadioButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "RadioButton",
+      "c_arguments": "(const char*label,int*v,int v_button)",
+      "signature": "(const char*,int*,int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int*"
+        },
+        {
+          "name": "v_button",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igRender",
+      "cimgui_name": "igRender",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Render",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igRenderPlatformWindowsDefault",
+      "cimgui_name": "igRenderPlatformWindowsDefault",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "RenderPlatformWindowsDefault",
+      "c_arguments": "(void*platform_render_arg,void*renderer_render_arg)",
+      "signature": "(void*,void*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "platform_render_arg",
+          "type": "void*"
+        },
+        {
+          "name": "renderer_render_arg",
+          "type": "void*"
+        }
+      ],
+      "defaults": {
+        "platform_render_arg": "NULL",
+        "renderer_render_arg": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igResetMouseDragDelta",
+      "cimgui_name": "igResetMouseDragDelta",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ResetMouseDragDelta",
+      "c_arguments": "(ImGuiMouseButton button)",
+      "signature": "(ImGuiMouseButton)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "button",
+          "type": "ImGuiMouseButton"
+        }
+      ],
+      "defaults": {
+        "button": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSameLine",
+      "cimgui_name": "igSameLine",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SameLine",
+      "c_arguments": "(float offset_from_start_x,float spacing)",
+      "signature": "(float,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "offset_from_start_x",
+          "type": "float"
+        },
+        {
+          "name": "spacing",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "offset_from_start_x": "0.0f",
+        "spacing": "-1.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSaveIniSettingsToDisk",
+      "cimgui_name": "igSaveIniSettingsToDisk",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SaveIniSettingsToDisk",
+      "c_arguments": "(const char*ini_filename)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ini_filename",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSaveIniSettingsToMemory",
+      "cimgui_name": "igSaveIniSettingsToMemory",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SaveIniSettingsToMemory",
+      "c_arguments": "(size_t*out_ini_size)",
+      "signature": "(size_t*)",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "out_ini_size",
+          "type": "size_t*"
+        }
+      ],
+      "defaults": {
+        "out_ini_size": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSelectable_Bool",
+      "cimgui_name": "igSelectable",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Selectable",
+      "c_arguments": "(const char*label,bool selected,ImGuiSelectableFlags flags,const ImVec2_c size)",
+      "signature": "(const char*,bool,ImGuiSelectableFlags,const ImVec2)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "selected",
+          "type": "bool"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSelectableFlags"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "selected": "false",
+        "size": "ImVec2(0,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSelectable_BoolPtr",
+      "cimgui_name": "igSelectable",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Selectable",
+      "c_arguments": "(const char*label,bool*p_selected,ImGuiSelectableFlags flags,const ImVec2_c size)",
+      "signature": "(const char*,bool*,ImGuiSelectableFlags,const ImVec2)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "p_selected",
+          "type": "bool*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSelectableFlags"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "size": "ImVec2(0,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSeparator",
+      "cimgui_name": "igSeparator",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Separator",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSeparatorText",
+      "cimgui_name": "igSeparatorText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SeparatorText",
+      "c_arguments": "(const char*label)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetAllocatorFunctions",
+      "cimgui_name": "igSetAllocatorFunctions",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetAllocatorFunctions",
+      "c_arguments": "(ImGuiMemAllocFunc alloc_func,ImGuiMemFreeFunc free_func,void*user_data)",
+      "signature": "(ImGuiMemAllocFunc,ImGuiMemFreeFunc,void*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "alloc_func",
+          "type": "ImGuiMemAllocFunc"
+        },
+        {
+          "name": "free_func",
+          "type": "ImGuiMemFreeFunc"
+        },
+        {
+          "name": "user_data",
+          "type": "void*"
+        }
+      ],
+      "defaults": {
+        "user_data": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetClipboardText",
+      "cimgui_name": "igSetClipboardText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetClipboardText",
+      "c_arguments": "(const char*text)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "text",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetColorEditOptions",
+      "cimgui_name": "igSetColorEditOptions",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetColorEditOptions",
+      "c_arguments": "(ImGuiColorEditFlags flags)",
+      "signature": "(ImGuiColorEditFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "flags",
+          "type": "ImGuiColorEditFlags"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetColumnOffset",
+      "cimgui_name": "igSetColumnOffset",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetColumnOffset",
+      "c_arguments": "(int column_index,float offset_x)",
+      "signature": "(int,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "column_index",
+          "type": "int"
+        },
+        {
+          "name": "offset_x",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetColumnWidth",
+      "cimgui_name": "igSetColumnWidth",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetColumnWidth",
+      "c_arguments": "(int column_index,float width)",
+      "signature": "(int,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "column_index",
+          "type": "int"
+        },
+        {
+          "name": "width",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetCurrentContext",
+      "cimgui_name": "igSetCurrentContext",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetCurrentContext",
+      "c_arguments": "(ImGuiContext*ctx)",
+      "signature": "(ImGuiContext*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ctx",
+          "type": "ImGuiContext*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetCursorPos",
+      "cimgui_name": "igSetCursorPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetCursorPos",
+      "c_arguments": "(const ImVec2_c local_pos)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "local_pos",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetCursorPosX",
+      "cimgui_name": "igSetCursorPosX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetCursorPosX",
+      "c_arguments": "(float local_x)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "local_x",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetCursorPosY",
+      "cimgui_name": "igSetCursorPosY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetCursorPosY",
+      "c_arguments": "(float local_y)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "local_y",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetCursorScreenPos",
+      "cimgui_name": "igSetCursorScreenPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetCursorScreenPos",
+      "c_arguments": "(const ImVec2_c pos)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetDragDropPayload",
+      "cimgui_name": "igSetDragDropPayload",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetDragDropPayload",
+      "c_arguments": "(const char*type,const void*data,size_t sz,ImGuiCond cond)",
+      "signature": "(const char*,const void*,size_t,ImGuiCond)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "const char*"
+        },
+        {
+          "name": "data",
+          "type": "const void*"
+        },
+        {
+          "name": "sz",
+          "type": "size_t"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetItemDefaultFocus",
+      "cimgui_name": "igSetItemDefaultFocus",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetItemDefaultFocus",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetItemKeyOwner_Nil",
+      "cimgui_name": "igSetItemKeyOwner",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetItemKeyOwner",
+      "c_arguments": "(ImGuiKey key)",
+      "signature": "(ImGuiKey)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "key",
+          "type": "ImGuiKey"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetItemTooltip",
+      "cimgui_name": "igSetItemTooltip",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetItemTooltip",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igSetItemTooltipV",
+      "cimgui_name": "igSetItemTooltipV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetItemTooltipV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetKeyboardFocusHere",
+      "cimgui_name": "igSetKeyboardFocusHere",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetKeyboardFocusHere",
+      "c_arguments": "(int offset)",
+      "signature": "(int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "offset",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "offset": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetMouseCursor",
+      "cimgui_name": "igSetMouseCursor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetMouseCursor",
+      "c_arguments": "(ImGuiMouseCursor cursor_type)",
+      "signature": "(ImGuiMouseCursor)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "cursor_type",
+          "type": "ImGuiMouseCursor"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNavCursorVisible",
+      "cimgui_name": "igSetNavCursorVisible",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNavCursorVisible",
+      "c_arguments": "(bool visible)",
+      "signature": "(bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "visible",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextFrameWantCaptureKeyboard",
+      "cimgui_name": "igSetNextFrameWantCaptureKeyboard",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextFrameWantCaptureKeyboard",
+      "c_arguments": "(bool want_capture_keyboard)",
+      "signature": "(bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "want_capture_keyboard",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextFrameWantCaptureMouse",
+      "cimgui_name": "igSetNextFrameWantCaptureMouse",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextFrameWantCaptureMouse",
+      "c_arguments": "(bool want_capture_mouse)",
+      "signature": "(bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "want_capture_mouse",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextItemAllowOverlap",
+      "cimgui_name": "igSetNextItemAllowOverlap",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextItemAllowOverlap",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextItemOpen",
+      "cimgui_name": "igSetNextItemOpen",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextItemOpen",
+      "c_arguments": "(bool is_open,ImGuiCond cond)",
+      "signature": "(bool,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "is_open",
+          "type": "bool"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextItemSelectionUserData",
+      "cimgui_name": "igSetNextItemSelectionUserData",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextItemSelectionUserData",
+      "c_arguments": "(ImGuiSelectionUserData selection_user_data)",
+      "signature": "(ImGuiSelectionUserData)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "selection_user_data",
+          "type": "ImGuiSelectionUserData"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextItemShortcut",
+      "cimgui_name": "igSetNextItemShortcut",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextItemShortcut",
+      "c_arguments": "(ImGuiKeyChord key_chord,ImGuiInputFlags flags)",
+      "signature": "(ImGuiKeyChord,ImGuiInputFlags)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "key_chord",
+          "type": "ImGuiKeyChord"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextItemStorageID",
+      "cimgui_name": "igSetNextItemStorageID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextItemStorageID",
+      "c_arguments": "(ImGuiID storage_id)",
+      "signature": "(ImGuiID)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "storage_id",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextItemWidth",
+      "cimgui_name": "igSetNextItemWidth",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextItemWidth",
+      "c_arguments": "(float item_width)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "item_width",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowBgAlpha",
+      "cimgui_name": "igSetNextWindowBgAlpha",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowBgAlpha",
+      "c_arguments": "(float alpha)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "alpha",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowClass",
+      "cimgui_name": "igSetNextWindowClass",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowClass",
+      "c_arguments": "(const ImGuiWindowClass*window_class)",
+      "signature": "(const ImGuiWindowClass*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "window_class",
+          "type": "const ImGuiWindowClass*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowCollapsed",
+      "cimgui_name": "igSetNextWindowCollapsed",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowCollapsed",
+      "c_arguments": "(bool collapsed,ImGuiCond cond)",
+      "signature": "(bool,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "collapsed",
+          "type": "bool"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowContentSize",
+      "cimgui_name": "igSetNextWindowContentSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowContentSize",
+      "c_arguments": "(const ImVec2_c size)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowDockID",
+      "cimgui_name": "igSetNextWindowDockID",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowDockID",
+      "c_arguments": "(ImGuiID dock_id,ImGuiCond cond)",
+      "signature": "(ImGuiID,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "dock_id",
+          "type": "ImGuiID"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowFocus",
+      "cimgui_name": "igSetNextWindowFocus",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowFocus",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowPos",
+      "cimgui_name": "igSetNextWindowPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowPos",
+      "c_arguments": "(const ImVec2_c pos,ImGuiCond cond,const ImVec2_c pivot)",
+      "signature": "(const ImVec2,ImGuiCond,const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        },
+        {
+          "name": "pivot",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {
+        "cond": "0",
+        "pivot": "ImVec2(0,0)"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowScroll",
+      "cimgui_name": "igSetNextWindowScroll",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowScroll",
+      "c_arguments": "(const ImVec2_c scroll)",
+      "signature": "(const ImVec2)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "scroll",
+          "type": "const ImVec2"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowSize",
+      "cimgui_name": "igSetNextWindowSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowSize",
+      "c_arguments": "(const ImVec2_c size,ImGuiCond cond)",
+      "signature": "(const ImVec2,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowSizeConstraints",
+      "cimgui_name": "igSetNextWindowSizeConstraints",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowSizeConstraints",
+      "c_arguments": "(const ImVec2_c size_min,const ImVec2_c size_max,ImGuiSizeCallback custom_callback,void*custom_callback_data)",
+      "signature": "(const ImVec2,const ImVec2,ImGuiSizeCallback,void*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "size_min",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "size_max",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "custom_callback",
+          "type": "ImGuiSizeCallback"
+        },
+        {
+          "name": "custom_callback_data",
+          "type": "void*"
+        }
+      ],
+      "defaults": {
+        "custom_callback": "NULL",
+        "custom_callback_data": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetNextWindowViewport",
+      "cimgui_name": "igSetNextWindowViewport",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetNextWindowViewport",
+      "c_arguments": "(ImGuiID viewport_id)",
+      "signature": "(ImGuiID)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "viewport_id",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetScrollFromPosX_Float",
+      "cimgui_name": "igSetScrollFromPosX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetScrollFromPosX",
+      "c_arguments": "(float local_x,float center_x_ratio)",
+      "signature": "(float,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "local_x",
+          "type": "float"
+        },
+        {
+          "name": "center_x_ratio",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "center_x_ratio": "0.5f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetScrollFromPosY_Float",
+      "cimgui_name": "igSetScrollFromPosY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetScrollFromPosY",
+      "c_arguments": "(float local_y,float center_y_ratio)",
+      "signature": "(float,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "local_y",
+          "type": "float"
+        },
+        {
+          "name": "center_y_ratio",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "center_y_ratio": "0.5f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetScrollHereX",
+      "cimgui_name": "igSetScrollHereX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetScrollHereX",
+      "c_arguments": "(float center_x_ratio)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "center_x_ratio",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "center_x_ratio": "0.5f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetScrollHereY",
+      "cimgui_name": "igSetScrollHereY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetScrollHereY",
+      "c_arguments": "(float center_y_ratio)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "center_y_ratio",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "center_y_ratio": "0.5f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetScrollX_Float",
+      "cimgui_name": "igSetScrollX",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetScrollX",
+      "c_arguments": "(float scroll_x)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "scroll_x",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetScrollY_Float",
+      "cimgui_name": "igSetScrollY",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetScrollY",
+      "c_arguments": "(float scroll_y)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "scroll_y",
+          "type": "float"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetStateStorage",
+      "cimgui_name": "igSetStateStorage",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetStateStorage",
+      "c_arguments": "(ImGuiStorage*storage)",
+      "signature": "(ImGuiStorage*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "storage",
+          "type": "ImGuiStorage*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetTabItemClosed",
+      "cimgui_name": "igSetTabItemClosed",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetTabItemClosed",
+      "c_arguments": "(const char*tab_or_docked_window_label)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "tab_or_docked_window_label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetTooltip",
+      "cimgui_name": "igSetTooltip",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetTooltip",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igSetTooltipV",
+      "cimgui_name": "igSetTooltipV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetTooltipV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowCollapsed_Bool",
+      "cimgui_name": "igSetWindowCollapsed",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowCollapsed",
+      "c_arguments": "(bool collapsed,ImGuiCond cond)",
+      "signature": "(bool,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "collapsed",
+          "type": "bool"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowCollapsed_Str",
+      "cimgui_name": "igSetWindowCollapsed",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowCollapsed",
+      "c_arguments": "(const char*name,bool collapsed,ImGuiCond cond)",
+      "signature": "(const char*,bool,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "const char*"
+        },
+        {
+          "name": "collapsed",
+          "type": "bool"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowFocus_Nil",
+      "cimgui_name": "igSetWindowFocus",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowFocus",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowFocus_Str",
+      "cimgui_name": "igSetWindowFocus",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowFocus",
+      "c_arguments": "(const char*name)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowPos_Str",
+      "cimgui_name": "igSetWindowPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowPos",
+      "c_arguments": "(const char*name,const ImVec2_c pos,ImGuiCond cond)",
+      "signature": "(const char*,const ImVec2,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "const char*"
+        },
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowPos_Vec2",
+      "cimgui_name": "igSetWindowPos",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowPos",
+      "c_arguments": "(const ImVec2_c pos,ImGuiCond cond)",
+      "signature": "(const ImVec2,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "pos",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowSize_Str",
+      "cimgui_name": "igSetWindowSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowSize",
+      "c_arguments": "(const char*name,const ImVec2_c size,ImGuiCond cond)",
+      "signature": "(const char*,const ImVec2,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSetWindowSize_Vec2",
+      "cimgui_name": "igSetWindowSize",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SetWindowSize",
+      "c_arguments": "(const ImVec2_c size,ImGuiCond cond)",
+      "signature": "(const ImVec2,ImGuiCond)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "cond",
+          "type": "ImGuiCond"
+        }
+      ],
+      "defaults": {
+        "cond": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShortcut_Nil",
+      "cimgui_name": "igShortcut",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Shortcut",
+      "c_arguments": "(ImGuiKeyChord key_chord,ImGuiInputFlags flags)",
+      "signature": "(ImGuiKeyChord,ImGuiInputFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "key_chord",
+          "type": "ImGuiKeyChord"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiInputFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShowAboutWindow",
+      "cimgui_name": "igShowAboutWindow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowAboutWindow",
+      "c_arguments": "(bool*p_open)",
+      "signature": "(bool*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "p_open",
+          "type": "bool*"
+        }
+      ],
+      "defaults": {
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShowDebugLogWindow",
+      "cimgui_name": "igShowDebugLogWindow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowDebugLogWindow",
+      "c_arguments": "(bool*p_open)",
+      "signature": "(bool*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "p_open",
+          "type": "bool*"
+        }
+      ],
+      "defaults": {
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShowDemoWindow",
+      "cimgui_name": "igShowDemoWindow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowDemoWindow",
+      "c_arguments": "(bool*p_open)",
+      "signature": "(bool*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "p_open",
+          "type": "bool*"
+        }
+      ],
+      "defaults": {
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShowFontSelector",
+      "cimgui_name": "igShowFontSelector",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowFontSelector",
+      "c_arguments": "(const char*label)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igShowIDStackToolWindow",
+      "cimgui_name": "igShowIDStackToolWindow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowIDStackToolWindow",
+      "c_arguments": "(bool*p_open)",
+      "signature": "(bool*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "p_open",
+          "type": "bool*"
+        }
+      ],
+      "defaults": {
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShowMetricsWindow",
+      "cimgui_name": "igShowMetricsWindow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowMetricsWindow",
+      "c_arguments": "(bool*p_open)",
+      "signature": "(bool*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "p_open",
+          "type": "bool*"
+        }
+      ],
+      "defaults": {
+        "p_open": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShowStyleEditor",
+      "cimgui_name": "igShowStyleEditor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowStyleEditor",
+      "c_arguments": "(ImGuiStyle*ref)",
+      "signature": "(ImGuiStyle*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ref",
+          "type": "ImGuiStyle*"
+        }
+      ],
+      "defaults": {
+        "ref": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igShowStyleSelector",
+      "cimgui_name": "igShowStyleSelector",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowStyleSelector",
+      "c_arguments": "(const char*label)",
+      "signature": "(const char*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igShowUserGuide",
+      "cimgui_name": "igShowUserGuide",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "ShowUserGuide",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderAngle",
+      "cimgui_name": "igSliderAngle",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderAngle",
+      "c_arguments": "(const char*label,float*v_rad,float v_degrees_min,float v_degrees_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float*,float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v_rad",
+          "type": "float*"
+        },
+        {
+          "name": "v_degrees_min",
+          "type": "float"
+        },
+        {
+          "name": "v_degrees_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.0f deg\"",
+        "v_degrees_max": "+360.0f",
+        "v_degrees_min": "-360.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderFloat",
+      "cimgui_name": "igSliderFloat",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderFloat",
+      "c_arguments": "(const char*label,float*v,float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float*,float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float*"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderFloat2",
+      "cimgui_name": "igSliderFloat2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderFloat2",
+      "c_arguments": "(const char*label,float v[2],float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float[2],float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[2]"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderFloat3",
+      "cimgui_name": "igSliderFloat3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderFloat3",
+      "c_arguments": "(const char*label,float v[3],float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float[3],float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[3]"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderFloat4",
+      "cimgui_name": "igSliderFloat4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderFloat4",
+      "c_arguments": "(const char*label,float v[4],float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,float[4],float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float[4]"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderInt",
+      "cimgui_name": "igSliderInt",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderInt",
+      "c_arguments": "(const char*label,int*v,int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int*,int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int*"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderInt2",
+      "cimgui_name": "igSliderInt2",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderInt2",
+      "c_arguments": "(const char*label,int v[2],int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int[2],int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[2]"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderInt3",
+      "cimgui_name": "igSliderInt3",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderInt3",
+      "c_arguments": "(const char*label,int v[3],int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int[3],int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[3]"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderInt4",
+      "cimgui_name": "igSliderInt4",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderInt4",
+      "c_arguments": "(const char*label,int v[4],int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,int[4],int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int[4]"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderScalar",
+      "cimgui_name": "igSliderScalar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderScalar",
+      "c_arguments": "(const char*label,ImGuiDataType data_type,void*p_data,const void*p_min,const void*p_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,ImGuiDataType,void*,const void*,const void*,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "data_type",
+          "type": "ImGuiDataType"
+        },
+        {
+          "name": "p_data",
+          "type": "void*"
+        },
+        {
+          "name": "p_min",
+          "type": "const void*"
+        },
+        {
+          "name": "p_max",
+          "type": "const void*"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSliderScalarN",
+      "cimgui_name": "igSliderScalarN",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SliderScalarN",
+      "c_arguments": "(const char*label,ImGuiDataType data_type,void*p_data,int components,const void*p_min,const void*p_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,ImGuiDataType,void*,int,const void*,const void*,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "data_type",
+          "type": "ImGuiDataType"
+        },
+        {
+          "name": "p_data",
+          "type": "void*"
+        },
+        {
+          "name": "components",
+          "type": "int"
+        },
+        {
+          "name": "p_min",
+          "type": "const void*"
+        },
+        {
+          "name": "p_max",
+          "type": "const void*"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igSmallButton",
+      "cimgui_name": "igSmallButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "SmallButton",
+      "c_arguments": "(const char*label)",
+      "signature": "(const char*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igSpacing",
+      "cimgui_name": "igSpacing",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Spacing",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igStyleColorsClassic",
+      "cimgui_name": "igStyleColorsClassic",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "StyleColorsClassic",
+      "c_arguments": "(ImGuiStyle*dst)",
+      "signature": "(ImGuiStyle*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "dst",
+          "type": "ImGuiStyle*"
+        }
+      ],
+      "defaults": {
+        "dst": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igStyleColorsDark",
+      "cimgui_name": "igStyleColorsDark",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "StyleColorsDark",
+      "c_arguments": "(ImGuiStyle*dst)",
+      "signature": "(ImGuiStyle*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "dst",
+          "type": "ImGuiStyle*"
+        }
+      ],
+      "defaults": {
+        "dst": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igStyleColorsLight",
+      "cimgui_name": "igStyleColorsLight",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "StyleColorsLight",
+      "c_arguments": "(ImGuiStyle*dst)",
+      "signature": "(ImGuiStyle*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "dst",
+          "type": "ImGuiStyle*"
+        }
+      ],
+      "defaults": {
+        "dst": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTabItemButton",
+      "cimgui_name": "igTabItemButton",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TabItemButton",
+      "c_arguments": "(const char*label,ImGuiTabItemFlags flags)",
+      "signature": "(const char*,ImGuiTabItemFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTabItemFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTableAngledHeadersRow",
+      "cimgui_name": "igTableAngledHeadersRow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableAngledHeadersRow",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableGetColumnCount",
+      "cimgui_name": "igTableGetColumnCount",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableGetColumnCount",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "int",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableGetColumnFlags",
+      "cimgui_name": "igTableGetColumnFlags",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableGetColumnFlags",
+      "c_arguments": "(int column_n)",
+      "signature": "(int)",
+      "return_type": "ImGuiTableColumnFlags",
+      "arguments": [
+        {
+          "name": "column_n",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "column_n": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTableGetColumnIndex",
+      "cimgui_name": "igTableGetColumnIndex",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableGetColumnIndex",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "int",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableGetColumnName_Int",
+      "cimgui_name": "igTableGetColumnName",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableGetColumnName",
+      "c_arguments": "(int column_n)",
+      "signature": "(int)",
+      "return_type": "const char*",
+      "arguments": [
+        {
+          "name": "column_n",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "column_n": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTableGetHoveredColumn",
+      "cimgui_name": "igTableGetHoveredColumn",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableGetHoveredColumn",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "int",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableGetRowIndex",
+      "cimgui_name": "igTableGetRowIndex",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableGetRowIndex",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "int",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableGetSortSpecs",
+      "cimgui_name": "igTableGetSortSpecs",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableGetSortSpecs",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "ImGuiTableSortSpecs*",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableHeader",
+      "cimgui_name": "igTableHeader",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableHeader",
+      "c_arguments": "(const char*label)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableHeadersRow",
+      "cimgui_name": "igTableHeadersRow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableHeadersRow",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableNextColumn",
+      "cimgui_name": "igTableNextColumn",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableNextColumn",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "bool",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableNextRow",
+      "cimgui_name": "igTableNextRow",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableNextRow",
+      "c_arguments": "(ImGuiTableRowFlags row_flags,float min_row_height)",
+      "signature": "(ImGuiTableRowFlags,float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "row_flags",
+          "type": "ImGuiTableRowFlags"
+        },
+        {
+          "name": "min_row_height",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "min_row_height": "0.0f",
+        "row_flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTableSetBgColor",
+      "cimgui_name": "igTableSetBgColor",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableSetBgColor",
+      "c_arguments": "(ImGuiTableBgTarget target,ImU32 color,int column_n)",
+      "signature": "(ImGuiTableBgTarget,ImU32,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "target",
+          "type": "ImGuiTableBgTarget"
+        },
+        {
+          "name": "color",
+          "type": "ImU32"
+        },
+        {
+          "name": "column_n",
+          "type": "int"
+        }
+      ],
+      "defaults": {
+        "column_n": "-1"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTableSetColumnEnabled",
+      "cimgui_name": "igTableSetColumnEnabled",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableSetColumnEnabled",
+      "c_arguments": "(int column_n,bool v)",
+      "signature": "(int,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "column_n",
+          "type": "int"
+        },
+        {
+          "name": "v",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableSetColumnIndex",
+      "cimgui_name": "igTableSetColumnIndex",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableSetColumnIndex",
+      "c_arguments": "(int column_n)",
+      "signature": "(int)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "column_n",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTableSetupColumn",
+      "cimgui_name": "igTableSetupColumn",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableSetupColumn",
+      "c_arguments": "(const char*label,ImGuiTableColumnFlags flags,float init_width_or_weight,ImGuiID user_id)",
+      "signature": "(const char*,ImGuiTableColumnFlags,float,ImGuiID)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTableColumnFlags"
+        },
+        {
+          "name": "init_width_or_weight",
+          "type": "float"
+        },
+        {
+          "name": "user_id",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "init_width_or_weight": "0.0f",
+        "user_id": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTableSetupScrollFreeze",
+      "cimgui_name": "igTableSetupScrollFreeze",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TableSetupScrollFreeze",
+      "c_arguments": "(int cols,int rows)",
+      "signature": "(int,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "cols",
+          "type": "int"
+        },
+        {
+          "name": "rows",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igText",
+      "cimgui_name": "igText",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Text",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTextColored",
+      "cimgui_name": "igTextColored",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextColored",
+      "c_arguments": "(const ImVec4_c col,const char*fmt,...)",
+      "signature": "(const ImVec4,const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "col",
+          "type": "const ImVec4"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTextColoredV",
+      "cimgui_name": "igTextColoredV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextColoredV",
+      "c_arguments": "(const ImVec4_c col,const char*fmt,va_list args)",
+      "signature": "(const ImVec4,const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "col",
+          "type": "const ImVec4"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTextDisabled",
+      "cimgui_name": "igTextDisabled",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextDisabled",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTextDisabledV",
+      "cimgui_name": "igTextDisabledV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextDisabledV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTextLink",
+      "cimgui_name": "igTextLink",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextLink",
+      "c_arguments": "(const char*label)",
+      "signature": "(const char*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTextLinkOpenURL",
+      "cimgui_name": "igTextLinkOpenURL",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextLinkOpenURL",
+      "c_arguments": "(const char*label,const char*url)",
+      "signature": "(const char*,const char*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "url",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "url": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTextUnformatted",
+      "cimgui_name": "igTextUnformatted",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextUnformatted",
+      "c_arguments": "(const char*text,const char*text_end)",
+      "signature": "(const char*,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "text",
+          "type": "const char*"
+        },
+        {
+          "name": "text_end",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "text_end": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTextV",
+      "cimgui_name": "igTextV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTextWrapped",
+      "cimgui_name": "igTextWrapped",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextWrapped",
+      "c_arguments": "(const char*fmt,...)",
+      "signature": "(const char*,...)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTextWrappedV",
+      "cimgui_name": "igTextWrappedV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TextWrappedV",
+      "c_arguments": "(const char*fmt,va_list args)",
+      "signature": "(const char*,va_list)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNodeExV_Ptr",
+      "cimgui_name": "igTreeNodeExV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeExV",
+      "c_arguments": "(const void*ptr_id,ImGuiTreeNodeFlags flags,const char*fmt,va_list args)",
+      "signature": "(const void*,ImGuiTreeNodeFlags,const char*,va_list)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "ptr_id",
+          "type": "const void*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTreeNodeFlags"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNodeExV_Str",
+      "cimgui_name": "igTreeNodeExV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeExV",
+      "c_arguments": "(const char*str_id,ImGuiTreeNodeFlags flags,const char*fmt,va_list args)",
+      "signature": "(const char*,ImGuiTreeNodeFlags,const char*,va_list)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTreeNodeFlags"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNodeEx_Ptr",
+      "cimgui_name": "igTreeNodeEx",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeEx",
+      "c_arguments": "(const void*ptr_id,ImGuiTreeNodeFlags flags,const char*fmt,...)",
+      "signature": "(const void*,ImGuiTreeNodeFlags,const char*,...)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "ptr_id",
+          "type": "const void*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTreeNodeFlags"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTreeNodeEx_Str",
+      "cimgui_name": "igTreeNodeEx",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeEx",
+      "c_arguments": "(const char*label,ImGuiTreeNodeFlags flags)",
+      "signature": "(const char*,ImGuiTreeNodeFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTreeNodeFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNodeEx_StrStr",
+      "cimgui_name": "igTreeNodeEx",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeEx",
+      "c_arguments": "(const char*str_id,ImGuiTreeNodeFlags flags,const char*fmt,...)",
+      "signature": "(const char*,ImGuiTreeNodeFlags,const char*,...)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiTreeNodeFlags"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTreeNodeGetOpen",
+      "cimgui_name": "igTreeNodeGetOpen",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeGetOpen",
+      "c_arguments": "(ImGuiID storage_id)",
+      "signature": "(ImGuiID)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "storage_id",
+          "type": "ImGuiID"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNodeV_Ptr",
+      "cimgui_name": "igTreeNodeV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeV",
+      "c_arguments": "(const void*ptr_id,const char*fmt,va_list args)",
+      "signature": "(const void*,const char*,va_list)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "ptr_id",
+          "type": "const void*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNodeV_Str",
+      "cimgui_name": "igTreeNodeV",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNodeV",
+      "c_arguments": "(const char*str_id,const char*fmt,va_list args)",
+      "signature": "(const char*,const char*,va_list)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "args",
+          "type": "va_list"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNode_Ptr",
+      "cimgui_name": "igTreeNode",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNode",
+      "c_arguments": "(const void*ptr_id,const char*fmt,...)",
+      "signature": "(const void*,const char*,...)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "ptr_id",
+          "type": "const void*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTreeNode_Str",
+      "cimgui_name": "igTreeNode",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNode",
+      "c_arguments": "(const char*label)",
+      "signature": "(const char*)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreeNode_StrStr",
+      "cimgui_name": "igTreeNode",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreeNode",
+      "c_arguments": "(const char*str_id,const char*fmt,...)",
+      "signature": "(const char*,const char*,...)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        },
+        {
+          "name": "fmt",
+          "type": "const char*"
+        },
+        {
+          "name": "...",
+          "type": "..."
+        }
+      ],
+      "defaults": {},
+      "traits": {
+        "isvararg": "...)"
+      }
+    },
+    {
+      "symbol": "igTreePop",
+      "cimgui_name": "igTreePop",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreePop",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreePush_Ptr",
+      "cimgui_name": "igTreePush",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreePush",
+      "c_arguments": "(const void*ptr_id)",
+      "signature": "(const void*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "ptr_id",
+          "type": "const void*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igTreePush_Str",
+      "cimgui_name": "igTreePush",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "TreePush",
+      "c_arguments": "(const char*str_id)",
+      "signature": "(const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "str_id",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igUnindent",
+      "cimgui_name": "igUnindent",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Unindent",
+      "c_arguments": "(float indent_w)",
+      "signature": "(float)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "indent_w",
+          "type": "float"
+        }
+      ],
+      "defaults": {
+        "indent_w": "0.0f"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igUpdatePlatformWindows",
+      "cimgui_name": "igUpdatePlatformWindows",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "UpdatePlatformWindows",
+      "c_arguments": "()",
+      "signature": "()",
+      "return_type": "void",
+      "arguments": [],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igVSliderFloat",
+      "cimgui_name": "igVSliderFloat",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "VSliderFloat",
+      "c_arguments": "(const char*label,const ImVec2_c size,float*v,float v_min,float v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,const ImVec2,float*,float,float,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "v",
+          "type": "float*"
+        },
+        {
+          "name": "v_min",
+          "type": "float"
+        },
+        {
+          "name": "v_max",
+          "type": "float"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%.3f\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igVSliderInt",
+      "cimgui_name": "igVSliderInt",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "VSliderInt",
+      "c_arguments": "(const char*label,const ImVec2_c size,int*v,int v_min,int v_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,const ImVec2,int*,int,int,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "v",
+          "type": "int*"
+        },
+        {
+          "name": "v_min",
+          "type": "int"
+        },
+        {
+          "name": "v_max",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "\"%d\""
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igVSliderScalar",
+      "cimgui_name": "igVSliderScalar",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "VSliderScalar",
+      "c_arguments": "(const char*label,const ImVec2_c size,ImGuiDataType data_type,void*p_data,const void*p_min,const void*p_max,const char*format,ImGuiSliderFlags flags)",
+      "signature": "(const char*,const ImVec2,ImGuiDataType,void*,const void*,const void*,const char*,ImGuiSliderFlags)",
+      "return_type": "bool",
+      "arguments": [
+        {
+          "name": "label",
+          "type": "const char*"
+        },
+        {
+          "name": "size",
+          "type": "const ImVec2"
+        },
+        {
+          "name": "data_type",
+          "type": "ImGuiDataType"
+        },
+        {
+          "name": "p_data",
+          "type": "void*"
+        },
+        {
+          "name": "p_min",
+          "type": "const void*"
+        },
+        {
+          "name": "p_max",
+          "type": "const void*"
+        },
+        {
+          "name": "format",
+          "type": "const char*"
+        },
+        {
+          "name": "flags",
+          "type": "ImGuiSliderFlags"
+        }
+      ],
+      "defaults": {
+        "flags": "0",
+        "format": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igValue_Bool",
+      "cimgui_name": "igValue",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Value",
+      "c_arguments": "(const char*prefix,bool b)",
+      "signature": "(const char*,bool)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "prefix",
+          "type": "const char*"
+        },
+        {
+          "name": "b",
+          "type": "bool"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igValue_Float",
+      "cimgui_name": "igValue",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Value",
+      "c_arguments": "(const char*prefix,float v,const char*float_format)",
+      "signature": "(const char*,float,const char*)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "prefix",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "float"
+        },
+        {
+          "name": "float_format",
+          "type": "const char*"
+        }
+      ],
+      "defaults": {
+        "float_format": "NULL"
+      },
+      "traits": {}
+    },
+    {
+      "symbol": "igValue_Int",
+      "cimgui_name": "igValue",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Value",
+      "c_arguments": "(const char*prefix,int v)",
+      "signature": "(const char*,int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "prefix",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    },
+    {
+      "symbol": "igValue_Uint",
+      "cimgui_name": "igValue",
+      "namespace": "ImGui",
+      "struct": "",
+      "function": "Value",
+      "c_arguments": "(const char*prefix,unsigned int v)",
+      "signature": "(const char*,unsigned int)",
+      "return_type": "void",
+      "arguments": [
+        {
+          "name": "prefix",
+          "type": "const char*"
+        },
+        {
+          "name": "v",
+          "type": "unsigned int"
+        }
+      ],
+      "defaults": {},
+      "traits": {}
+    }
+  ]
+}

--- a/tools/tests/test_api_surface_report.py
+++ b/tools/tests/test_api_surface_report.py
@@ -1,0 +1,459 @@
+import contextlib
+import copy
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_DIR = REPO_ROOT / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import api_surface_report  # noqa: E402
+
+
+CIMGUI_REVISION = "1" * 40
+IMGUI_REVISION = "2" * 40
+
+
+def declaration(
+    funcname="Foo",
+    symbol="igFoo",
+    signature="()",
+    namespace="ImGui",
+    location="imgui:1",
+    ret="void",
+):
+    return {
+        "args": signature,
+        "argsT": [],
+        "cimguiname": symbol.split("_")[0],
+        "defaults": {},
+        "funcname": funcname,
+        "location": location,
+        "namespace": namespace,
+        "ov_cimguiname": symbol,
+        "ret": ret,
+        "signature": signature,
+        "stname": "" if namespace == "ImGui" else namespace,
+    }
+
+
+def empty_policy():
+    return {"schema_version": 2, "scope": "ImGui", "groups": []}
+
+
+class CliFixture:
+    def __init__(self, root: Path):
+        self.root = root
+        self.definitions = root / "definitions.json"
+        self.rust_source = root / "rust"
+        self.manifest = root / "Cargo.toml"
+        self.policy = root / "policy.json"
+        self.snapshot = root / "snapshot.json"
+        self.rust_source.mkdir()
+
+    def write(
+        self,
+        definitions=None,
+        rust_source='#[doc(alias = "Foo")]\npub fn foo() {}\n',
+        policy=None,
+    ):
+        if definitions is None:
+            definitions = {"Foo": [declaration()]}
+        if policy is None:
+            policy = empty_policy()
+        self.definitions.write_text(json.dumps(definitions), encoding="utf-8")
+        (self.rust_source / "lib.rs").write_text(rust_source, encoding="utf-8")
+        self.policy.write_text(json.dumps(policy), encoding="utf-8")
+        self.manifest.write_text(
+            "[package]\n"
+            'name = "fixture"\n'
+            'version = "0.0.0"\n'
+            "\n[package.metadata.dear-imgui-sources]\n"
+            f'cimgui-revision = "{CIMGUI_REVISION}"\n'
+            f'imgui-revision = "{IMGUI_REVISION}"\n',
+            encoding="utf-8",
+        )
+        loaded = api_surface_report._load_public_declarations(self.definitions)
+        api_surface_report._write_snapshot(
+            self.snapshot,
+            loaded,
+            {"cimgui": CIMGUI_REVISION, "imgui": IMGUI_REVISION},
+        )
+
+    def args(self):
+        return [
+            "--definitions",
+            str(self.definitions),
+            "--rust-source",
+            str(self.rust_source),
+            "--manifest",
+            str(self.manifest),
+            "--policy",
+            str(self.policy),
+            "--snapshot",
+            str(self.snapshot),
+            "--check",
+        ]
+
+    def run(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            result = api_surface_report.main(self.args())
+        return result, stdout.getvalue(), stderr.getvalue()
+
+
+class ApiSurfaceReportTests(unittest.TestCase):
+    def test_repository_policy_and_snapshot_cover_the_current_surface(self):
+        declarations = api_surface_report._load_public_declarations(
+            api_surface_report.DEFS_JSON
+        )
+        groups = api_surface_report._group_top_level_imgui(declarations)
+        aliases = api_surface_report._collect_doc_aliases(
+            api_surface_report._iter_rs_files(api_surface_report.DEAR_IMGUI_SRC)
+        )
+        policy = api_surface_report._load_policy(api_surface_report.POLICY_JSON)
+        revisions = api_surface_report._load_source_revisions(
+            api_surface_report.MANIFEST_TOML
+        )
+        snapshot_revisions, snapshot_values = api_surface_report._load_snapshot(
+            api_surface_report.SNAPSHOT_JSON
+        )
+
+        audit = api_surface_report._audit_surface(groups, aliases, policy)
+        drift = api_surface_report._compare_snapshot(
+            declarations,
+            revisions,
+            snapshot_values,
+            snapshot_revisions,
+        )
+
+        self.assertEqual(len(declarations), 748)
+        self.assertEqual(audit.unexpected, frozenset())
+        self.assertEqual(audit.stale_policy, frozenset())
+        self.assertFalse(drift.has_drift())
+        self.assertEqual(
+            len(audit.aliased) + len(audit.policy_decided),
+            len(groups),
+        )
+        self.assertNotIn(
+            "safe-equivalent",
+            {decision.classification for decision in policy.values()},
+        )
+
+    def test_alias_collector_accepts_only_public_safe_items(self):
+        source = r'''
+// #[doc(alias = "LineComment")]
+/* #[doc(alias = "BlockComment")] */
+const NORMAL: &str = "#[doc(alias = \\"NormalString\\")] pub fn fake() {}";
+const RAW: &str = r###"#[doc(alias = "RawString")] pub fn fake() {}"###;
+
+#[doc(alias = "PrivateFn")]
+fn private_fn() {}
+
+#[doc(alias = "CrateOnly")]
+pub(crate) fn crate_only() {}
+
+#[cfg(test)]
+#[doc(alias = "CfgTest")]
+pub fn cfg_test() {}
+
+#[cfg_attr(test, doc(alias = "CfgAttrTest"))]
+pub fn cfg_attr_test() {}
+
+#[doc(alias = "UnsafeFn")]
+pub unsafe fn unsafe_fn() {}
+
+#[doc(alias = "HiddenFn")]
+#[doc(hidden)]
+pub fn hidden_fn() {}
+
+mod private_module {
+    #[doc(alias = "PrivateModuleFn")]
+    pub fn visible_only_inside_parent() {}
+}
+
+#[cfg(test)]
+mod tests {
+    #[doc(alias = "TestModuleFn")]
+    pub fn helper() {}
+}
+
+#[doc(alias = "SafeFn")]
+pub fn safe_fn<'a>(value: &'a str) -> &'a str { value }
+
+#[doc(alias = "SafeType")]
+pub struct SafeType;
+
+impl SafeType {
+    #[doc(alias = "SafeMethod")]
+    pub fn safe_method(&self) {}
+}
+
+pub mod exported {
+    #[doc(alias = "NestedSafe")]
+    pub fn nested_safe() {}
+}
+
+create_token!(
+    #[doc(alias = "MacroToken")]
+    pub struct Token<'ui>;
+    drop { () }
+);
+'''
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "fixture.rs"
+            path.write_text(source, encoding="utf-8")
+            aliases = api_surface_report._collect_doc_aliases([path])
+
+        self.assertEqual(
+            aliases,
+            {"SafeFn", "SafeType", "SafeMethod", "NestedSafe", "MacroToken"},
+        )
+
+    def test_policy_schema_is_fail_closed(self):
+        valid_group = {
+            "classification": "deferred-design",
+            "name": "deferred",
+            "reason": "Needs a lifetime design.",
+            "functions": ["Foo"],
+        }
+        invalid_policies = {
+            "boolean schema": {
+                "schema_version": True,
+                "scope": "ImGui",
+                "groups": [valid_group],
+            },
+            "unknown top key": {
+                "schema_version": 2,
+                "scope": "ImGui",
+                "groups": [valid_group],
+                "extra": True,
+            },
+            "unknown group key": {
+                "schema_version": 2,
+                "scope": "ImGui",
+                "groups": [{**valid_group, "extra": True}],
+            },
+            "safe equivalent": {
+                "schema_version": 2,
+                "scope": "ImGui",
+                "groups": [{**valid_group, "classification": "safe-equivalent"}],
+            },
+            "empty functions": {
+                "schema_version": 2,
+                "scope": "ImGui",
+                "groups": [{**valid_group, "functions": []}],
+            },
+            "duplicate functions": {
+                "schema_version": 2,
+                "scope": "ImGui",
+                "groups": [{**valid_group, "functions": ["Foo", "Foo"]}],
+            },
+            "duplicate group names": {
+                "schema_version": 2,
+                "scope": "ImGui",
+                "groups": [valid_group, {**valid_group, "functions": ["Bar"]}],
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "policy.json"
+            for name, policy in invalid_policies.items():
+                with self.subTest(name=name):
+                    path.write_text(json.dumps(policy), encoding="utf-8")
+                    with self.assertRaises(api_surface_report.InputError):
+                        api_surface_report._load_policy(path)
+
+    def test_policy_rejects_duplicate_function_decisions(self):
+        policy = {
+            "schema_version": 2,
+            "scope": "ImGui",
+            "groups": [
+                {
+                    "classification": "deferred-design",
+                    "name": "first",
+                    "reason": "first decision",
+                    "functions": ["Foo"],
+                },
+                {
+                    "classification": "intentional-sys-only",
+                    "name": "second",
+                    "reason": "second decision",
+                    "functions": ["Foo"],
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "policy.json"
+            path.write_text(json.dumps(policy), encoding="utf-8")
+            with self.assertRaisesRegex(api_surface_report.InputError, "both 'first' and 'second'"):
+                api_surface_report._load_policy(path)
+
+    def test_cli_clean_surface_returns_zero(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = CliFixture(Path(temp_dir))
+            fixture.write()
+            result, stdout, stderr = fixture.run()
+
+        self.assertEqual(result, 0)
+        self.assertIn("checks passed", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_cli_unexpected_and_stale_policy_return_one(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = CliFixture(Path(temp_dir))
+            fixture.write(rust_source="pub fn unrelated() {}\n")
+            result, _, stderr = fixture.run()
+            self.assertEqual(result, 1)
+            self.assertIn("Unexpected missing", stderr)
+
+            policy = {
+                "schema_version": 2,
+                "scope": "ImGui",
+                "groups": [
+                    {
+                        "classification": "deferred-design",
+                        "name": "stale",
+                        "reason": "Covered directly now.",
+                        "functions": ["Foo"],
+                    }
+                ],
+            }
+            fixture.policy.write_text(json.dumps(policy), encoding="utf-8")
+            (fixture.rust_source / "lib.rs").write_text(
+                '#[doc(alias = "Foo")]\npub fn foo() {}\n', encoding="utf-8"
+            )
+            result, _, stderr = fixture.run()
+            self.assertEqual(result, 1)
+            self.assertIn("Stale API surface policy", stderr)
+
+    def test_cli_detects_overload_signature_and_namespace_drift(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = CliFixture(Path(temp_dir))
+            fixture.write()
+
+            definitions = json.loads(fixture.definitions.read_text(encoding="utf-8"))
+            definitions["Foo"].append(
+                declaration(symbol="igFoo_Int", signature="(int)")
+            )
+            fixture.definitions.write_text(json.dumps(definitions), encoding="utf-8")
+            result, _, stderr = fixture.run()
+            self.assertEqual(result, 1)
+            self.assertIn("added declarations", stderr)
+            self.assertIn("igFoo_Int", stderr)
+
+            fixture.write()
+            definitions = json.loads(fixture.definitions.read_text(encoding="utf-8"))
+            definitions["Foo"][0]["signature"] = "(float)"
+            definitions["Foo"][0]["args"] = "(float value)"
+            fixture.definitions.write_text(json.dumps(definitions), encoding="utf-8")
+            result, _, stderr = fixture.run()
+            self.assertEqual(result, 1)
+            self.assertIn("changed declarations", stderr)
+
+            fixture.write()
+            definitions = json.loads(fixture.definitions.read_text(encoding="utf-8"))
+            definitions["Draw"] = [
+                declaration(
+                    funcname="AddThing",
+                    symbol="ImDrawList_AddThing",
+                    namespace="ImDrawList",
+                )
+            ]
+            fixture.definitions.write_text(json.dumps(definitions), encoding="utf-8")
+            result, _, stderr = fixture.run()
+            self.assertEqual(result, 1)
+            self.assertIn("ImDrawList_AddThing", stderr)
+
+    def test_cli_ignores_generator_line_number_only_changes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = CliFixture(Path(temp_dir))
+            fixture.write()
+            definitions = json.loads(fixture.definitions.read_text(encoding="utf-8"))
+            definitions["Foo"][0]["location"] = "imgui:9999"
+            fixture.definitions.write_text(json.dumps(definitions), encoding="utf-8")
+            result, _, stderr = fixture.run()
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+
+    def test_cli_revision_drift_returns_one(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = CliFixture(Path(temp_dir))
+            fixture.write()
+            fixture.manifest.write_text(
+                "[package]\n"
+                'name = "fixture"\n'
+                'version = "0.0.0"\n'
+                "\n[package.metadata.dear-imgui-sources]\n"
+                f'cimgui-revision = "{"3" * 40}"\n'
+                f'imgui-revision = "{IMGUI_REVISION}"\n',
+                encoding="utf-8",
+            )
+            result, _, stderr = fixture.run()
+
+        self.assertEqual(result, 1)
+        self.assertIn("source revision drift", stderr)
+
+    def test_cli_invalid_inputs_return_two(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = CliFixture(Path(temp_dir))
+            fixture.write()
+            cases = {
+                "invalid policy json": (fixture.policy, "{"),
+                "invalid definitions utf8": (fixture.definitions, b"\xff"),
+                "invalid snapshot schema": (
+                    fixture.snapshot,
+                    json.dumps({"schema_version": True}),
+                ),
+            }
+            for name, (path, content) in cases.items():
+                with self.subTest(name=name):
+                    fixture.write()
+                    if isinstance(content, bytes):
+                        path.write_bytes(content)
+                    else:
+                        path.write_text(content, encoding="utf-8")
+                    result, _, stderr = fixture.run()
+                    self.assertEqual(result, 2)
+                    self.assertIn("API surface input error", stderr)
+
+            fixture.write()
+            fixture.snapshot.unlink()
+            result, _, stderr = fixture.run()
+            self.assertEqual(result, 2)
+            self.assertIn("API surface input error", stderr)
+
+    def test_snapshot_schema_rejects_unknown_and_malformed_fields(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = CliFixture(Path(temp_dir))
+            fixture.write()
+            snapshot = json.loads(fixture.snapshot.read_text(encoding="utf-8"))
+            invalid_values = []
+
+            unknown = copy.deepcopy(snapshot)
+            unknown["extra"] = True
+            invalid_values.append(unknown)
+
+            malformed = copy.deepcopy(snapshot)
+            malformed["declarations"][0]["arguments"] = "not an array"
+            invalid_values.append(malformed)
+
+            boolean_schema = copy.deepcopy(snapshot)
+            boolean_schema["schema_version"] = True
+            invalid_values.append(boolean_schema)
+
+            for value in invalid_values:
+                fixture.snapshot.write_text(json.dumps(value), encoding="utf-8")
+                with self.assertRaises(api_surface_report.InputError):
+                    api_surface_report._load_snapshot(fixture.snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

This completes the reviewed safe Rust surface for the pinned cimgui/Dear ImGui revision. It adds direct integer table column IDs, current-font text measurement, typed stack and input helpers, font/list-clipper/debug/style coverage, effective managed texture IDs, and fixes tree, combo, and multi-select semantics found during the audit.

The PR also adds a source-pinned snapshot of every public cimgui generator declaration and an explicit policy for top-level `ImGui` functions that are intentionally sys-only or require a future lifetime design. CI now rejects generator drift, stale policy entries, and unreviewed safe API gaps.

## Why

Issues #39 and #40 exposed that raw cimgui availability was not enough to make the corresponding operations usable from safe Rust. The previous report also treated internal `sys` usage as coverage, which could hide missing public interfaces. The new audit requires an accessible safe rustdoc alias or a reviewed policy decision.

The pinned surface contains 748 public declarations across all namespaces and 376 top-level `ImGui` function groups: 347 map to public safe Rust items and 29 have explicit policy decisions. Lifetime-sensitive namespaced font and custom-rectangle APIs remain documented design work rather than mechanical wrappers.

## Affected crates

- [x] `dear-imgui-rs`
- [ ] `dear-imgui-sys`
- [x] `backends/dear-imgui-wgpu`
- [x] `backends/dear-imgui-glow`
- [x] `backends/dear-imgui-ash`
- [ ] `backends/dear-imgui-winit`
- [ ] `backends/dear-imgui-sdl3`
- [ ] `dear-app`
- [ ] extensions
- [x] CI / tooling / docs

## Behavior

- [x] Source build only
- [ ] Prebuilt logic (feature/env)
- [ ] Packaging (.tar.gz)
- [ ] No behavior change (refactor/cleanup)

The pinned cimgui and Dear ImGui revisions and the existing owner-bound context architecture are unchanged.

## Breaking changes

- [x] Yes: remove the incomplete `FontLoader::new` and `FontLoader::with_loader_init` stubs. Use `FontLoader::stb_truetype()` for the built-in loader, or `unsafe FontLoader::from_raw` for a complete externally owned native callback table.

## Testing / validation

```text
cargo fmt --all -- --check
cargo nextest run -p dear-imgui-rs --no-fail-fast
cargo test -p dear-imgui-rs --doc
cargo check -p dear-imgui-wgpu --lib
cargo check -p dear-imgui-glow --lib
cargo check -p dear-imgui-ash --lib
cargo check -p dear-imgui-rs --target wasm32-unknown-unknown --no-default-features --features wasm
python -m unittest discover -s tools/tests -p test_api_surface_report.py
python tools/api_surface_report.py --check
git diff --check origin/main...HEAD
```

Core nextest passed 283/283 tests. The coverage tool passed 11/11 tests and reported 347 safe mappings plus 29 explicit policy decisions. Native checks ran on Windows; the WASM check completed with existing dead-code warnings only.

## Docs

- [x] Updated `CHANGELOG.md`, crate docs, and `docs/API_COVERAGE.md`

## Links

- Fixes #39
- Fixes #40