### PR TITLE
Make tracing crate optional

### DIFF
--- a/dear-imgui/Cargo.toml
+++ b/dear-imgui/Cargo.toml
@@ -28,7 +28,7 @@ glam = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [features]
-default = ["tracing"]
+default = []
 # Docking is always enabled; feature removed.
 # Enable multi-viewport support (define feature to satisfy cfg checks; opt-in)
 multi-viewport = []


### PR DESCRIPTION
- What
  - Tracing crate is always pulled and built even with default-features = false.

- Why
  - Decreases compile time :)

- Affected crates
  - [x] dear-imgui-rs
  - [ ] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [ ] backends/dear-imgui-winit
  - [ ] backends/dear-imgui-sdl3
  - [ ] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [ ] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [x] No behavior change (refactor/cleanup)

- Breaking changes
  - [x] None (I think)
  - [ ] Yes (describe):

- Testing / validation
  - Patched my own project with [patch.crates-io]
  - x86_64-unknown-linux-gnu

- Docs
  - [ ] N/A
  - [ ] Updated README / crate docs

- Links
  - Fixes #
  - Related #
