### PR TITLE
fix(ci): remove deprecated Node LLVM setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,10 +318,9 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Install fixed LLVM toolchain
-        uses: KyleMayes/install-llvm-action@v2.0.9
-        with:
-          directory: ${{ runner.temp }}/llvm
-          version: '14.0'
+        run: >-
+          python3 tools/ci/install_llvm.py
+          --destination "${{ runner.temp }}/llvm"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/tools/ci/install_llvm.py
+++ b/tools/ci/install_llvm.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Install the pinned LLVM toolchain used to regenerate bindings in CI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import BinaryIO, Protocol
+
+
+CI_DIR = Path(__file__).resolve().parent
+if str(CI_DIR) not in sys.path:
+    sys.path.insert(0, str(CI_DIR))
+
+from _process import CommandError, run  # noqa: E402
+
+
+LLVM_VERSION = "14.0.0"
+LLVM_ARCHIVE_NAME = "clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
+LLVM_ARCHIVE_URL = (
+    "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/"
+    "clang%2Bllvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
+)
+DOWNLOAD_ATTEMPTS = 3
+DOWNLOAD_TIMEOUT_SECONDS = 120
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+
+
+class LlvmInstallError(RuntimeError):
+    """The pinned LLVM toolchain could not be installed safely."""
+
+
+class Response(Protocol):
+    headers: Mapping[str, str]
+
+    def __enter__(self) -> Response: ...
+
+    def __exit__(self, *args: object) -> None: ...
+
+    def read(self, size: int = -1) -> bytes: ...
+
+
+Opener = Callable[..., Response]
+
+
+def require_supported_host() -> None:
+    """Keep the pinned release asset aligned with the CI host contract."""
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system != "Linux" or machine not in {"x86_64", "amd64"}:
+        raise LlvmInstallError(
+            "the pinned LLVM asset only supports Linux x86_64; "
+            f"detected {system} {platform.machine()}"
+        )
+
+
+def prepare_destination(destination: Path) -> None:
+    """Create an empty destination without deleting pre-existing files."""
+    if destination.exists():
+        if not destination.is_dir():
+            raise LlvmInstallError(f"LLVM destination is not a directory: {destination}")
+        if any(destination.iterdir()):
+            raise LlvmInstallError(f"LLVM destination is not empty: {destination}")
+        return
+    destination.mkdir(parents=True)
+
+
+def _copy_response(response: Response, output: BinaryIO) -> int:
+    downloaded = 0
+    while chunk := response.read(DOWNLOAD_CHUNK_BYTES):
+        output.write(chunk)
+        downloaded += len(chunk)
+    return downloaded
+
+
+def download_archive(
+    archive: Path,
+    *,
+    opener: Opener | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Download the version-pinned LLVM release URL with bounded retries."""
+    open_url = opener or urllib.request.urlopen
+    request = urllib.request.Request(
+        LLVM_ARCHIVE_URL,
+        headers={"User-Agent": "dear-imgui-rs-binding-contract"},
+    )
+    failures: list[str] = []
+    for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+        archive.unlink(missing_ok=True)
+        try:
+            with open_url(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+                expected_header = response.headers.get("Content-Length")
+                with archive.open("xb") as output:
+                    downloaded = _copy_response(response, output)
+            if expected_header is not None and downloaded != int(expected_header):
+                raise LlvmInstallError(
+                    "LLVM download size mismatch: "
+                    f"expected {expected_header} bytes, received {downloaded}"
+                )
+            print(f"Downloaded LLVM {LLVM_VERSION} ({downloaded} bytes).")
+            return
+        except (LlvmInstallError, OSError, ValueError, urllib.error.URLError) as error:
+            failures.append(f"attempt {attempt}: {error}")
+            archive.unlink(missing_ok=True)
+            if attempt < DOWNLOAD_ATTEMPTS:
+                sleep(float(2 ** (attempt - 1)))
+    raise LlvmInstallError(
+        f"could not download LLVM {LLVM_VERSION} after {DOWNLOAD_ATTEMPTS} attempts: "
+        + "; ".join(failures)
+    )
+
+
+def extract_archive(archive: Path, destination: Path) -> None:
+    """Extract the official archive with the same layout used by the old action."""
+    run(
+        (
+            "tar",
+            "xf",
+            archive,
+            "--strip-components=1",
+            "-C",
+            destination,
+        )
+    )
+
+
+def validate_installation(destination: Path) -> None:
+    """Require the tools and shared library consumed by binding generation."""
+    clang = destination / "bin" / "clang"
+    llvm_config = destination / "bin" / "llvm-config"
+    for executable in (clang, llvm_config):
+        if not executable.is_file():
+            raise LlvmInstallError(f"LLVM archive is missing {executable}")
+
+    libclang_candidates = tuple((destination / "lib").glob("libclang.so*"))
+    if not any(path.is_file() for path in libclang_candidates):
+        raise LlvmInstallError(
+            f"LLVM archive is missing a libclang shared library in {destination / 'lib'}"
+        )
+
+    result = run((llvm_config, "--version"), capture_output=True)
+    actual_version = (result.stdout or "").strip()
+    if actual_version != LLVM_VERSION:
+        raise LlvmInstallError(
+            f"expected LLVM {LLVM_VERSION}, but llvm-config reported {actual_version!r}"
+        )
+
+
+def _append_lines(path: Path, lines: Sequence[str]) -> None:
+    encoded = bytearray()
+    for line in lines:
+        if not line or "\n" in line or "\r" in line:
+            raise LlvmInstallError("GitHub environment entries must be non-empty lines")
+        encoded.extend(f"{line}\n".encode())
+    with path.open("ab") as output:
+        output.write(encoded)
+
+
+def export_github_environment(
+    destination: Path, environment: Mapping[str, str]
+) -> None:
+    """Replicate the PATH and library exports provided by the removed action."""
+    github_path_value = environment.get("GITHUB_PATH")
+    github_env_value = environment.get("GITHUB_ENV")
+    if github_path_value is None and github_env_value is None:
+        return
+    if not github_path_value or not github_env_value:
+        raise LlvmInstallError("GITHUB_PATH and GITHUB_ENV must be provided together")
+
+    binary_dir = destination / "bin"
+    library_dir = destination / "lib"
+    library_path = os.fspath(library_dir)
+    inherited = environment.get("LD_LIBRARY_PATH", "")
+    if inherited:
+        library_path = f"{library_path}{os.pathsep}{inherited}"
+    _append_lines(Path(github_path_value), (os.fspath(binary_dir),))
+    _append_lines(
+        Path(github_env_value),
+        (
+            f"LLVM_PATH={destination}",
+            f"LD_LIBRARY_PATH={library_path}",
+        ),
+    )
+
+
+def install_llvm(
+    destination: Path, *, environment: Mapping[str, str] | None = None
+) -> None:
+    """Install and export the pinned toolchain into one empty directory."""
+    require_supported_host()
+    resolved_destination = destination.resolve()
+    prepare_destination(resolved_destination)
+    with tempfile.TemporaryDirectory(
+        prefix="dear-imgui-llvm-", dir=resolved_destination.parent
+    ) as temporary:
+        archive = Path(temporary) / LLVM_ARCHIVE_NAME
+        download_archive(archive)
+        extract_archive(archive, resolved_destination)
+    validate_installation(resolved_destination)
+    export_github_environment(
+        resolved_destination, os.environ if environment is None else environment
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install the LLVM release pinned by the binding contract"
+    )
+    parser.add_argument("--destination", required=True, type=Path)
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    options = _build_parser().parse_args(arguments)
+    try:
+        install_llvm(options.destination)
+    except (CommandError, LlvmInstallError, OSError, ValueError) as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_ci_contracts.py
+++ b/tools/tests/test_ci_contracts.py
@@ -735,13 +735,19 @@ class WorkflowPortabilityTests(unittest.TestCase):
         jobs = self._ci_jobs()
         job = jobs["binding-contract"]
         install = named_step(job, "Install fixed LLVM toolchain")
-        install_inputs = require_mapping(
-            install.get("with"), "jobs.binding-contract.steps.install-llvm.with"
+        install_command = str(install.get("run", ""))
+        self.assertNotIn("uses", install)
+        self.assertIn("python3 tools/ci/install_llvm.py", install_command)
+        self.assertIn("${{ runner.temp }}/llvm", install_command)
+        self.assertFalse(
+            any(
+                "install-llvm-action" in str(step.get("uses", ""))
+                for workflow_job in jobs.values()
+                for step in workflow_job.get("steps", ())
+                if isinstance(step, dict)
+            ),
+            "JavaScript LLVM setup actions must not re-enter the workflow",
         )
-        self.assertEqual(
-            install.get("uses"), "KyleMayes/install-llvm-action@v2.0.9"
-        )
-        self.assertNotIn("cached", install_inputs)
 
         step = named_step(
             job, "Regenerate and verify every maintained binding profile"
@@ -755,7 +761,7 @@ class WorkflowPortabilityTests(unittest.TestCase):
         )
         self.assertFalse(
             any(
-                "install-llvm-action" in str(step.get("uses", ""))
+                "install_llvm.py" in str(step.get("run", ""))
                 for step in jobs["wasm-check"]["steps"]
             ),
             "WASM uses pregenerated bindings and must not install libclang",

--- a/tools/tests/test_install_llvm.py
+++ b/tools/tests/test_install_llvm.py
@@ -1,0 +1,139 @@
+import importlib
+import io
+import os
+import subprocess
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_DIR = REPO_ROOT / "tools" / "ci"
+if str(CI_DIR) not in sys.path:
+    sys.path.insert(0, str(CI_DIR))
+
+INSTALL_LLVM = importlib.import_module("install_llvm")
+
+
+class FakeResponse(io.BytesIO):
+    def __init__(self, payload: bytes):
+        super().__init__(payload)
+        self.headers = {"Content-Length": str(len(payload))}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+class InstallLlvmTests(unittest.TestCase):
+    def test_binding_contract_pins_the_exact_official_release_asset(self):
+        self.assertEqual(INSTALL_LLVM.LLVM_VERSION, "14.0.0")
+        self.assertEqual(
+            INSTALL_LLVM.LLVM_ARCHIVE_URL,
+            "https://github.com/llvm/llvm-project/releases/download/"
+            "llvmorg-14.0.0/"
+            "clang%2Bllvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
+        )
+
+    def test_download_retries_the_exact_pinned_asset(self):
+        with TemporaryDirectory() as temporary:
+            archive = Path(temporary) / INSTALL_LLVM.LLVM_ARCHIVE_NAME
+            calls = []
+
+            def opener(request, *, timeout):
+                calls.append((request.full_url, timeout))
+                if len(calls) == 1:
+                    raise urllib.error.URLError("temporary failure")
+                return FakeResponse(b"pinned archive")
+
+            INSTALL_LLVM.download_archive(archive, opener=opener, sleep=lambda _: None)
+
+            self.assertEqual(archive.read_bytes(), b"pinned archive")
+            self.assertEqual(len(calls), 2)
+            self.assertTrue(
+                all(url == INSTALL_LLVM.LLVM_ARCHIVE_URL for url, _ in calls)
+            )
+            self.assertTrue(
+                all(
+                    timeout == INSTALL_LLVM.DOWNLOAD_TIMEOUT_SECONDS
+                    for _, timeout in calls
+                )
+            )
+
+    def test_install_rejects_a_nonempty_destination_before_downloading(self):
+        with TemporaryDirectory() as temporary:
+            destination = Path(temporary) / "llvm"
+            destination.mkdir()
+            (destination / "owned-by-caller").touch()
+            with (
+                patch.object(INSTALL_LLVM, "require_supported_host"),
+                patch.object(INSTALL_LLVM, "download_archive") as download,
+                self.assertRaisesRegex(
+                    INSTALL_LLVM.LlvmInstallError, "destination is not empty"
+                ),
+            ):
+                INSTALL_LLVM.install_llvm(destination, environment={})
+
+            download.assert_not_called()
+
+    def test_validation_requires_the_exact_llvm_version_and_libclang(self):
+        with TemporaryDirectory() as temporary:
+            destination = Path(temporary)
+            (destination / "bin").mkdir()
+            (destination / "lib").mkdir()
+            (destination / "bin" / "clang").touch()
+            (destination / "bin" / "llvm-config").touch()
+            (destination / "lib" / "libclang.so.14").touch()
+            result = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="14.0.1\n"
+            )
+            with (
+                patch.object(INSTALL_LLVM, "run", return_value=result),
+                self.assertRaisesRegex(
+                    INSTALL_LLVM.LlvmInstallError,
+                    "expected LLVM 14.0.0",
+                ),
+            ):
+                INSTALL_LLVM.validate_installation(destination)
+
+    def test_exports_the_action_compatible_github_environment(self):
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            destination = root / "llvm"
+            destination.mkdir()
+            github_path = root / "github-path"
+            github_environment = root / "github-environment"
+            github_path.write_bytes(b"existing-bin\n")
+            github_environment.write_bytes(b"EXISTING=value\n")
+
+            INSTALL_LLVM.export_github_environment(
+                destination,
+                {
+                    "GITHUB_PATH": os.fspath(github_path),
+                    "GITHUB_ENV": os.fspath(github_environment),
+                    "LD_LIBRARY_PATH": "/existing/lib",
+                },
+            )
+
+            self.assertEqual(
+                github_path.read_bytes(),
+                f"existing-bin\n{destination / 'bin'}\n".encode(),
+            )
+            self.assertEqual(
+                github_environment.read_bytes(),
+                (
+                    "EXISTING=value\n"
+                    f"LLVM_PATH={destination}\n"
+                    f"LD_LIBRARY_PATH={destination / 'lib'}"
+                    f"{os.pathsep}/existing/lib\n"
+                ).encode(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- What
  - The binding contract no longer emits GitHub's Node.js 20 deprecation annotation. A repository-owned Python installer preserves the previous LLVM 14.0.0 asset, directory layout, and environment exports.

- Why
  - `KyleMayes/install-llvm-action@v2.0.9` is still the latest stable release and still declares a Node.js 20 runtime. GitHub currently forces it onto Node.js 24, so replacing the JavaScript action removes the warning without changing the binding-generation toolchain.

- Affected crates
  - [ ] dear-imgui-rs
  - [ ] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [ ] backends/dear-imgui-winit
  - [ ] backends/dear-imgui-sdl3
  - [ ] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [x] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [x] No behavior change (refactor/cleanup)

- Breaking changes
  - [x] None
  - [ ] Yes (describe):

- Testing / validation
  - `python -B -m unittest discover -s tools/tests -p 'test_*.py' -v` (296 passed, 1 platform-specific skip)
  - `python -B tools/ci/workflow_policy.py`
  - Windows local tooling tests; the PR's Ubuntu binding-contract job performs the live LLVM download and binding regeneration.

- Docs
  - [x] N/A
  - [ ] Updated README / crate docs

- Links
  - N/A
