### PR TITLE
fix(ui): isolate unsafe font atlas diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Multi-context use is one major beneficiary rather than the sole motivation: the 
 - Make external font data an explicit unsafe boundary. `FontSource` is now opaque; its TTF/OTF, compressed TTF, Base85, and file constructors, plus the corresponding direct `FontAtlas::add_font_from_*` methods, are `unsafe` because the upstream native parsers do not consistently enforce input bounds. Remove `FontConfig::font_data_owned_by_atlas`; memory inputs are copied into Dear ImGui-owned allocations. Direct glyph ranges and `GlyphRangesBuilder::add_ranges` now accept structured `&[(u32, u32)]` pairs instead of raw sentinel arrays.
 - Remove safe raw font-atlas texture escape hatches `FontAtlas::{get_tex_ref,set_tex_ref,get_tex_data,get_tex_data_ptr,tex_data_mut}`. Use `FontAtlas::texture_id()` for the current legacy handle, `FontAtlas::tex_data()` for a read-only `FontAtlasTexture<'_>` lease, and `unsafe { ctx.font_atlas().set_texture_id(texture_id) }` only when a legacy renderer can uphold the GPU-handle and synchronization contract. While a texture lease is alive, atlas operations or frame advancement that could invalidate it are rejected; custom-rectangle updates after a legacy atlas upload also fail explicitly because only `RENDERER_HAS_TEXTURES` backends can consume partial updates.
 - Reject every structural `FontAtlas` mutator while any registered context is inside a frame, including managed frames where Dear ImGui leaves `FontAtlas::Locked` clear; perform such changes before `Context::frame()` or after `Context::render()`.
-- Make `Ui::{show_demo_window,show_metrics_window,show_style_editor,show_default_style_editor}` unsafe because upstream Fonts panels expose destructive atlas controls when `RENDERER_HAS_TEXTURES` leaves the atlas unlocked, including a Remove path that deletes an `ImFont` and then continues reading it in the same native call. Normal `FontSizeBase` and scale controls remain supported; callers must prevent destructive controls from being activated or use application-owned diagnostics.
+- Split built-in diagnostics at the exact font-atlas boundary. `Ui::{show_demo_window,show_metrics_window,show_style_editor,show_default_style_editor}` remain safe and retain every control outside upstream `ShowFontAtlas()` panels, including ordinary font selection and scaling; use the explicitly unsafe `show_upstream_*` variants for the exact native windows, or `show_font_atlas_debug_panel()` for the isolated font diagnostics. Native source, prebuilt, and WASM provider routes compile the same checked shim, and prebuilt manifests reject artifacts without that ABI capability.
 - Remove the core `tracing` feature, `dear_imgui_rs::logging`, exported `imgui_*` logging macros, process-global subscriber helpers, and logging side effects from error constructors. Applications now own subscriber policy; `dear-imgui-wgpu` emits its existing diagnostics only with its opt-in `tracing` feature. This completes and expands the opt-in tracing direction contributed by [@DBLouis](https://github.com/DBLouis) in [PR #42](https://github.com/Latias94/dear-imgui-rs/pull/42).
 - Make `test-engine` a native source-only feature. It now implies `build-from-source` and is rejected with the WASM import provider instead of compiling without its promised native hooks.
 - Make `prebuilt` native-only and reject it with the WASM import provider. Its download/extraction stack is now confined to the host build graph, while the package helper consumes build-script-generated artifact metadata without adding build-support to the target dependency graph.
@@ -216,14 +216,25 @@ Use `SharedFontAtlas::create()` only when multiple legacy-rendered contexts inte
 
 #### Built-in font debug tools
 
-Dear ImGui's Demo, Metrics, and Style Editor windows can open upstream Fonts panels with controls that mutate the atlas during a frame. When `BackendFlags::RENDERER_HAS_TEXTURES` is active, upstream leaves the atlas unlocked so dynamic sizing can work, but the same panel also exposes Remove: it deletes an `ImFont` and the native debug function continues reading that pointer in the same call. Rust lifetimes cannot constrain a mutation performed internally by that monolithic C++ UI function, so these wrappers are unsafe:
+Dear ImGui's Demo, Metrics, and Style Editor windows can open upstream Fonts panels with controls that mutate the atlas during a frame. When `BackendFlags::RENDERER_HAS_TEXTURES` is active, upstream leaves the atlas unlocked so dynamic sizing can work, but the same panel also exposes Remove: it deletes an `ImFont` and the native debug function continues reading that pointer in the same call. Rust lifetimes cannot constrain a mutation performed internally by that C++ UI function, so the normal wrappers now preserve every non-font control and omit only the `ShowFontAtlas()` paths:
 
 ```rust
-// SAFETY: This integration prevents the upstream Fonts panels and destructive controls from being activated.
-unsafe { ui.show_demo_window(&mut demo_open) };
+ui.show_demo_window(&mut demo_open);
+ui.show_metrics_window(&mut metrics_open);
+ui.show_default_style_editor();
 ```
 
-Changing `FontSizeBase`, `FontScaleMain`, or `FontScaleDpi` is supported and is not the reason for the unsafe boundary. Do not use these wrappers when arbitrary users can reach the destructive font/atlas controls; build application-owned diagnostics instead.
+The exact upstream windows remain available only through explicitly named unsafe entry points. Use them when the integration owns the complete native atlas contract, or open the hazardous panel directly when diagnosing fonts:
+
+```rust
+// SAFETY: The application prevents destructive atlas controls from invalidating live Rust state.
+unsafe {
+    ui.show_upstream_demo_window(&mut demo_open);
+    ui.show_font_atlas_debug_panel();
+}
+```
+
+Changing `FontSizeBase`, `FontScaleMain`, or `FontScaleDpi` remains supported in the safe Style Editor and is not part of the unsafe boundary.
 
 #### Context-owned rendering and managed textures
 

--- a/backends/dear-imgui-bevy/examples/basic/simple.rs
+++ b/backends/dear-imgui-bevy/examples/basic/simple.rs
@@ -73,7 +73,6 @@ fn simple_ui(mut contexts: ImguiContexts, mut state: ResMut<SimpleUiState>) {
         });
 
     if state.show_demo_window {
-        // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-        unsafe { ui.show_demo_window(&mut state.show_demo_window) };
+        ui.show_demo_window(&mut state.show_demo_window);
     }
 }

--- a/dear-imgui-sys/bin/package/main.rs
+++ b/dear-imgui-sys/bin/package/main.rs
@@ -39,8 +39,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Package features (comma-separated), e.g. "wchar32,freetype".
     //
-    // We always compile with `IMGUI_USE_WCHAR32`, so this is always declared to allow the sys
-    // build script to reject ABI-incompatible prebuilts.
+    // We always compile with `IMGUI_USE_WCHAR32` and the repository-owned safe demo shim, so
+    // those capabilities are always declared to let the sys build script reject incompatible
+    // prebuilts.
     // Artifact-changing features must match the Cargo profile that built this binary. The
     // optional environment list may add metadata but cannot claim an unavailable artifact.
     let explicit_features = env::var("IMGUI_SYS_PKG_FEATURES").unwrap_or_default();
@@ -54,7 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "stack-layout" => cfg!(feature = "stack-layout"),
             "freetype" => cfg!(feature = "freetype"),
             "test-engine" => cfg!(feature = "test-engine"),
