### PR TITLE
fix(release): keep verification checkout clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,9 @@ jobs:
       - name: Extract release notes
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-        run: python3 -B tools/ci/run_contract.py release-notes --output release-notes.md
+        run: >-
+          python3 -B tools/ci/run_contract.py release-notes
+          --output "$RUNNER_TEMP/release-notes.md"
 
       - name: Verify every crate version is published
         run: >-
@@ -193,7 +195,7 @@ jobs:
           tag_name: ${{ inputs.tag }}
           target_commitish: ${{ github.sha }}
           name: ${{ inputs.tag }}
-          body_path: release-notes.md
+          body_path: ${{ runner.temp }}/release-notes.md
           files: ${{ runner.temp }}/release-assets/*
           fail_on_unmatched_files: true
           overwrite_files: false


### PR DESCRIPTION
## Summary

Crate publication could finish successfully and the release workflow could still fail before creating the GitHub Release. Extracting release notes created `release-notes.md` in the checkout, so the strict published-version verifier rejected the now-dirty release source.

Generated release notes now live in `RUNNER_TEMP`, and the release action reads the same temporary path. Registry verification therefore continues against the exact clean candidate checkout.

## Validation

- Extracted `v0.16.0-alpha.2` notes into a simulated runner temp directory and confirmed no checkout-root file was created.
- `python -m unittest tools.tests.test_run_contract` — 16 tests passed.
- Parsed `.github/workflows/release.yml` successfully with PyYAML.
- Recovered and verified the `v0.16.0-alpha.2` GitHub prerelease with all 86 expected assets.
