### PR TITLE
fix(ci): retain the authoritative release decision

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -538,7 +538,7 @@ jobs:
           --repo-root "${{ github.workspace }}"
           --candidate-sha "${{ inputs.candidate_sha }}"
           --evidence-root target/release-evidence/cells
-          --output target/release-evidence/cells/gate-result.json
+          --output gate-result.json
 
       - name: Retain authoritative release decision
         if: always()

--- a/tools/tests/test_release_gate_workflow.py
+++ b/tools/tests/test_release_gate_workflow.py
@@ -156,6 +156,27 @@ class ReleaseGateWorkflowTests(unittest.TestCase):
         self.assertIn("if: always()", gate)
         self.assertIn("retention-days: 30", gate)
 
+    def test_aggregate_output_is_relative_to_the_evidence_root(self):
+        jobs = workflow_jobs(parsed_workflow("release-gate.yml"))
+        aggregate = jobs["aggregate"]
+        command = shlex.split(
+            named_step(aggregate, "Aggregate exact-SHA release evidence").get(
+                "run", ""
+            )
+        )
+        self.assertEqual(
+            command[command.index("--evidence-root") + 1],
+            "target/release-evidence/cells",
+        )
+        self.assertEqual(command[command.index("--output") + 1], "gate-result.json")
+
+        retain = named_step(aggregate, "Retain authoritative release decision")
+        retain_inputs = require_mapping(retain.get("with"), "aggregate.retain.with")
+        self.assertEqual(
+            retain_inputs.get("path"),
+            "target/release-evidence/cells/gate-result.json",
+        )
+
     def test_candidate_sha_is_required_and_checked_out_exactly(self):
         gate = workflow("release-gate.yml")
         native = workflow("native-runtime.yml")


### PR DESCRIPTION
- What
  - Release Gate now retains the authoritative `gate-result.json` at the artifact path consumed by the upload step, so a successful exact-SHA aggregate can be published instead of being reported as an upload failure.

- Why
  - The evidence aggregator resolves relative output paths beneath `--evidence-root`. Passing the full evidence-root path duplicated that prefix and left the expected artifact missing even though all release cells and the aggregate decision succeeded.

- Affected crates
  - [ ] dear-imgui-rs
  - [ ] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [ ] backends/dear-imgui-winit
  - [ ] backends/dear-imgui-sdl3
  - [ ] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [x] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [x] No product behavior change (CI evidence retention only)

- Breaking changes
  - [x] None
  - [ ] Yes (describe):

- Testing / validation
  - `python -B -m unittest tools.tests.test_release_gate_workflow tools.tests.test_release_evidence tools.tests.test_release_cell` (62 passed)
  - `python -B tools/ci/workflow_policy.py --check` (passed)
  - `git diff --check` (passed)
  - The failed release-gate run confirmed all 13 required cells and the aggregate decision were successful; only artifact upload could not find the nested output path.
  - After merge, the formal Release Gate will be rerun against the final `main` SHA and its retained decision artifact will be audited.

- Docs
  - [x] N/A
  - [ ] Updated README / crate docs

- Links
  - Fixes #
  - Related: #44

## Post-Deploy Monitoring & Validation

- Rerun the formal Release Gate on the final merged `main` commit.
- Verify the retained artifact contains `gate-result.json` with an exact candidate SHA, decision `Go`, 13 successful cells, and zero failed cells.