-            "wchar32" | "platform-io-aggregate-hooks" => true,
+            "wchar32" | "platform-io-aggregate-hooks" | "safe-demo-font-boundary-v1" => true,
             _ => {
                 return Err(
                     format!("IMGUI_SYS_PKG_FEATURES contains unknown feature {feature}").into(),

--- a/dear-imgui-sys/build.rs
+++ b/dear-imgui-sys/build.rs
@@ -75,7 +75,11 @@ impl BuildConfig {
         }
     }
     fn artifact_features(&self) -> Vec<&'static str> {
-        let mut features = vec!["platform-io-aggregate-hooks", "wchar32"];
+        let mut features = vec![
+            "platform-io-aggregate-hooks",
+            build_support::SAFE_DEMO_FONT_BOUNDARY_ARTIFACT_FEATURE,
+            "wchar32",
+        ];
         if cfg!(feature = "stack-layout") {
             features.push("stack-layout");
         }
@@ -222,6 +226,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/bindings_pregenerated_windows.rs");
     println!("cargo:rerun-if-changed=src/wasm_bindings_pregenerated.rs");
     println!("cargo:rerun-if-changed=src/imgui_test_engine_hooks.cpp");
+    println!("cargo:rerun-if-changed=src/demo_window_shim.cpp");
     println!("cargo:rerun-if-changed=src/platform_io_hooks.cpp");
     println!("cargo:rerun-if-changed=src/stack_layout_shim.cpp");
     println!("cargo:rerun-if-changed=src/stack_layout_imgui_externs.cpp.inc");
@@ -232,6 +237,8 @@ fn main() {
     println!("cargo:rerun-if-changed=backend-shims/android.cpp");
     println!("cargo:rerun-if-changed=backend-shims/win32.cpp");
     println!("cargo:rerun-if-changed=backend-shims/dx11.cpp");
+    println!("cargo:rerun-if-changed=third-party/cimgui/imgui/imgui.cpp");
+    println!("cargo:rerun-if-changed=third-party/cimgui/imgui/imgui_demo.cpp");
     for name in CORE_BUILD_ENV_VARS {
         println!("cargo:rerun-if-env-changed={name}");
     }
@@ -603,23 +610,26 @@ fn build_with_cc_cfg(cfg: &BuildConfig) {
     let imgui_src = cfg.imgui_src();
     let mut build = new_native_cpp_build(cfg);
     build.include(&cimgui_root);
-    if cfg!(feature = "stack-layout") {
-        build.file(write_stack_layout_patched_imgui_cpp(
-            cfg,
-            &imgui_src.join("imgui.cpp"),
-        ));
+    let imgui_cpp = if cfg!(feature = "stack-layout") {
+        let patched = write_stack_layout_patched_imgui_cpp(cfg, &imgui_src.join("imgui.cpp"));
         build.file(cfg.manifest_dir.join("src/stack_layout_shim.cpp"));
+        patched
     } else {
-        build.file(imgui_src.join("imgui.cpp"));
-    }
+        imgui_src.join("imgui.cpp")
+    };
+    build.file(write_safe_demo_patched_imgui_cpp(cfg, &imgui_cpp));
     build.file(imgui_src.join("imgui_draw.cpp"));
     build.file(imgui_src.join("imgui_widgets.cpp"));
     build.file(imgui_src.join("imgui_tables.cpp"));
+    build.file(cfg.manifest_dir.join("src/demo_window_shim.cpp"));
     build.file(cfg.manifest_dir.join("src/platform_io_hooks.cpp"));
     // Include official demo/metrics/debug windows for native builds so symbols like
     // ImGui::ShowDemoWindow/ShowAboutWindow/ShowStyleEditor resolve.
     // This is excluded from the WASM single‑module path below.
-    build.file(imgui_src.join("imgui_demo.cpp"));
+    build.file(write_safe_demo_patched_imgui_demo_cpp(
+        cfg,
+        &imgui_src.join("imgui_demo.cpp"),
+    ));
     build.file(cimgui_root.join("cimgui.cpp"));
     if cfg!(feature = "test-engine") {
         build.define("IMGUI_ENABLE_TEST_ENGINE", None);
@@ -641,6 +651,37 @@ fn build_with_cc_cfg(cfg: &BuildConfig) {
     }
 
     build.compile("dear_imgui");
+}
+
+fn write_safe_demo_patched_imgui_cpp(cfg: &BuildConfig, imgui_cpp: &Path) -> PathBuf {
+    let source = std::fs::read_to_string(imgui_cpp)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", imgui_cpp.display()));
+    let patched = build_support::patch_imgui_cpp_for_safe_demo(&source).unwrap_or_else(|error| {
+        panic!(
+            "failed to patch {} for safe demo windows: {error}",
+            imgui_cpp.display()
+        )
+    });
+    let out = cfg.out_dir.join("imgui_safe_demo_patched.cpp");
+    std::fs::write(&out, patched)
+        .unwrap_or_else(|error| panic!("failed to write {}: {error}", out.display()));
+    out
+}
+
+fn write_safe_demo_patched_imgui_demo_cpp(cfg: &BuildConfig, imgui_demo_cpp: &Path) -> PathBuf {
+    let source = std::fs::read_to_string(imgui_demo_cpp)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", imgui_demo_cpp.display()));
+    let patched =
+        build_support::patch_imgui_demo_cpp_for_safe_demo(&source).unwrap_or_else(|error| {
+            panic!(
+                "failed to patch {} for safe demo windows: {error}",
+                imgui_demo_cpp.display()
+            )
+        });
+    let out = cfg.out_dir.join("imgui_demo_safe_demo_patched.cpp");
+    std::fs::write(&out, patched)
+        .unwrap_or_else(|error| panic!("failed to write {}: {error}", out.display()));
+    out
 }
 
 // imgui-node-editor's stack layout extension is not a standalone widget layer:

--- a/dear-imgui-sys/src/demo_window_shim.cpp
+++ b/dear-imgui-sys/src/demo_window_shim.cpp
@@ -1,0 +1,29 @@
+#include "imgui.h"
+#include "imgui_internal.h"
+
+void DearImGuiRsShowDemoWindowWithoutFontAtlas(bool* p_open);
+void DearImGuiRsShowMetricsWindowWithoutFontAtlas(bool* p_open);
+void DearImGuiRsShowStyleEditorWithoutFontAtlas(ImGuiStyle* ref);
+
+extern "C"
+{
+void dear_imgui_rs_show_demo_window_without_font_atlas(bool* p_open)
+{
+    DearImGuiRsShowDemoWindowWithoutFontAtlas(p_open);
+}
+
+void dear_imgui_rs_show_metrics_window_without_font_atlas(bool* p_open)
+{
+    DearImGuiRsShowMetricsWindowWithoutFontAtlas(p_open);
+}
+
+void dear_imgui_rs_show_style_editor_without_font_atlas(ImGuiStyle* ref)
+{
+    DearImGuiRsShowStyleEditorWithoutFontAtlas(ref);
+}
+
+void dear_imgui_rs_show_font_atlas_debug_panel()
+{
+    ImGui::ShowFontAtlas(ImGui::GetIO().Fonts);
+}
+}

--- a/dear-imgui-sys/src/lib.rs
+++ b/dear-imgui-sys/src/lib.rs
@@ -104,6 +104,17 @@ compile_error!("feature `prebuilt` is native-only and cannot be combined with WA
 mod ffi;
 pub use ffi::*;
 
+#[cfg_attr(
+    dear_imgui_rs_wasm_import_target,
+    link(wasm_import_module = "imgui-sys-v0")
+)]
+unsafe extern "C" {
+    pub fn dear_imgui_rs_show_demo_window_without_font_atlas(p_open: *mut bool);
+    pub fn dear_imgui_rs_show_metrics_window_without_font_atlas(p_open: *mut bool);
+    pub fn dear_imgui_rs_show_style_editor_without_font_atlas(ref_: *mut ImGuiStyle);
+    pub fn dear_imgui_rs_show_font_atlas_debug_panel();
+}
+
 /// Optional backend shim entry points for downstream integrations.
 ///
 /// These modules expose the repository-owned C shim ABI for selected official

--- a/dear-imgui/src/style.rs
+++ b/dear-imgui/src/style.rs
@@ -16,8 +16,7 @@
 //! }
 //! // Optionally show the style editor for the current style
 //! # let ui = ctx.frame();
-//! // SAFETY: Do not activate the upstream Fonts tab's destructive atlas controls.
-//! unsafe { ui.show_default_style_editor() };
+//! ui.show_default_style_editor();
 //! ```
 //!
 //! Quick example (temporary style color):

--- a/dear-imgui/src/ui/debug_tools.rs
+++ b/dear-imgui/src/ui/debug_tools.rs
@@ -1,18 +1,33 @@
 use super::*;
 
 impl Ui {
-    /// Renders a demo window (previously called a test window), which demonstrates most
-    /// Dear ImGui features.
+    /// Renders Dear ImGui's demo window without its destructive font-atlas debug controls.
+    ///
+    /// This preserves the ordinary demo, Metrics/Debugger, and Style Editor controls. Only the
+    /// panels backed by upstream `ShowFontAtlas()` are omitted, so the safe API does not bypass
+    /// Rust's font-atlas lifetime and generation tracking.
+    ///
+    /// Use [`show_upstream_demo_window`](Self::show_upstream_demo_window) to opt into the exact
+    /// upstream window, including its font-atlas controls.
+    #[doc(alias = "ShowDemoWindow")]
+    pub fn show_demo_window(&self, opened: &mut bool) {
+        self.run_with_bound_context(|| unsafe {
+            crate::sys::dear_imgui_rs_show_demo_window_without_font_atlas(opened);
+        });
+    }
+
+    /// Renders the exact upstream Dear ImGui demo window, including font-atlas debug controls.
+    ///
+    /// Prefer [`show_demo_window`](Self::show_demo_window) unless the application deliberately
+    /// owns the full font-atlas mutation contract.
     ///
     /// # Safety
     ///
-    /// With `BackendFlags::RENDERER_HAS_TEXTURES`, upstream intentionally leaves the font atlas
-    /// unlocked during a frame. The Fonts panel's Remove control deletes an `ImFont` and then the
-    /// same native debug function continues reading that pointer; other destructive controls also
-    /// bypass Rust's atlas-generation tracking. The caller must ensure those controls cannot be
-    /// activated. Changing `FontSizeBase` or the font-scale controls is supported.
-    #[doc(alias = "ShowDemoWindow")]
-    pub unsafe fn show_demo_window(&self, opened: &mut bool) {
+    /// With `BackendFlags::RENDERER_HAS_TEXTURES`, the upstream Fonts panel can delete an
+    /// `ImFont` and continue reading it in the same native call. Other destructive controls also
+    /// bypass Rust's atlas-generation tracking. The caller must prevent those controls from being
+    /// activated or otherwise uphold the native font-atlas contract.
+    pub unsafe fn show_upstream_demo_window(&self, opened: &mut bool) {
         self.run_with_bound_context(|| unsafe {
             crate::sys::igShowDemoWindow(opened);
         });
@@ -28,22 +43,42 @@ impl Ui {
         });
     }
 
-    /// Renders a metrics/debug window.
+    /// Renders a metrics/debug window without its destructive font-atlas tree.
     ///
     /// Displays Dear ImGui internals: draw commands (with individual draw calls and vertices),
     /// window list, basic internal state, etc.
+    #[doc(alias = "ShowMetricsWindow")]
+    pub fn show_metrics_window(&self, opened: &mut bool) {
+        self.run_with_bound_context(|| unsafe {
+            crate::sys::dear_imgui_rs_show_metrics_window_without_font_atlas(opened);
+        });
+    }
+
+    /// Renders the exact upstream metrics/debug window, including its font-atlas tree.
     ///
     /// # Safety
     ///
-    /// With `BackendFlags::RENDERER_HAS_TEXTURES`, upstream intentionally leaves the font atlas
-    /// unlocked during a frame. The Fonts section's Remove control deletes an `ImFont` and then the
-    /// same native debug function continues reading that pointer; other destructive controls also
-    /// bypass Rust's atlas-generation tracking. The caller must ensure those controls cannot be
-    /// activated. Changing `FontSizeBase` or the font-scale controls is supported.
-    #[doc(alias = "ShowMetricsWindow")]
-    pub unsafe fn show_metrics_window(&self, opened: &mut bool) {
+    /// The upstream Fonts tree can mutate or destroy font-atlas data while Rust font handles and
+    /// renderer state are live. The caller must uphold the native font-atlas contract.
+    pub unsafe fn show_upstream_metrics_window(&self, opened: &mut bool) {
         self.run_with_bound_context(|| unsafe {
             crate::sys::igShowMetricsWindow(opened);
+        });
+    }
+
+    /// Renders upstream's internal Font Atlas debug panel for this context.
+    ///
+    /// This is the isolated font-specific part omitted from the safe demo, metrics, and style
+    /// editor APIs.
+    ///
+    /// # Safety
+    ///
+    /// The panel exposes destructive atlas operations and may continue using native font pointers
+    /// after a control mutates the atlas. The caller must uphold the native font-atlas contract.
+    #[doc(alias = "ShowFontAtlas")]
+    pub unsafe fn show_font_atlas_debug_panel(&self) {
+        self.run_with_bound_context(|| unsafe {
+            crate::sys::dear_imgui_rs_show_font_atlas_debug_panel();
         });
     }
 
@@ -127,9 +162,12 @@ impl Ui {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn font_atlas_debug_windows_are_explicitly_unsafe() {
-        let _: unsafe fn(&crate::Ui, &mut bool) = crate::Ui::show_demo_window;
-        let _: unsafe fn(&crate::Ui, &mut bool) = crate::Ui::show_metrics_window;
+    fn safe_debug_windows_keep_font_atlas_controls_explicit() {
+        let _: fn(&crate::Ui, &mut bool) = crate::Ui::show_demo_window;
+        let _: fn(&crate::Ui, &mut bool) = crate::Ui::show_metrics_window;
+        let _: unsafe fn(&crate::Ui, &mut bool) = crate::Ui::show_upstream_demo_window;
+        let _: unsafe fn(&crate::Ui, &mut bool) = crate::Ui::show_upstream_metrics_window;
+        let _: unsafe fn(&crate::Ui) = crate::Ui::show_font_atlas_debug_panel;
     }
 
     #[test]
@@ -140,7 +178,13 @@ mod tests {
         let _ = ctx.font_atlas().build();
         let ui = ctx.frame();
 
+        let mut demo_open = true;
+        ui.show_demo_window(&mut demo_open);
+        let mut metrics_open = true;
+        ui.show_metrics_window(&mut metrics_open);
+
         ui.window("debug_helpers").build(|| {
+            ui.show_default_style_editor();
             let cursor_y = ui.cursor_pos_y();
             ui.debug_text_encoding("A UTF-8 string: 界");
             assert!(ui.cursor_pos_y() > cursor_y);

--- a/dear-imgui/src/ui/style.rs
+++ b/dear-imgui/src/ui/style.rs
@@ -3,31 +3,48 @@ use super::*;
 impl Ui {
     /// Renders a style editor block (not a window) for the given `Style` structure.
     ///
-    /// # Safety
-    ///
-    /// With `BackendFlags::RENDERER_HAS_TEXTURES`, upstream intentionally leaves the font atlas
-    /// unlocked during a frame. The Fonts tab's Remove control deletes an `ImFont` and then the
-    /// same native debug function continues reading that pointer; other destructive controls also
-    /// bypass Rust's atlas-generation tracking. The caller must ensure those controls cannot be
-    /// activated. Changing `FontSizeBase` or the font-scale controls is supported.
+    /// The safe editor retains all upstream style controls except its destructive Fonts tab.
+    /// Font selection and font-scale controls remain available because they do not mutate the
+    /// atlas topology.
     #[doc(alias = "ShowStyleEditor")]
-    pub unsafe fn show_style_editor(&self, style: &mut crate::style::Style) {
+    pub fn show_style_editor(&self, style: &mut crate::style::Style) {
         self.run_with_bound_context(|| unsafe {
-            crate::sys::igShowStyleEditor(style.raw_mut());
+            crate::sys::dear_imgui_rs_show_style_editor_without_font_atlas(style.raw_mut());
         });
     }
 
     /// Renders a style editor block (not a window) for the currently active style.
     ///
+    /// The safe editor retains all upstream style controls except its destructive Fonts tab.
+    #[doc(alias = "ShowStyleEditor")]
+    pub fn show_default_style_editor(&self) {
+        self.run_with_bound_context(|| unsafe {
+            crate::sys::dear_imgui_rs_show_style_editor_without_font_atlas(std::ptr::null_mut());
+        });
+    }
+
+    /// Renders the exact upstream style editor for the given `Style` structure.
+    ///
+    /// Prefer [`show_style_editor`](Self::show_style_editor) unless the application deliberately
+    /// owns the full font-atlas mutation contract.
+    ///
     /// # Safety
     ///
-    /// With `BackendFlags::RENDERER_HAS_TEXTURES`, upstream intentionally leaves the font atlas
-    /// unlocked during a frame. The Fonts tab's Remove control deletes an `ImFont` and then the
-    /// same native debug function continues reading that pointer; other destructive controls also
-    /// bypass Rust's atlas-generation tracking. The caller must ensure those controls cannot be
-    /// activated. Changing `FontSizeBase` or the font-scale controls is supported.
-    #[doc(alias = "ShowStyleEditor")]
-    pub unsafe fn show_default_style_editor(&self) {
+    /// The upstream Fonts tab exposes destructive font-atlas operations that bypass Rust's atlas
+    /// generation tracking. The caller must uphold the native font-atlas contract.
+    pub unsafe fn show_upstream_style_editor(&self, style: &mut crate::style::Style) {
+        self.run_with_bound_context(|| unsafe {
+            crate::sys::igShowStyleEditor(style.raw_mut());
+        });
+    }
+
+    /// Renders the exact upstream style editor for the active style.
+    ///
+    /// # Safety
+    ///
+    /// The upstream Fonts tab exposes destructive font-atlas operations that bypass Rust's atlas
+    /// generation tracking. The caller must uphold the native font-atlas contract.
+    pub unsafe fn show_upstream_default_style_editor(&self) {
         self.run_with_bound_context(|| unsafe {
             crate::sys::igShowStyleEditor(std::ptr::null_mut());
         });
@@ -120,5 +137,16 @@ impl Ui {
         self.run_with_bound_context(|| unsafe {
             sys::igShowFontSelector(self.scratch_txt(label));
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn safe_style_editors_keep_font_atlas_controls_explicit() {
+        let _: fn(&crate::Ui, &mut crate::Style) = crate::Ui::show_style_editor;
+        let _: fn(&crate::Ui) = crate::Ui::show_default_style_editor;
+        let _: unsafe fn(&crate::Ui, &mut crate::Style) = crate::Ui::show_upstream_style_editor;
+        let _: unsafe fn(&crate::Ui) = crate::Ui::show_upstream_default_style_editor;
     }
 }

--- a/docs/API_COVERAGE.md
+++ b/docs/API_COVERAGE.md
@@ -112,9 +112,10 @@ state-aware APIs:
   atlas-validated `CustomRectId`, strict `CustomRectData`, and copy-out `CustomRectSnapshot` values.
   Pixel writes queue the exact managed texture region for renderer upload; `Ui::image_custom_rect`
   resolves current texture and UV data at submission time.
-- `Ui::{show_demo_window,show_metrics_window,show_style_editor,show_default_style_editor}` remains an
-  explicit unsafe boundary because upstream Fonts panels can perform destructive atlas operations
-  during the call; the safe layer does not claim control over later user interaction.
+- `Ui::{show_demo_window,show_metrics_window,show_style_editor,show_default_style_editor}` are safe
+  curated upstream diagnostics: they retain all controls outside the destructive `ShowFontAtlas()`
+  paths, including ordinary font selection and scaling. Exact upstream surfaces remain explicitly
+  named `unsafe` APIs, and `Ui::show_font_atlas_debug_panel()` isolates the font-atlas boundary.
 - `ListClipper::unknown_count()` returns a distinct token whose `next_range()` protocol is finalized
   by consuming `finish(final_items_count)`. Known counts reject the native `INT_MAX` sentinel.
   Clipper tokens enforce native LIFO plus their exact frame, window `Begin`, and table instance. An

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -211,7 +211,8 @@ requested artifact profile:
 - crate name and version
 - target triple, static link type, and MSVC CRT (`md` or `mt`)
 - normalized core artifact features, including `wchar32`,
-  `platform-io-aggregate-hooks`, and optional `stack-layout` or `freetype`
+  `platform-io-aggregate-hooks`, `safe-demo-font-boundary-v1`, and optional
+  `stack-layout` or `freetype`
 - the exact 40-hex cimgui and nested Dear ImGui source revisions
 - the deterministic binding-spec hash
 

--- a/examples-android/dear-imgui-android-smoke/src/lib.rs
+++ b/examples-android/dear-imgui-android-smoke/src/lib.rs
@@ -495,8 +495,7 @@ impl SmokeApp {
             });
 
         if *show_demo_window {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(show_demo_window) };
+            ui.show_demo_window(show_demo_window);
         }
 
         let clear_color = *clear_color;

--- a/examples-ios/dear-imgui-ios-sdl3-smoke/src/lib.rs
+++ b/examples-ios/dear-imgui-ios-sdl3-smoke/src/lib.rs
@@ -186,8 +186,7 @@ fn run_inner(_argc: c_int, _argv: *mut *mut c_char) -> Result<c_int, Box<dyn std
             });
 
         if show_demo_window {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut show_demo_window) };
+            ui.show_demo_window(&mut show_demo_window);
         }
 
         let draw_data = imgui.render();

--- a/examples-ios/dear-imgui-ios-smoke/src/lib.rs
+++ b/examples-ios/dear-imgui-ios-smoke/src/lib.rs
@@ -211,8 +211,7 @@ impl AppWindow {
             });
 
         if self.imgui.show_demo_window {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut self.imgui.show_demo_window) };
+            ui.show_demo_window(&mut self.imgui.show_demo_window);
         }
 
         self.imgui

--- a/examples-wasm/src/lib.rs
+++ b/examples-wasm/src/lib.rs
@@ -294,8 +294,7 @@ impl AppWindow {
             });
 
         if self.imgui.demo_open {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut self.imgui.demo_open) };
+            ui.show_demo_window(&mut self.imgui.demo_open);
         }
 
         #[cfg(feature = "implot")]

--- a/examples/01-renderers/ash_basic.rs
+++ b/examples/01-renderers/ash_basic.rs
@@ -412,8 +412,7 @@ impl AppWindow {
             });
 
         if self.imgui.demo_open {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut self.imgui.demo_open) };
+            ui.show_demo_window(&mut self.imgui.demo_open);
         }
 
         self.imgui

