### PR TITLE
fix(context): use GetCurrentWindowRead in scope snapshot

### DIFF
--- a/dear-imgui/src/scope.rs
+++ b/dear-imgui/src/scope.rs
@@ -39,7 +39,7 @@ impl ScopeSnapshot {
         debug_assert_eq!(unsafe { sys::igGetCurrentContext() }, ui.context_raw());
         let context = unsafe { &*ui.context_raw() };
         let frame = context.FrameCount;
-        let window = unsafe { sys::igGetCurrentWindow() };
+        let window = unsafe { sys::igGetCurrentWindowRead() };
         let window = (!window.is_null()).then(|| WindowScope {
             frame,
             window: window as usize,
@@ -896,5 +896,30 @@ impl Ui {
     pub(crate) fn current_native_scope(&self) -> ScopeSnapshot {
         let current = unsafe { ScopeSnapshot::current_raw(self) };
         self.native_scopes.borrow().resolve_scope(current)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ending_a_top_level_window_does_not_mark_the_fallback_window_written() {
+        let mut ctx = crate::Context::create();
+        ctx.io_mut().set_display_size([128.0, 128.0]);
+        ctx.io_mut().set_delta_time(1.0 / 60.0);
+        ctx.font_atlas()
+            .try_claim_legacy_renderer()
+            .expect("legacy renderer font atlas should be available")
+            .build();
+
+        let ui = ctx.frame();
+        ui.window("Regression").build(|| {});
+
+        let fallback = unsafe { crate::sys::igGetCurrentWindowRead() };
+        assert!(!fallback.is_null());
+        assert!(
+            !unsafe { (*fallback).WriteAccessed },
+            "ending a top-level window must not mark Dear ImGui's implicit \
+             fallback window as written-to"
+        );
     }
 }

--- a/dear-imgui/src/scope.rs
+++ b/dear-imgui/src/scope.rs
@@ -903,6 +903,7 @@ impl Ui {
 mod tests {
     #[test]
     fn ending_a_top_level_window_does_not_mark_the_fallback_window_written() {
+        let _guard = crate::test_support::imgui_context_guard();
         let mut ctx = crate::Context::create();
         ctx.io_mut().set_display_size([128.0, 128.0]);
         ctx.io_mut().set_delta_time(1.0 / 60.0);


### PR DESCRIPTION
- Context
  - This bug was noticed in version `0.16.0-alpha.2`
  - All testing has been done locally on Windows x86_64 (MSVC)

- What
  - Switch `ScopeSnapshot::current_raw()` from using `GetCurrentWindow()` to `GetCurrentWindowRead()`

- Why
  - Using `.window("...").build(|| {})` would cause the imgui `Debug##Default` window to appear even when not drawn to. Traced back to the call to GetCurrentWindow() causing that window to be marked as drawn to (causing imgui to render it even when empty).

- Affected crates
  - [x] dear-imgui-rs
  - [ ] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [ ] backends/dear-imgui-winit
  - [ ] backends/dear-imgui-sdl3
  - [ ] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [ ] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [ ] No behavior change (refactor/cleanup)
  - None of the above seem to fit (or I just don't know how to fill this part out). One line fix of bug behavior.

- Breaking changes
  - [x] None

- Testing / validation
  - `cargo test -p dear-imgui-rs -- --test-threads=1` passes locally
  - added a regression test `scope::tests::ending_a_top_level_window_does_not_mark_the_fallback_window_written` that fails before, passes after
  - tested the fixed version against the personal project that surfaced this bug, Debug window no longer incidentally triggered

- Docs
  - [x] N/A

- AI disclosure
  - AI (Claude Code) was used in triaging and fixing this issue, however the code was human reviewed, human tested, and this PR description was prepared by hand.