--- a/examples/01-renderers/ash_textures.rs
+++ b/examples/01-renderers/ash_textures.rs
@@ -476,8 +476,7 @@ impl AppWindow {
                 }
             });
 
-        // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-        unsafe { ui.show_demo_window(&mut true) };
+        ui.show_demo_window(&mut true);
 
         // Finalize inputs on platform and build draw data.
         self.imgui

--- a/examples/01-renderers/glow_basic.rs
+++ b/examples/01-renderers/glow_basic.rs
@@ -191,8 +191,7 @@ impl AppWindow {
 
         // Show demo window if requested
         if self.imgui.demo_open {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut self.imgui.demo_open) };
+            ui.show_demo_window(&mut self.imgui.demo_open);
         }
 
         // Render

--- a/examples/01-renderers/glow_textures.rs
+++ b/examples/01-renderers/glow_textures.rs
@@ -434,8 +434,7 @@ impl AppWindow {
         self.imgui.texture_demo.show_ui(ui);
 
         // Show demo window
-        // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-        unsafe { ui.show_demo_window(&mut true) };
+        ui.show_demo_window(&mut true);
 
         // Render
         if let Some(gl) = self.imgui.renderer.gl_context() {

--- a/examples/01-renderers/sdl3_sdlrenderer.rs
+++ b/examples/01-renderers/sdl3_sdlrenderer.rs
@@ -93,8 +93,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             });
 
         if show_demo {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut show_demo) };
+            ui.show_demo_window(&mut show_demo);
         }
         if show_debug {
             ui.show_debug_log_window(&mut show_debug);

--- a/examples/01-renderers/sdl3_wgpu.rs
+++ b/examples/01-renderers/sdl3_wgpu.rs
@@ -195,8 +195,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             });
 
         if show_demo {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut show_demo) };
+            ui.show_demo_window(&mut show_demo);
         }
 
         let draw_data = imgui.render();

--- a/examples/01-renderers/wgpu_basic.rs
+++ b/examples/01-renderers/wgpu_basic.rs
@@ -318,8 +318,7 @@ impl AppWindow {
 
         // Show demo window if requested
         if self.imgui.demo_open {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut self.imgui.demo_open) };
+            ui.show_demo_window(&mut self.imgui.demo_open);
         }
 
         self.imgui

--- a/examples/02-docking/dear_app_docking.rs
+++ b/examples/02-docking/dear_app_docking.rs
@@ -247,8 +247,7 @@ impl Application for DockDemoState {
         }
 
         if state.show_imgui_demo {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut state.show_imgui_demo) };
+            ui.show_demo_window(&mut state.show_imgui_demo);
         }
         Ok(())
     }

--- a/examples/02-docking/multi_viewport_ash.rs
+++ b/examples/02-docking/multi_viewport_ash.rs
@@ -631,8 +631,7 @@ impl AppWindow {
             });
 
         if self.imgui.demo_open {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut self.imgui.demo_open) };
+            ui.show_demo_window(&mut self.imgui.demo_open);
         }
 
         self.imgui

--- a/examples/02-docking/multi_viewport_wgpu.rs
+++ b/examples/02-docking/multi_viewport_wgpu.rs
@@ -663,7 +663,7 @@ impl AppWindow {
 
         // Optionally show demo to validate interaction
         // let mut show_demo = true;
-        // unsafe { ui.show_demo_window(&mut show_demo) };
+        // ui.show_demo_window(&mut show_demo);
 
         let mut encoder = self
             .device

--- a/examples/02-docking/sdl3_ash_multi_viewport.rs
+++ b/examples/02-docking/sdl3_ash_multi_viewport.rs
@@ -1439,8 +1439,7 @@ impl App {
                 });
 
             if self.imgui.show_demo {
-                // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-                unsafe { ui.show_demo_window(&mut self.imgui.show_demo) };
+                ui.show_demo_window(&mut self.imgui.show_demo);
             }
 
             if let Some((texture, sampler)) = external_sampler_update {

--- a/examples/02-docking/sdl3_sdlgpu_multi_view.rs
+++ b/examples/02-docking/sdl3_sdlgpu_multi_view.rs
@@ -113,8 +113,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             });
 
         if show_demo {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut show_demo) };
+            ui.show_demo_window(&mut show_demo);
         }
         if show_debug {
             ui.show_debug_log_window(&mut show_debug);

--- a/examples/02-docking/sdl3_wgpu_multi_viewport.rs
+++ b/examples/02-docking/sdl3_wgpu_multi_viewport.rs
@@ -193,8 +193,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             });
 
         if show_demo {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_demo_window(&mut show_demo) };
+            ui.show_demo_window(&mut show_demo);
         }
 
         let draw_data = imgui.render();

--- a/examples/03-features/implot3d_basic.rs
+++ b/examples/03-features/implot3d_basic.rs
@@ -1356,22 +1356,18 @@ fn demo_tools(ui: &Ui, plot_ui: &Plot3DUi) {
     }
     if imgui_metrics {
         let mut opened = true;
-        // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-        unsafe { ui.show_metrics_window(&mut opened) };
+        ui.show_metrics_window(&mut opened);
         if !opened {
             SHOW_IMGUI_METRICS.with(|c| c.set(false));
         }
     }
     if imgui_style {
-        ui.window("Style Editor (ImGui)").build(|| {
-            // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-            unsafe { ui.show_default_style_editor() }
-        });
+        ui.window("Style Editor (ImGui)")
+            .build(|| ui.show_default_style_editor());
     }
     if imgui_demo {
         let mut opened = true;
-        // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-        unsafe { ui.show_demo_window(&mut opened) };
+        ui.show_demo_window(&mut opened);
         if !opened {
             SHOW_IMGUI_DEMO.with(|c| c.set(false));
         }

--- a/examples/03-features/style_and_fonts.rs
+++ b/examples/03-features/style_and_fonts.rs
@@ -1680,8 +1680,7 @@ impl AppWindow {
                 ui.separator();
                 ui.text("Built-in Style Editor");
                 let mut style_copy = ui.clone_style();
-                // SAFETY: This demo assumes the destructive font-atlas controls are not activated.
-                unsafe { ui.show_style_editor(&mut style_copy) };
+                ui.show_style_editor(&mut style_copy);
             });
 
         self.imgui

--- a/tools/api_surface_policy.json
+++ b/tools/api_surface_policy.json
@@ -57,16 +57,6 @@
         "MemAlloc",
         "MemFree"
       ]
-    },
-    {
-      "classification": "unsafe-wrapper",
-      "name": "destructive-native-font-debug-ui",
-      "reason": "Upstream Demo, Metrics, and Style Editor font panels can mutate or delete atlas-owned fonts during the call and may continue using invalidated native pointers; the Rust wrappers therefore require an explicit unsafe precondition.",
-      "functions": [
-        "ShowDemoWindow",
-        "ShowMetricsWindow",
-        "ShowStyleEditor"
-      ]
     }
   ]
 }

--- a/tools/build-support/src/lib.rs
+++ b/tools/build-support/src/lib.rs
@@ -4651,6 +4651,7 @@ pub const DEFAULT_GITHUB_REPO: &str = "dear-imgui";
 
 #[cfg(test)]
 mod binding_contract_tests {
+    use super::SAFE_DEMO_FONT_BOUNDARY_ARTIFACT_FEATURE;
     use super::binding::{
         ArtifactProfile, BindingOwner, BindingSpec, BuildRequest, BuildRequestInput,
         CORE_BUILD_ENV_VARS, CORE_WASM_TARGET, CoreArtifactIdentity, CrateBindingDefine,

--- a/tools/build-support/src/lib.rs
+++ b/tools/build-support/src/lib.rs
@@ -4,6 +4,293 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 static STATIC_CPP_STDLIB_LINK_EMITTED: AtomicBool = AtomicBool::new(false);
 
+/// Native artifact capability for the repository-owned safe demo-window ABI.
+pub const SAFE_DEMO_FONT_BOUNDARY_ARTIFACT_FEATURE: &str = "safe-demo-font-boundary-v1";
+
+/// Extra C symbols exported by the WebAssembly cimgui provider.
+pub const SAFE_DEMO_FONT_BOUNDARY_WASM_EXPORTS: &[&str] = &[
+    "dear_imgui_rs_show_demo_window_without_font_atlas",
+    "dear_imgui_rs_show_font_atlas_debug_panel",
+    "dear_imgui_rs_show_metrics_window_without_font_atlas",
+    "dear_imgui_rs_show_style_editor_without_font_atlas",
+];
+
+/// Patch `imgui.cpp` so the metrics window can omit the destructive font-atlas panel.
+pub fn patch_imgui_cpp_for_safe_demo(source: &str) -> Result<String, String> {
+    let (mut patched, newline) = normalize_cpp_source(source);
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "void ImGui::ShowMetricsWindow(bool* p_open)\n{",
+        concat!(
+            "static void DearImGuiRsShowMetricsWindowInternal(bool* p_open, bool show_font_atlas)\n",
+            "{\n",
+            "    using namespace ImGui;"
+        ),
+        "ShowMetricsWindow definition",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        concat!(
+            "    // Details for Fonts\n",
+            "    for (ImFontAtlas* atlas : g.FontAtlases)\n",
+            "        if (TreeNode((void*)atlas, \"Fonts (%d), Textures (%d)\", atlas->Fonts.Size, atlas->TexList.Size))\n",
+            "        {\n",
+            "            ShowFontAtlas(atlas);\n",
+            "            TreePop();\n",
+            "        }"
+        ),
+        concat!(
+            "    // Details for Fonts\n",
+            "    if (show_font_atlas)\n",
+            "    {\n",
+            "        for (ImFontAtlas* atlas : g.FontAtlases)\n",
+            "            if (TreeNode((void*)atlas, \"Fonts (%d), Textures (%d)\", atlas->Fonts.Size, atlas->TexList.Size))\n",
+            "            {\n",
+            "                ShowFontAtlas(atlas);\n",
+            "                TreePop();\n",
+            "            }\n",
+            "    }"
+        ),
+        "ShowMetricsWindow font-atlas section",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "    End();\n}\n\nvoid ImGui::DebugBreakClearData()",
+        concat!(
+            "    End();\n",
+            "}\n\n",
+            "void ImGui::ShowMetricsWindow(bool* p_open)\n",
+            "{\n",
+            "    ::DearImGuiRsShowMetricsWindowInternal(p_open, true);\n",
+            "}\n\n",
+            "void DearImGuiRsShowMetricsWindowWithoutFontAtlas(bool* p_open)\n",
+            "{\n",
+            "    DearImGuiRsShowMetricsWindowInternal(p_open, false);\n",
+            "}\n\n",
+            "void ImGui::DebugBreakClearData()"
+        ),
+        "ShowMetricsWindow wrapper boundary",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "void ImGui::ShowMetricsWindow(bool*) {}",
+        concat!(
+            "void ImGui::ShowMetricsWindow(bool*) {}\n",
+            "void DearImGuiRsShowMetricsWindowWithoutFontAtlas(bool*) {}"
+        ),
+        "disabled ShowMetricsWindow stub",
+    )?;
+
+    Ok(restore_cpp_newlines(patched, newline))
+}
+
+/// Patch `imgui_demo.cpp` so demo and style windows can omit font-atlas debug controls.
+pub fn patch_imgui_demo_cpp_for_safe_demo(source: &str) -> Result<String, String> {
+    let (mut patched, newline) = normalize_cpp_source(source);
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "void ImGui::ShowDemoWindow(bool* p_open)\n{",
+        concat!(
+            "void DearImGuiRsShowMetricsWindowWithoutFontAtlas(bool* p_open);\n",
+            "void DearImGuiRsShowStyleEditorWithoutFontAtlas(ImGuiStyle* ref);\n\n",
+            "static void DearImGuiRsShowDemoWindowInternal(bool* p_open, bool show_font_atlas)\n",
+            "{\n",
+            "    using namespace ImGui;"
+        ),
+        "ShowDemoWindow definition",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "    if (demo_data.ShowMetrics)              { ImGui::ShowMetricsWindow(&demo_data.ShowMetrics); }",
+        concat!(
+            "    if (demo_data.ShowMetrics)\n",
+            "    {\n",
+            "        if (show_font_atlas)\n",
+            "            ImGui::ShowMetricsWindow(&demo_data.ShowMetrics);\n",
+            "        else\n",
+            "            DearImGuiRsShowMetricsWindowWithoutFontAtlas(&demo_data.ShowMetrics);\n",
+            "    }"
+        ),
+        "ShowDemoWindow metrics call",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        concat!(
+            "    if (demo_data.ShowStyleEditor)\n",
+            "    {\n",
+            "        ImGui::Begin(\"Dear ImGui Style Editor\", &demo_data.ShowStyleEditor);\n",
+            "        ImGui::ShowStyleEditor();\n",
+            "        ImGui::End();\n",
+            "    }"
+        ),
+        concat!(
+            "    if (demo_data.ShowStyleEditor)\n",
+            "    {\n",
+            "        ImGui::Begin(\"Dear ImGui Style Editor\", &demo_data.ShowStyleEditor);\n",
+            "        if (show_font_atlas)\n",
+            "            ImGui::ShowStyleEditor();\n",
+            "        else\n",
+            "            DearImGuiRsShowStyleEditorWithoutFontAtlas(NULL);\n",
+            "        ImGui::End();\n",
+            "    }"
+        ),
+        "ShowDemoWindow style-editor call",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "static void DemoWindowWidgets(ImGuiDemoWindowData* demo_data);",
+        "static void DemoWindowWidgets(ImGuiDemoWindowData* demo_data, bool show_font_atlas);",
+        "DemoWindowWidgets declaration",
+    )?;
+    patched = replace_cpp_source_once(
+        &patched,
+        "    DemoWindowWidgets(&demo_data);",
+        "    DemoWindowWidgets(&demo_data, show_font_atlas);",
+        "DemoWindowWidgets call",
+    )?;
+    patched = replace_cpp_source_once(
+        &patched,
+        "static void DemoWindowWidgets(ImGuiDemoWindowData* demo_data)\n{",
+        "static void DemoWindowWidgets(ImGuiDemoWindowData* demo_data, bool show_font_atlas)\n{",
+        "DemoWindowWidgets definition",
+    )?;
+    patched = replace_cpp_source_once(
+        &patched,
+        "    DemoWindowWidgetsFonts();",
+        "    if (show_font_atlas)\n        DemoWindowWidgetsFonts();",
+        "DemoWindowWidgets font-atlas call",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        concat!(
+            "    ImGui::PopItemWidth();\n",
+            "    ImGui::End();\n",
+            "}\n\n",
+            "//-----------------------------------------------------------------------------\n",
+            "// [SECTION] DemoWindowMenuBar()"
+        ),
+        concat!(
+            "    ImGui::PopItemWidth();\n",
+            "    ImGui::End();\n",
+            "}\n\n",
+            "void ImGui::ShowDemoWindow(bool* p_open)\n",
+            "{\n",
+            "    ::DearImGuiRsShowDemoWindowInternal(p_open, true);\n",
+            "}\n\n",
+            "void DearImGuiRsShowDemoWindowWithoutFontAtlas(bool* p_open)\n",
+            "{\n",
+            "    DearImGuiRsShowDemoWindowInternal(p_open, false);\n",
+            "}\n\n",
+            "//-----------------------------------------------------------------------------\n",
+            "// [SECTION] DemoWindowMenuBar()"
+        ),
+        "ShowDemoWindow wrapper boundary",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "void ImGui::ShowStyleEditor(ImGuiStyle* ref)\n{",
+        concat!(
+            "static void DearImGuiRsShowStyleEditorInternal(ImGuiStyle* ref, bool show_font_atlas)\n",
+            "{\n",
+            "    using namespace ImGui;"
+        ),
+        "ShowStyleEditor definition",
+    )?;
+    patched = replace_cpp_source_once(
+        &patched,
+        "        if (BeginTabItem(\"Fonts\"))",
+        "        if (show_font_atlas && BeginTabItem(\"Fonts\"))",
+        "ShowStyleEditor font-atlas tab",
+    )?;
+    patched = replace_cpp_source_once(
+        &patched,
+        concat!(
+            "    PopItemWidth();\n",
+            "}\n\n",
+            "//-----------------------------------------------------------------------------\n",
+            "// [SECTION] User Guide / ShowUserGuide()"
+        ),
+        concat!(
+            "    PopItemWidth();\n",
+            "}\n\n",
+            "void ImGui::ShowStyleEditor(ImGuiStyle* ref)\n",
+            "{\n",
+            "    ::DearImGuiRsShowStyleEditorInternal(ref, true);\n",
+            "}\n\n",
+            "void DearImGuiRsShowStyleEditorWithoutFontAtlas(ImGuiStyle* ref)\n",
+            "{\n",
+            "    DearImGuiRsShowStyleEditorInternal(ref, false);\n",
+            "}\n\n",
+            "//-----------------------------------------------------------------------------\n",
+            "// [SECTION] User Guide / ShowUserGuide()"
+        ),
+        "ShowStyleEditor wrapper boundary",
+    )?;
+
+    patched = replace_cpp_source_once(
+        &patched,
+        "void ImGui::ShowDemoWindow(bool*) {}",
+        concat!(
+            "void ImGui::ShowDemoWindow(bool*) {}\n",
+            "void DearImGuiRsShowDemoWindowWithoutFontAtlas(bool*) {}"
+        ),
+        "disabled ShowDemoWindow stub",
+    )?;
+    patched = replace_cpp_source_once(
+        &patched,
+        "void ImGui::ShowStyleEditor(ImGuiStyle*) {}",
+        concat!(
+            "void ImGui::ShowStyleEditor(ImGuiStyle*) {}\n",
+            "void DearImGuiRsShowStyleEditorWithoutFontAtlas(ImGuiStyle*) {}"
+        ),
+        "disabled ShowStyleEditor stub",
+    )?;
+
+    Ok(restore_cpp_newlines(patched, newline))
+}
+
+fn normalize_cpp_source(source: &str) -> (String, &'static str) {
+    let newline = if source.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    (source.replace("\r\n", "\n"), newline)
+}
+
+fn restore_cpp_newlines(source: String, newline: &str) -> String {
+    if newline == "\r\n" {
+        source.replace('\n', "\r\n")
+    } else {
+        source
+    }
+}
+
+fn replace_cpp_source_once(
+    source: &str,
+    marker: &str,
+    replacement: &str,
+    description: &str,
+) -> Result<String, String> {
+    let count = source.match_indices(marker).count();
+    if count != 1 {
+        return Err(format!(
+            "{description}: expected exactly one source marker, found {count}"
+        ));
+    }
+    Ok(source.replacen(marker, replacement, 1))
+}
+
 #[cfg(any(feature = "binding-spec", test))]
 pub mod binding {
     use std::collections::{BTreeMap, BTreeSet};
@@ -4416,7 +4703,11 @@ mod binding_contract_tests {
             target_endian: "little",
             target_pointer_width: "64",
             cargo_profile: "release",
-            artifact_features: vec!["platform-io-aggregate-hooks", "wchar32"],
+            artifact_features: vec![
+                "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_ARTIFACT_FEATURE,
+                "wchar32",
+            ],
             environment: values,
         })
     }
@@ -4428,7 +4719,11 @@ mod binding_contract_tests {
             "x86_64-pc-windows-msvc",
             "static",
             "md",
-            ["platform-io-aggregate-hooks", "wchar32"],
+            [
+                "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_ARTIFACT_FEATURE,
+                "wchar32",
+            ],
             SourceRevisions::new(
                 "1261b231939fc210032f30c4ee8a8f0440372237",
                 "b61e56346a92cfcaf1f43a545ca37b0b32239654",
@@ -4446,6 +4741,7 @@ mod binding_contract_tests {
             "md",
             [
                 "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_ARTIFACT_FEATURE,
                 "wchar32",
                 "freetype",
                 "stack-layout",
@@ -4926,14 +5222,18 @@ mod binding_contract_tests {
             "x86_64-pc-windows-msvc",
             "static",
             "md",
-            ["platform-io-aggregate-hooks", "wchar32"],
+            [
+                "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_ARTIFACT_FEATURE,
+                "wchar32",
+            ],
             SourceRevisions::new(
                 "1261b231939fc210032f30c4ee8a8f0440372237",
                 "b61e56346a92cfcaf1f43a545ca37b0b32239654",
             ),
             "fnv1a64:0123456789abcdef",
         );
-        assert_eq!(profile.deterministic_hash(), "fnv1a64:1c6bc757a0743a80");
+        assert_eq!(profile.deterministic_hash(), "fnv1a64:2b8ec258d4aa24c6");
     }
 
     #[test]
@@ -5842,6 +6142,92 @@ mod tests {
 
     #[cfg(any(feature = "pkg-config", feature = "vcpkg"))]
     const TARGET_ENV_VARS: [&str; 2] = ["CARGO_CFG_TARGET_OS", "CARGO_CFG_TARGET_ENV"];
+
+    #[test]
+    fn metrics_patch_guards_only_the_font_atlas_section() {
+        let source = concat!(
+            "void ImGui::ShowMetricsWindow(bool* p_open)\n",
+            "{\n",
+            "    KeepOrdinaryMetrics();\n",
+            "    // Details for Fonts\n",
+            "    for (ImFontAtlas* atlas : g.FontAtlases)\n",
+            "        if (TreeNode((void*)atlas, \"Fonts (%d), Textures (%d)\", atlas->Fonts.Size, atlas->TexList.Size))\n",
+            "        {\n",
+            "            ShowFontAtlas(atlas);\n",
+            "            TreePop();\n",
+            "        }\n",
+            "    End();\n",
+            "}\n\n",
+            "void ImGui::DebugBreakClearData()\n",
+            "{\n",
+            "}\n\n",
+            "void ImGui::ShowMetricsWindow(bool*) {}\n",
+        );
+
+        let patched = patch_imgui_cpp_for_safe_demo(source).unwrap();
+
+        assert!(patched.contains("KeepOrdinaryMetrics();"));
+        assert!(patched.contains("if (show_font_atlas)"));
+        assert!(patched.contains("void ImGui::ShowMetricsWindow(bool* p_open)"));
+        assert!(
+            patched.contains("void DearImGuiRsShowMetricsWindowWithoutFontAtlas(bool* p_open)")
+        );
+    }
+
+    #[test]
+    fn demo_patch_preserves_non_font_demo_and_style_controls() {
+        let source = concat!(
+            "static void DemoWindowWidgets(ImGuiDemoWindowData* demo_data);\n",
+            "void ImGui::ShowDemoWindow(bool* p_open)\n",
+            "{\n",
+            "    KeepOrdinaryDemo();\n",
+            "    if (demo_data.ShowMetrics)              { ImGui::ShowMetricsWindow(&demo_data.ShowMetrics); }\n",
+            "    if (demo_data.ShowStyleEditor)\n",
+            "    {\n",
+            "        ImGui::Begin(\"Dear ImGui Style Editor\", &demo_data.ShowStyleEditor);\n",
+            "        ImGui::ShowStyleEditor();\n",
+            "        ImGui::End();\n",
+            "    }\n",
+            "    DemoWindowWidgets(&demo_data);\n",
+            "    ImGui::PopItemWidth();\n",
+            "    ImGui::End();\n",
+            "}\n\n",
+            "//-----------------------------------------------------------------------------\n",
+            "// [SECTION] DemoWindowMenuBar()\n",
+            "static void DemoWindowWidgets(ImGuiDemoWindowData* demo_data)\n",
+            "{\n",
+            "    DemoWindowWidgetsFonts();\n",
+            "}\n",
+            "void ImGui::ShowStyleEditor(ImGuiStyle* ref)\n",
+            "{\n",
+            "        if (BeginTabItem(\"Colors\"))\n",
+            "            KeepColorEditor();\n",
+            "        if (BeginTabItem(\"Fonts\"))\n",
+            "            ShowFontAtlas(atlas);\n",
+            "    PopItemWidth();\n",
+            "}\n\n",
+            "//-----------------------------------------------------------------------------\n",
+            "// [SECTION] User Guide / ShowUserGuide()\n",
+            "void ImGui::ShowDemoWindow(bool*) {}\n",
+            "void ImGui::ShowStyleEditor(ImGuiStyle*) {}\n",
+        );
+
+        let patched = patch_imgui_demo_cpp_for_safe_demo(source).unwrap();
+
+        assert!(patched.contains("KeepOrdinaryDemo();"));
+        assert!(patched.contains("KeepColorEditor();"));
+        assert!(
+            patched.contains(
+                "DemoWindowWidgets(ImGuiDemoWindowData* demo_data, bool show_font_atlas)"
+            )
+        );
+        assert!(patched.contains("if (show_font_atlas)\n        DemoWindowWidgetsFonts();"));
+        assert!(patched.contains("show_font_atlas && BeginTabItem(\"Fonts\")"));
+        assert!(patched.contains("void DearImGuiRsShowDemoWindowWithoutFontAtlas(bool* p_open)"));
+        assert!(
+            patched.contains("void DearImGuiRsShowStyleEditorWithoutFontAtlas(ImGuiStyle* ref)")
+        );
+    }
 
     #[test]
     fn static_cpp_stdlib_is_limited_to_windows_gnu_targets() {

--- a/tools/ci/_archive.py
+++ b/tools/ci/_archive.py
@@ -28,6 +28,7 @@ REQUIRED_CORE_BINDINGS = (
 )
 SYS_SENTINELS = {
     "dear-imgui-sys": (
+        "src/demo_window_shim.cpp",
         "src/platform_io_hooks.cpp",
         "third-party/cimgui/cimgui.cpp",
         "third-party/cimgui/imgui/imgui.cpp",

--- a/tools/ci/_prebuilt.py
+++ b/tools/ci/_prebuilt.py
@@ -16,6 +16,7 @@ from _verification import VerificationError, temporary_workspace
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+SAFE_DEMO_FONT_BOUNDARY_FEATURE = "safe-demo-font-boundary-v1"
 
 
 @dataclass(frozen=True)
@@ -45,19 +46,39 @@ class ExtensionSpec:
 PREBUILT_PROFILES = (
     PrebuiltProfile(
         "normal",
-        frozenset(("platform-io-aggregate-hooks", "wchar32")),
+        frozenset(
+            (
+                "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_FEATURE,
+                "wchar32",
+            )
+        ),
         (),
         True,
     ),
     PrebuiltProfile(
         "stack-layout",
-        frozenset(("platform-io-aggregate-hooks", "stack-layout", "wchar32")),
+        frozenset(
+            (
+                "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_FEATURE,
+                "stack-layout",
+                "wchar32",
+            )
+        ),
         ("stack-layout",),
         True,
     ),
     PrebuiltProfile(
         "freetype",
-        frozenset(("platform-io-aggregate-hooks", "freetype", "wchar32")),
+        frozenset(
+            (
+                "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_FEATURE,
+                "freetype",
+                "wchar32",
+            )
+        ),
         ("freetype",),
         False,
     ),
@@ -66,6 +87,7 @@ PREBUILT_PROFILES = (
         frozenset(
             (
                 "platform-io-aggregate-hooks",
+                SAFE_DEMO_FONT_BOUNDARY_FEATURE,
                 "stack-layout",
                 "freetype",
                 "wchar32",

--- a/tools/tests/test_api_surface_report.py
+++ b/tools/tests/test_api_surface_report.py
@@ -192,7 +192,7 @@ class ApiSurfaceReportTests(unittest.TestCase):
                 for name, decision in policy.items()
                 if decision.classification == "unsafe-wrapper"
             },
-            {"ShowDemoWindow", "ShowMetricsWindow", "ShowStyleEditor"},
+            set(),
         )
 
     def test_alias_collector_accepts_only_public_safe_items(self):

--- a/tools/tests/test_verify_packaged_core.py
+++ b/tools/tests/test_verify_packaged_core.py
@@ -28,11 +28,15 @@ CLI = importlib.import_module("verify_packaged_core")
 
 
 PROFILE_FEATURES = {
-    "normal": "platform-io-aggregate-hooks,wchar32",
-    "freetype": "freetype,platform-io-aggregate-hooks,wchar32",
-    "stack-layout": "platform-io-aggregate-hooks,stack-layout,wchar32",
+    "normal": "platform-io-aggregate-hooks,safe-demo-font-boundary-v1,wchar32",
+    "freetype": (
+        "freetype,platform-io-aggregate-hooks,safe-demo-font-boundary-v1,wchar32"
+    ),
+    "stack-layout": (
+        "platform-io-aggregate-hooks,safe-demo-font-boundary-v1,stack-layout,wchar32"
+    ),
     "stack-layout-freetype": (
-        "freetype,platform-io-aggregate-hooks,stack-layout,wchar32"
+        "freetype,platform-io-aggregate-hooks,safe-demo-font-boundary-v1,stack-layout,wchar32"
     ),
 }
 CANDIDATE_SHA = "cccccccccccccccccccccccccccccccccccccccc"
@@ -250,7 +254,7 @@ class PrebuiltArchiveSelectionTests(unittest.TestCase):
 
             self.assertEqual(
                 PREBUILT.core_artifact_profile_hash(fields, archive),
-                "fnv1a64:1c6bc757a0743a80",
+                "fnv1a64:2b8ec258d4aa24c6",
             )
 
     def test_core_identity_anchors_candidate_and_rejects_legacy_manifests(self):

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1151,6 +1151,20 @@ fn build_cimgui_provider() -> Result<()> {
         .join("imGuIZMO.quat")
         .join("imguizmo_quat");
     let out_js = out_dir.join("imgui-sys-v0.js"); // Output to .js, not .wasm
+    let patched_imgui_cpp = out_dir.join("imgui_safe_demo_patched.cpp");
+    let patched_imgui_demo_cpp = out_dir.join("imgui_demo_safe_demo_patched.cpp");
+    let imgui_cpp_source = fs::read_to_string(imgui_src.join("imgui.cpp"))?;
+    fs::write(
+        &patched_imgui_cpp,
+        build_support::patch_imgui_cpp_for_safe_demo(&imgui_cpp_source)
+            .map_err(anyhow::Error::msg)?,
+    )?;
+    let imgui_demo_cpp_source = fs::read_to_string(imgui_src.join("imgui_demo.cpp"))?;
+    fs::write(
+        &patched_imgui_demo_cpp,
+        build_support::patch_imgui_demo_cpp_for_safe_demo(&imgui_demo_cpp_source)
+            .map_err(anyhow::Error::msg)?,
+    )?;
 
     // Generate ES module glue export names by scanning pregenerated wasm bindings
     let bindings = sys_root.join("src").join("wasm_bindings_pregenerated.rs");
@@ -1169,6 +1183,9 @@ fn build_cimgui_provider() -> Result<()> {
                 }
             }
         }
+    }
+    for name in build_support::SAFE_DEMO_FONT_BOUNDARY_WASM_EXPORTS {
+        names.insert((*name).to_owned());
     }
     // Also include ImPlot symbols from dear-implot-sys wasm bindings when available,
     // so the provider can satisfy imports from the ImPlot FFI crate.
@@ -1390,11 +1407,12 @@ fn build_cimgui_provider() -> Result<()> {
         .arg("-I")
         .arg(&imguizmo_src)
         .arg(cimgui_root.join("cimgui.cpp"))
-        .arg(imgui_src.join("imgui.cpp"))
+        .arg(&patched_imgui_cpp)
         .arg(imgui_src.join("imgui_draw.cpp"))
         .arg(imgui_src.join("imgui_widgets.cpp"))
         .arg(imgui_src.join("imgui_tables.cpp"))
-        .arg(imgui_src.join("imgui_demo.cpp"))
+        .arg(&patched_imgui_demo_cpp)
+        .arg(sys_root.join("src").join("demo_window_shim.cpp"))
         .arg(cimplot_root.join("cimplot.cpp"))
         .arg(implot_src.join("implot.cpp"))
         .arg(implot_src.join("implot_items.cpp"))


### PR DESCRIPTION
- What
  - Built-in Demo, Metrics, and Style Editor windows are safe to use again while retaining every control outside upstream `ShowFontAtlas()` panels, including normal font selection and scaling. Exact upstream behavior remains available through explicit `show_upstream_*` unsafe methods, and the hazardous font panel is isolated as `show_font_atlas_debug_panel()`. Native source builds, prebuilts, and the WASM provider use the same checked patch contract, while a new artifact capability rejects stale prebuilts.

- Why
  - Upstream's font-atlas debugger can delete an `ImFont` and continue reading that pointer in the same native call when managed renderer textures leave the atlas unlocked. Rust cannot make that monolithic interaction safe, so the binding now removes only those call paths instead of marking the entire diagnostic surface unsafe.

- Affected crates
  - [x] dear-imgui-rs
  - [x] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [ ] backends/dear-imgui-winit
  - [ ] backends/dear-imgui-sdl3
  - [x] backends/dear-imgui-bevy (example only)
  - [ ] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [x] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [x] Prebuilt logic (feature/env)
  - [x] Packaging (.tar.gz)
  - [x] WASM provider
  - [ ] No behavior change (refactor/cleanup)

- Breaking changes
  - [ ] None
  - [x] Yes: the safe diagnostic methods no longer render `ShowFontAtlas()` panels. Use `show_upstream_*` or `show_font_atlas_debug_panel()` in an unsafe block for exact upstream behavior.

- Testing / validation
  - `rustfmt --check` passed for the changed Rust surfaces.
  - 15 focused prebuilt and source-archive Python tests passed.
  - LLVM 22 `clang++ -fsyntax-only` passed for the new C++ shim.
  - Changelog extraction and soft-wrap checks passed for `0.16.0-alpha.1`.
  - Full Cargo, native-link, WASM-provider, and prebuilt producer/consumer validation is intentionally deferred to PR CI to avoid local resource contention.
  - Platforms/targets checked locally: Windows host static validation; cross-platform targets pending CI.

- Docs
  - [ ] N/A
  - [x] Updated changelog, API coverage, compatibility docs, crate docs, and runnable examples

- Links
  - None.
