### PR TITLE
refactor: harden multiview ownership boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ## [Unreleased]
 
+### Breaking Changes and Migration
+
+- SDL3 callback-mode applications must replace `Sdl3CallbackEventHandoff::try_drain` and `Sdl3CallbackEventQueue` with `drain`, inspect the returned batch through `faults()`, and then consume its retained events. The atomic batch preserves every distinct deferred fault and keeps ordered input available after overflow or lock-poison recovery.
+- Bevy applications must handle `Result` from `ImguiContexts::{primary_id,ids,contains}`, register application input producers through `ImguiAppExt::add_imgui_input_producers`, and register frame systems through an App-issued `ImguiPass` plus its sealed `ImguiSystemConfigs`. The public `ImguiInputSystems` set was removed so application ordering cannot suspend or split the backend-owned input transaction.
+- In `dear-app`, only `configure_imgui` retains full Dear ImGui `Context` access before platform and renderer attachment. `initialized` now receives `InitializedContext`, while event, pre-frame, and shutdown callbacks use narrow IO, style, font-atlas, and managed-texture capabilities. Every callback boundary validates the Context identity, native frame sequence, and lifecycle state.
+
+### Changed
+
+- Winit multi-viewport failures now retain the exact Context, viewport generation, native handle, and platform userdata until the close request is observed, preventing stale failures from closing a reused viewport. macOS `NO_FOCUS_ON_APPEARING` windows are shown without activating the application.
+- Bevy frame input is now a move-only, exactly-once transaction that binds route epoch, Context metrics, and cursor/IME authority to the same driver run. Terminal registries and private pass lifecycles fail explicitly instead of returning active-looking empty state.
+
+### Fixed
+
+- `Viewport::is_main` now identifies main viewports across all live managed Contexts without depending on whichever native Context is temporarily current.
+- `dear-app` now reports and closes frames leaked by application callbacks while preserving the callback's original error as the primary failure.
+- SDL3 callback coalescing now uses a bounded indexed queue, keeping high-frequency mouse, window, and display state updates O(1) without changing FIFO, reserve, or overflow behavior.
+
 ## [0.16.0-alpha.2] - 2026-08-09
 
 This source-breaking prerelease completes the ownership work started in alpha.1. Safe APIs now carry the Context, frame, renderer, native-callback, and GPU-completion capabilities needed for the operation they expose; provisional aliases and manual phase controls were removed instead of becoming permanent compatibility surface.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ name = "dear-imgui-winit"
 version = "0.16.0-alpha.2"
 dependencies = [
  "dear-imgui-rs",
+ "objc2-app-kit 0.3.2",
  "thiserror 2.0.18",
  "web-sys",
  "web-time",

--- a/backends/dear-imgui-bevy/CHANGELOG.md
+++ b/backends/dear-imgui-bevy/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- `ImguiContexts::{primary_id,ids,contains}` now return `Result` so a retained registry reports terminal App shutdown instead of looking like an active empty registry.
+- The public `ImguiInputSystems` set was removed. Register application-owned producers with `ImguiAppExt::add_imgui_input_producers`; backend lifecycle, producer, and commit ordering is private and cannot be suspended through an application run condition.
+- Frame systems must be branded with an App-issued `ImguiPass` and registered as sealed `ImguiSystemConfigs`; pass declarations and registration now validate before mutating Bevy schedules.
+
+### Changed
+
+- Each driver run consumes one move-only input transaction containing its route epoch, Context metrics, and cursor/IME authority. Missing producer runs cannot replay prior-frame input, and custom producers commit into the same Context frame.
+- Explicit shutdown now retires private pass registrations with the Context registry and leaves retained registry handles in an observable terminal state.
+
 ## 0.16.0-alpha.2 - 2026-08-09
 
 ### Changed

--- a/backends/dear-imgui-bevy/README.md
+++ b/backends/dear-imgui-bevy/README.md
@@ -10,13 +10,13 @@ The backend owns Dear ImGui Contexts on Bevy's main thread, routes Bevy window i
 | --- | --- |
 | Rust | `1.95.0` or newer |
 | Bevy | exactly `0.19.0` |
-| dear-imgui-rs | `0.16.0-alpha.2` |
+| dear-imgui-rs | `main` (next prerelease) |
 
 `dear-imgui-bevy` defaults to the renderer plus deterministic Bevy UI ordering. Native multi-viewport is supported through an explicit feature and runtime opt-in. WASM supports the normal and headless feature sets but cannot create native platform windows.
 
 ## Installation
 
-Until `0.16.0-alpha.2` is published:
+This README documents the source-breaking API on `main`. Use matching Git dependencies:
 
 ```toml
 [dependencies]
@@ -25,19 +25,13 @@ dear-imgui-bevy = { git = "https://github.com/Latias94/dear-imgui-rs", branch = 
 dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
 ```
 
-After publication:
-
-```toml
-[dependencies]
-bevy = "=0.19.0"
-dear-imgui-bevy = "=0.16.0-alpha.2"
-dear-imgui-rs = "=0.16.0-alpha.2"
-```
+For the published `0.16.0-alpha.2` API and crates.io dependencies, use the
+[tagged alpha.2 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.16.0-alpha.2/backends/dear-imgui-bevy/README.md).
 
 For a headless integration that drives private UI passes without installing the Bevy renderer:
 
 ```toml
-dear-imgui-bevy = { version = "=0.16.0-alpha.2", default-features = false }
+dear-imgui-bevy = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", default-features = false }
 ```
 
 ## Quick Start
@@ -48,18 +42,18 @@ One primary window and one active primary-window camera are routed automatically
 use bevy::prelude::*;
 use dear_imgui_bevy::prelude::*;
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins);
-    app.try_install_imgui(ImguiPlugin::default())
-        .expect("the Dear ImGui configuration is valid");
+    app.try_install_imgui(ImguiPlugin::default())?;
     app
         .add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Camera2d);
         });
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(tools_ui))
-        .run();
+    let primary_pass = app.imgui_primary_pass()?;
+    app.add_imgui_systems(&primary_pass, primary_pass.system(tools_ui))?;
+    app.run();
+    Ok(())
 }
 
 fn tools_ui(frame: ImguiFrame<'_>) {
@@ -74,7 +68,7 @@ existing Context registry, and private-driver schedule placement before it mutat
 `app.add_plugins(ImguiPlugin::default())` remains available as an explicit panic-on-invalid-config
 convenience adapter over the same installation transaction.
 
-The plugin opens and closes each frame around a private, runner-owned pass. UI systems borrow the active frame through `ImguiFrame<'_, P>` and must not call `Context::frame()` or `Context::render()` themselves. Bind each UI function with `pass.system(...)`, then register it through `ImguiAppExt::add_imgui_systems`.
+The plugin opens and closes each frame around a private, runner-owned pass. UI systems borrow the active frame through `ImguiFrame<'_, P>` and must not call `Context::frame()` or `Context::render()` themselves. Bind each UI function with `pass.system(...)`, then register it through `ImguiAppExt::add_imgui_systems`. The resulting `ImguiSystemConfigs<P>` is sealed and cannot be added to an ordinary Bevy schedule.
 
 ## Feature Modes
 
@@ -102,7 +96,7 @@ The plugin opens and closes each frame around a private, runner-owned pass. UI s
 | `ImguiViewportWindow { viewport_id }`, `ImguiViewportCamera { viewport_id }`, direct field access, or `.copied()` marker queries | Query markers by reference. Retain `instance_id()` for stable lifecycle identity; call `viewport_id()` only for the current Dear ImGui route. The backend exclusively creates and repairs these projections. |
 | Public begin/end schedules, renderer resources, or viewport queue access | Let the plugin drive frames; order custom passes through `ImguiRenderSystems` and observe only public route, diagnostic, capture, texture, and viewport identity/configuration types. |
 | Reusing an application schedule for an additional Context | Declare an `ImguiPass<P>` and register typed frame systems through `ImguiAppExt`; the private runner cannot be invoked as an application schedule. |
-| Single-system `add_imgui_system` registration | Bind systems with `pass.system(...)`, then pass normal Bevy system configs to `add_imgui_systems`; tuples, `chain`, `before`, `after`, `run_if`, and system sets retain Bevy semantics. |
+| Single-system `add_imgui_system` registration | Bind systems with `pass.system(...)`, combine the sealed configs with tuples and `IntoImguiSystemConfigs` modifiers such as `chain`, `before`, `after`, `run_if`, and `in_set`, then handle the `Result` from `add_imgui_systems`. |
 | Constructing `ImguiContexts::with_primary` and inserting it manually | Call `app.adopt_imgui_primary_context(context)` before adding `ImguiPlugin`; the App-scoped lifecycle prevents registry reconstruction after terminal shutdown. |
 | Wrapper extraction through `into_inner()` | Advanced code that must recover the native owner calls `try_remove_immediately`, advances the required render/viewport schedules on `RemovalPending`, and retries explicitly. Normal removal destroys the Context through the managed queue. |
 
@@ -110,7 +104,7 @@ The plugin opens and closes each frame around a private, runner-owned pass. UI s
 
 ### Contexts and Passes
 
-`ImguiContexts` owns every Dear ImGui Context in deterministic order. `imgui_primary_pass()` returns the stable pass handle owned by the primary Context. Create an independent Context with a private typed pass:
+`ImguiContexts` owns every Dear ImGui Context in deterministic order. `imgui_primary_pass()` returns the stable pass handle owned by the primary Context. Pass lookup and declaration are fallible, so applications should propagate or explicitly handle `ImguiPassError`. Create an independent Context with a private typed pass:
 
 ```rust
 struct InspectorPass;
@@ -127,21 +121,24 @@ fn inspector_ui(frame: ImguiFrame<'_, InspectorPass>) {
     frame.ui().text("Independent inspector Context");
 }
 
-let inspector_pass = app.declare_imgui_pass::<InspectorPass>();
-app.insert_resource(inspector_pass.clone())
-    .add_systems(Startup, create_inspector)
-    .add_imgui_systems(&inspector_pass, inspector_pass.system(inspector_ui));
+fn install_inspector(app: &mut App) -> Result {
+    let inspector_pass = app.declare_imgui_pass::<InspectorPass>()?;
+    app.insert_resource(inspector_pass.clone())
+        .add_systems(Startup, create_inspector);
+    app.add_imgui_systems(&inspector_pass, inspector_pass.system(inspector_ui))?;
+    Ok(())
+}
 ```
 
-Each `declare_imgui_pass::<P>()` call creates a distinct runtime pass, even when `P` is the same type. The handle is `Clone`, not `Copy`; keep the exact handle for `ImguiContextConfig::new(&pass)`, `pass.system(...)`, and `add_imgui_systems`. The type parameter prevents accidental cross-brand registration, while the private runtime identity prevents two Contexts of one brand from sharing a runner. A raw frame-input function cannot be added to a normal Bevy schedule; only the private driver can supply its `ImguiFrame`. A bound system registered elsewhere fails closed before accessing `Ui`, including in a render sub-app or on another thread. Use `frame.context_id()` when a system needs its active Context identity, and use `contexts.configure(context_id, |context| ...)` only outside an active frame for font, ini, style, or other Context configuration.
+Each successful `declare_imgui_pass::<P>()` call creates a distinct runtime pass, even when `P` is the same type. The handle is `Clone`, not `Copy`; keep the exact handle for `ImguiContextConfig::new(&pass)`, `pass.system(...)`, and `add_imgui_systems`. The type parameter prevents accidental cross-brand registration, while the private runtime identity prevents two Contexts of one brand from sharing a runner. Neither a raw frame-input function nor the `ImguiSystemConfigs<P>` produced by `pass.system(...)` can enter a normal Bevy schedule; only the private driver can supply its `ImguiFrame`. A bound system registered elsewhere fails closed before accessing `Ui`, including in a render sub-app or on another thread. Use `frame.context_id()` when a system needs its active Context identity, and use `contexts.configure(context_id, |context| ...)` only outside an active frame for font, ini, style, or other Context configuration.
 
-`add_imgui_systems` and `configure_imgui_sets` forward Bevy's native `SystemConfigs` and set configs into the private pass schedule. Chained systems receive Bevy's normal intermediate `ApplyDeferred` barriers, so commands from one UI system can be observed by the next system in the chain.
+The sealed `IntoImguiSystemConfigs` trait retains the common Bevy modifiers needed inside a private pass: tuples, `in_set`, `before`, `after`, deferred-barrier variants, `run_if`, `distributive_run_if`, ambiguity controls, and chaining. `configure_imgui_sets` continues to accept Bevy's native set configs. Both `add_imgui_systems` and `configure_imgui_sets` return `Result<&mut App, ImguiPassError>` and validate the App lifecycle, runtime pass identity, and Rust brand; system registration also validates the bound-system provenance. Every error is returned before the target runner is modified, so the runner remains unchanged. Chained systems receive Bevy's normal intermediate `ApplyDeferred` barriers, so commands from one UI system can be observed by the next system in the chain.
 
 The serial Context driver runs immediately after `PreUpdate` by default. Bevy input is mapped and `WantCapture*` is sampled before Dear ImGui opens its frame, as required for a stable decision about that input batch. Gameplay systems in `Update` observe that pre-`NewFrame` capture decision together with the current UI output. Use `ImguiPluginConfig::with_driver_before(label)` or `with_driver_after(label)` when an application instead needs UI to observe later gameplay or transform state. A custom anchor must already be present in Bevy's `MainScheduleOrder` when `ImguiPlugin` is added, and the resulting placement must remain after `PreUpdate` completes and before `PostUpdate` begins. Camera and route topology is published in `PostUpdate` for the next frame; moving the driver past that publication boundary is rejected.
 
 `ImguiContexts::promote_primary(context_id)` selects an existing idle Context as the primary input and fallback-window target. `replace_primary(context, config)` first admits a new Context and changes the primary pointer only after admission succeeds; the previous primary remains registered for explicit asynchronous removal. Neither operation silently moves pass ownership, docking settings, or native viewport ownership between Contexts.
 
-An App claims its `ImguiContexts` registry exactly once. Temporarily removing that non-send value from the World does not reopen admission; reinsert the same value before continuing or call terminal shutdown. This prevents two registries from sharing one set of private passes and backend resources.
+An App claims its `ImguiContexts` registry exactly once. Temporarily removing that non-send value from the World does not reopen admission; reinsert the same value before continuing or call terminal shutdown. This prevents two registries from sharing one set of private passes and backend resources. A retained registry becomes explicitly terminal after shutdown: `primary_id`, `ids`, and `contains` return `ImguiContextError::AppTerminated` instead of disguising that state as `None`, an empty iterator, or `false`.
 
 ### Fonts
 
@@ -152,7 +149,7 @@ const ROBOTO_MEDIUM: &[u8] = include_bytes!("../assets/Roboto-Medium.ttf");
 
 fn configure_fonts(mut contexts: NonSendMut<ImguiContexts>) -> Result {
     let primary = contexts
-        .primary_id()
+        .primary_id()?
         .ok_or("ImguiPlugin should install a primary Context before Startup")?;
 
     let roboto = StbTrueTypeFontData::from_slice(ROBOTO_MEDIUM)?;

--- a/backends/dear-imgui-bevy/examples/advanced/custom_post_process.rs
+++ b/backends/dear-imgui-bevy/examples/advanced/custom_post_process.rs
@@ -119,7 +119,7 @@ impl FullscreenMaterial for AfterOverlayEffect {
     }
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(
         DefaultPlugins
@@ -149,9 +149,10 @@ fn main() {
         Update,
         (close_on_escape, animate_scene, apply_composition_settings),
     );
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(composition_ui))
-        .run();
+    let primary_pass = app.imgui_primary_pass()?;
+    app.add_imgui_systems(&primary_pass, primary_pass.system(composition_ui))?;
+    app.run();
+    Ok(())
 }
 
 fn setup(mut commands: Commands) {

--- a/backends/dear-imgui-bevy/examples/advanced/multiple_contexts.rs
+++ b/backends/dear-imgui-bevy/examples/advanced/multiple_contexts.rs
@@ -35,7 +35,7 @@ struct MultipleContextState {
     retirement_status: String,
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
@@ -47,8 +47,7 @@ fn main() {
         }),
         ..Default::default()
     }));
-    app.try_install_imgui(ImguiPlugin::default())
-        .expect("the example configuration is valid");
+    app.try_install_imgui(ImguiPlugin::default())?;
     app.init_resource::<MultipleContextState>()
         .add_systems(Startup, setup)
         .add_systems(
@@ -59,12 +58,13 @@ fn main() {
                 (retire_secondary_context, finish_secondary_retirement).chain(),
             ),
         );
-    let primary_pass = app.imgui_primary_pass();
-    let secondary_pass = app.declare_imgui_pass::<SecondaryContextPass>();
-    app.insert_resource(secondary_pass.clone())
-        .add_imgui_systems(&primary_pass, primary_pass.system(primary_ui))
-        .add_imgui_systems(&secondary_pass, secondary_pass.system(secondary_ui))
-        .run();
+    let primary_pass = app.imgui_primary_pass()?;
+    let secondary_pass = app.declare_imgui_pass::<SecondaryContextPass>()?;
+    app.insert_resource(secondary_pass.clone());
+    app.add_imgui_systems(&primary_pass, primary_pass.system(primary_ui))?;
+    app.add_imgui_systems(&secondary_pass, secondary_pass.system(secondary_ui))?;
+    app.run();
+    Ok(())
 }
 
 fn setup(
@@ -73,7 +73,7 @@ fn setup(
     secondary_pass: Res<ImguiPass<SecondaryContextPass>>,
 ) -> Result {
     let primary_context = contexts
-        .primary_id()
+        .primary_id()?
         .ok_or("ImguiPlugin should install a primary Context before Startup")?;
     let secondary_context =
         contexts.create(ImguiContextConfig::new(&secondary_pass).with_docking(false))?;

--- a/backends/dear-imgui-bevy/examples/advanced/render_to_image.rs
+++ b/backends/dear-imgui-bevy/examples/advanced/render_to_image.rs
@@ -35,7 +35,7 @@ struct RenderToImageState {
     value: f32,
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
@@ -50,12 +50,13 @@ fn main() {
     .add_plugins(ImguiPlugin::default())
     .add_systems(Startup, setup)
     .add_systems(Update, (close_on_escape, resize_render_target));
-    let primary_pass = app.imgui_primary_pass();
-    let offscreen_pass = app.declare_imgui_pass::<OffscreenContextPass>();
-    app.insert_resource(offscreen_pass.clone())
-        .add_imgui_systems(&primary_pass, primary_pass.system(primary_ui))
-        .add_imgui_systems(&offscreen_pass, offscreen_pass.system(offscreen_ui))
-        .run();
+    let primary_pass = app.imgui_primary_pass()?;
+    let offscreen_pass = app.declare_imgui_pass::<OffscreenContextPass>()?;
+    app.insert_resource(offscreen_pass.clone());
+    app.add_imgui_systems(&primary_pass, primary_pass.system(primary_ui))?;
+    app.add_imgui_systems(&offscreen_pass, offscreen_pass.system(offscreen_ui))?;
+    app.run();
+    Ok(())
 }
 
 fn setup(

--- a/backends/dear-imgui-bevy/examples/app/app_integration.rs
+++ b/backends/dear-imgui-bevy/examples/app/app_integration.rs
@@ -63,8 +63,11 @@ impl Plugin for DebugUiPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ImguiPlugin::default())
             .add_systems(Startup, setup_imgui);
-        let primary_pass = app.imgui_primary_pass();
-        app.add_imgui_systems(&primary_pass, primary_pass.system(tools_ui));
+        let primary_pass = app
+            .imgui_primary_pass()
+            .expect("ImguiPlugin should install the primary pass before UI registration");
+        app.add_imgui_systems(&primary_pass, primary_pass.system(tools_ui))
+            .expect("the primary pass should accept its bound UI system");
     }
 }
 

--- a/backends/dear-imgui-bevy/examples/basic/custom_font.rs
+++ b/backends/dear-imgui-bevy/examples/basic/custom_font.rs
@@ -18,7 +18,7 @@ struct CustomFonts {
     roboto_medium: Option<FontId>,
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
@@ -30,13 +30,13 @@ fn main() {
         }),
         ..Default::default()
     }));
-    app.try_install_imgui(ImguiPlugin::default())
-        .expect("the custom-font example configuration is valid");
+    app.try_install_imgui(ImguiPlugin::default())?;
     app.insert_non_send(CustomFonts::default())
         .add_systems(Startup, (setup_scene, configure_fonts));
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(custom_font_ui))
-        .run();
+    let primary_pass = app.imgui_primary_pass()?;
+    app.add_imgui_systems(&primary_pass, primary_pass.system(custom_font_ui))?;
+    app.run();
+    Ok(())
 }
 
 fn setup_scene(mut commands: Commands) {
@@ -48,7 +48,7 @@ fn configure_fonts(
     mut fonts: NonSendMut<CustomFonts>,
 ) -> Result {
     let primary = contexts
-        .primary_id()
+        .primary_id()?
         .ok_or("ImguiPlugin should install a primary Context before Startup")?;
 
     let roboto = StbTrueTypeFontData::from_slice(ROBOTO_MEDIUM)?;

--- a/backends/dear-imgui-bevy/examples/basic/simple.rs
+++ b/backends/dear-imgui-bevy/examples/basic/simple.rs
@@ -17,7 +17,7 @@ struct SimpleUiState {
     show_demo_window: bool,
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
@@ -33,9 +33,10 @@ fn main() {
     .init_resource::<SimpleUiState>()
     .add_systems(Startup, setup)
     .add_systems(Update, close_on_escape);
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(simple_ui))
-        .run();
+    let primary_pass = app.imgui_primary_pass()?;
+    app.add_imgui_systems(&primary_pass, primary_pass.system(simple_ui))?;
+    app.run();
+    Ok(())
 }
 
 fn setup(mut commands: Commands) {

--- a/backends/dear-imgui-bevy/examples/ecosystem/bevy_plot_controls.rs
+++ b/backends/dear-imgui-bevy/examples/ecosystem/bevy_plot_controls.rs
@@ -58,7 +58,7 @@ struct PlotDemoContexts {
     plot: dear_implot::PlotContext,
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
@@ -74,11 +74,12 @@ fn main() {
     .init_resource::<PlotDemoState>()
     .add_systems(Startup, setup_scene)
     .add_systems(Update, (close_on_escape, animate_marker));
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(plot_demo_ui));
+    let primary_pass = app.imgui_primary_pass()?;
+    app.add_imgui_systems(&primary_pass, primary_pass.system(plot_demo_ui))?;
 
     install_plot_context(&mut app);
     app.run();
+    Ok(())
 }
 
 fn setup_scene(mut commands: Commands) {
@@ -102,6 +103,7 @@ fn install_plot_context(app: &mut App) {
             .expect("ImguiPlugin should install ImguiContexts before examples create extensions");
         let primary_id = registry
             .primary_id()
+            .expect("ImguiContexts must remain active during plugin setup")
             .expect("ImguiPlugin should install a primary Context");
         registry
             .configure(primary_id, |context| PlotDemoContexts {

--- a/backends/dear-imgui-bevy/examples/ecosystem/ecosystem.rs
+++ b/backends/dear-imgui-bevy/examples/ecosystem/ecosystem.rs
@@ -65,7 +65,7 @@ impl Default for EcosystemWindowKeys {
     }
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
@@ -82,10 +82,11 @@ fn main() {
     .init_resource::<EcosystemWindowKeys>()
     .add_systems(Startup, setup_scene)
     .add_systems(Update, close_on_escape);
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(ecosystem_ui));
+    let primary_pass = app.imgui_primary_pass()?;
+    app.add_imgui_systems(&primary_pass, primary_pass.system(ecosystem_ui))?;
     install_ecosystem_contexts(&mut app);
     app.run();
+    Ok(())
 }
 
 fn setup_scene(mut commands: Commands) {
@@ -106,6 +107,7 @@ fn install_ecosystem_contexts(app: &mut App) {
             .expect("ImguiPlugin should install ImguiContexts before examples create extensions");
         let primary_id = registry
             .primary_id()
+            .expect("ImguiContexts must remain active during plugin setup")
             .expect("ImguiPlugin should install a primary Context");
         registry
             .configure(primary_id, |context| {

--- a/backends/dear-imgui-bevy/examples/game_engine/game_engine.rs
+++ b/backends/dear-imgui-bevy/examples/game_engine/game_engine.rs
@@ -70,7 +70,7 @@ impl Default for EditorWindowKeys {
     }
 }
 
-fn main() {
+fn main() -> Result {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
@@ -91,9 +91,10 @@ fn main() {
     .init_resource::<EditorWindowKeys>()
     .add_systems(Startup, setup)
     .add_systems(Update, (close_on_escape, animate_scene));
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(editor_ui))
-        .run();
+    let primary_pass = app.imgui_primary_pass()?;
+    app.add_imgui_systems(&primary_pass, primary_pass.system(editor_ui))?;
+    app.run();
+    Ok(())
 }
 
 fn setup(

--- a/backends/dear-imgui-bevy/src/context/driver.rs
+++ b/backends/dear-imgui-bevy/src/context/driver.rs
@@ -13,7 +13,7 @@ use super::ImguiFrameMailbox;
 use super::platform;
 use super::{ImguiActiveRendererContextError, ImguiContextError, ImguiContexts};
 #[cfg(feature = "render")]
-use crate::input::{ImguiContextInputMetrics, ImguiInputFrameMetrics};
+use crate::input::{ImguiFrameInputSlot, ImguiInputFrameMetrics};
 
 pub(crate) fn install_context_lifecycle(app: &mut App) {
     #[cfg(feature = "render")]
@@ -60,80 +60,86 @@ pub(crate) fn drive_imgui_contexts(world: &mut World) {
         .map(ImguiContexts::drive_order)
         .unwrap_or_default();
     #[cfg(feature = "render")]
-    let routed_input_metrics = world
-        .get_resource::<ImguiContextInputMetrics>()
-        .cloned()
-        .unwrap_or_default();
+    let frame_input = world
+        .get_resource_mut::<ImguiFrameInputSlot>()
+        .and_then(|mut slot| slot.take());
     #[cfg(feature = "render")]
-    let render_route_epoch = world
-        .get_resource::<crate::route::ImguiResolvedRoutes>()
-        .map(crate::route::ImguiResolvedRoutes::render_epoch)
-        .unwrap_or_default();
-    #[cfg(feature = "render")]
-    if routed_input_metrics.epoch() != render_route_epoch.epoch() {
-        return;
-    }
+    let render_route_epoch = frame_input
+        .as_ref()
+        .map(|input| input.render_routes().clone());
     #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
     {
         let native_viewport_contexts = world
             .get_non_send::<ImguiContexts>()
             .map(ImguiContexts::native_viewport_context_ids)
             .unwrap_or_default();
-        world
-            .resource_mut::<crate::ImguiNativeViewportSupport>()
-            .begin_frame(native_viewport_contexts);
+        if frame_input.is_some() {
+            world
+                .resource_mut::<crate::ImguiNativeViewportSupport>()
+                .begin_frame(native_viewport_contexts);
+        }
     }
     let primary_id = world
         .get_non_send::<ImguiContexts>()
-        .and_then(ImguiContexts::primary_id);
+        .and_then(|contexts| contexts.primary_id().ok().flatten());
     let delta_time = frame_delta_time(world);
     let primary_metrics = primary_frame_metrics(world);
     #[cfg(feature = "render")]
     let (routed_render_metrics, routed_platform_hosts) = {
         let metrics = render_route_epoch
-            .render_routes()
-            .iter()
-            .filter(|route| {
-                route
-                    .host_window()
-                    .is_none_or(|host_window| world.get::<Window>(host_window).is_some())
-            })
-            .map(|route| {
-                let framebuffer_scale = finite_framebuffer_scale([
-                    route.target_info().scale_factor,
-                    route.target_info().scale_factor,
-                ]);
-                let physical_size = route.physical_output_size();
-                (
-                    route.context_id(),
-                    RoutedFrameMetrics {
-                        display_size: finite_display_size([
-                            physical_size.x as f32 / framebuffer_scale[0],
-                            physical_size.y as f32 / framebuffer_scale[1],
-                        ]),
-                        framebuffer_scale,
-                    },
-                )
-            })
-            .collect::<HashMap<_, _>>();
+            .as_ref()
+            .map_or_else(HashMap::new, |epoch| {
+                epoch
+                    .render_routes()
+                    .iter()
+                    .filter(|route| {
+                        route
+                            .host_window()
+                            .is_none_or(|host_window| world.get::<Window>(host_window).is_some())
+                    })
+                    .map(|route| {
+                        let framebuffer_scale = finite_framebuffer_scale([
+                            route.target_info().scale_factor,
+                            route.target_info().scale_factor,
+                        ]);
+                        let physical_size = route.physical_output_size();
+                        (
+                            route.context_id(),
+                            RoutedFrameMetrics {
+                                display_size: finite_display_size([
+                                    physical_size.x as f32 / framebuffer_scale[0],
+                                    physical_size.y as f32 / framebuffer_scale[1],
+                                ]),
+                                framebuffer_scale,
+                            },
+                        )
+                    })
+                    .collect()
+            });
         let hosts = render_route_epoch
-            .render_routes()
-            .iter()
-            .filter(|route| {
-                route
-                    .host_window()
-                    .is_none_or(|host_window| world.get::<Window>(host_window).is_some())
-            })
-            .filter_map(|route| {
-                route
-                    .host_window()
-                    .map(|host_window| (route.context_id(), host_window))
-            })
-            .collect::<HashMap<_, _>>();
+            .as_ref()
+            .map_or_else(HashMap::new, |epoch| {
+                epoch
+                    .render_routes()
+                    .iter()
+                    .filter(|route| {
+                        route
+                            .host_window()
+                            .is_none_or(|host_window| world.get::<Window>(host_window).is_some())
+                    })
+                    .filter_map(|route| {
+                        route
+                            .host_window()
+                            .map(|host_window| (route.context_id(), host_window))
+                    })
+                    .collect()
+            });
         (metrics, hosts)
     };
     #[cfg(feature = "render")]
-    platform::begin_platform_feedback(world);
+    if frame_input.is_some() {
+        platform::begin_platform_feedback(world);
+    }
 
     for context_id in order {
         let is_primary = Some(context_id) == primary_id;
@@ -168,8 +174,14 @@ pub(crate) fn drive_imgui_contexts(world: &mut World) {
             continue;
         }
         #[cfg(feature = "render")]
+        let Some(frame_input) = frame_input.as_ref() else {
+            poll_context_completions_or_quarantine(world, context_id);
+            clear_context_output(world, context_id);
+            continue;
+        };
+        #[cfg(feature = "render")]
         let has_routed_metrics = routed_render_metrics.contains_key(&context_id)
-            || routed_input_metrics
+            || frame_input
                 .get(context_id)
                 .is_some_and(|metrics| world.get::<Window>(metrics.host_window).is_some());
         #[cfg(not(feature = "render"))]
@@ -194,7 +206,7 @@ pub(crate) fn drive_imgui_contexts(world: &mut World) {
             .then_some(primary_metrics.as_ref())
             .flatten();
         #[cfg(feature = "render")]
-        let routed_input_metrics_for_context = routed_input_metrics
+        let routed_input_metrics_for_context = frame_input
             .get(context_id)
             .filter(|metrics| world.get::<Window>(metrics.host_window).is_some());
         #[cfg(feature = "render")]
@@ -208,6 +220,10 @@ pub(crate) fn drive_imgui_contexts(world: &mut World) {
             .copied()
             .or_else(|| routed_input_metrics_for_context.map(|metrics| metrics.host_window))
             .or_else(|| primary_metrics_for_context.map(|metrics| metrics.host_window));
+        #[cfg(feature = "render")]
+        let platform_feedback_host = frame_input
+            .platform_feedback_host(context_id)
+            .filter(|host_window| world.get::<Window>(*host_window).is_some());
         #[cfg(not(feature = "render"))]
         let platform_host = primary_metrics_for_context.map(|metrics| metrics.host_window);
         #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
@@ -330,10 +346,16 @@ pub(crate) fn drive_imgui_contexts(world: &mut World) {
                         world,
                         context_id,
                         platform_host,
+                        platform_feedback_host.is_some(),
                         context_raw,
                     );
                     #[cfg(feature = "render")]
-                    platform::sync_context_platform_feedback(world, context_id, platform_host, ui);
+                    platform::sync_context_platform_feedback(
+                        world,
+                        context_id,
+                        platform_feedback_host,
+                        ui,
+                    );
                     #[cfg(not(feature = "render"))]
                     if is_primary {
                         platform::sync_context_platform_feedback(
@@ -386,7 +408,10 @@ pub(crate) fn drive_imgui_contexts(world: &mut World) {
                         frame_index,
                         config.multi_viewport(),
                         #[cfg(feature = "render")]
-                        render_route_epoch.clone(),
+                        render_route_epoch
+                            .as_ref()
+                            .expect("frame input must contain a render route epoch")
+                            .clone(),
                         output,
                     );
                 }));
@@ -440,7 +465,9 @@ pub(crate) fn drive_imgui_contexts(world: &mut World) {
         }
     }
     #[cfg(feature = "render")]
-    platform::finish_platform_feedback(world);
+    if frame_input.is_some() {
+        platform::finish_platform_feedback(world);
+    }
 }
 
 #[cfg(feature = "render")]

--- a/backends/dear-imgui-bevy/src/context/lifecycle.rs
+++ b/backends/dear-imgui-bevy/src/context/lifecycle.rs
@@ -8,19 +8,30 @@ use bevy_ecs::resource::Resource;
 /// App-scoped lifecycle shared by every pass handle and Context registry created for one backend.
 #[derive(Clone, Default, Resource)]
 pub(crate) struct ImguiAppLifecycle {
-    registry_claimed: Arc<AtomicBool>,
+    context_registry_claimed: Arc<AtomicBool>,
+    pass_registry_claimed: Arc<AtomicBool>,
     terminal: Arc<AtomicBool>,
 }
 
 impl ImguiAppLifecycle {
-    pub(crate) fn try_claim_registry(&self) -> bool {
-        self.registry_claimed
+    pub(crate) fn try_claim_context_registry(&self) -> bool {
+        self.context_registry_claimed
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
     }
 
-    pub(crate) fn registry_claimed(&self) -> bool {
-        self.registry_claimed.load(Ordering::Acquire)
+    pub(crate) fn context_registry_claimed(&self) -> bool {
+        self.context_registry_claimed.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn try_claim_pass_registry(&self) -> bool {
+        self.pass_registry_claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    pub(crate) fn pass_registry_claimed(&self) -> bool {
+        self.pass_registry_claimed.load(Ordering::Acquire)
     }
 
     pub(crate) fn is_terminal(&self) -> bool {

--- a/backends/dear-imgui-bevy/src/context/mod.rs
+++ b/backends/dear-imgui-bevy/src/context/mod.rs
@@ -21,9 +21,10 @@ pub(crate) use driver::{drive_imgui_contexts, install_context_lifecycle};
 #[cfg(feature = "render")]
 pub(crate) use mailbox::{ImguiFrameMailbox, PendingFrame};
 pub(crate) use owner::ContextOwner;
-pub use pass::{ImguiFrame, ImguiPass, ImguiPrimaryPass, ImguiSystem};
-#[doc(hidden)]
-pub use pass::{ImguiFrameAdapter, ImguiSystemMarker};
+pub use pass::{
+    ImguiFrame, ImguiPass, ImguiPassError, ImguiPrimaryPass, ImguiSystemConfigs,
+    IntoImguiSystemConfigs,
+};
 pub(crate) use pass::{PassIdentity, run_pass};
 #[cfg(feature = "render")]
 pub(crate) use plugin::ImguiBackendRuntime;

--- a/backends/dear-imgui-bevy/src/context/pass.rs
+++ b/backends/dear-imgui-bevy/src/context/pass.rs
@@ -1,5 +1,5 @@
 use std::any::{TypeId, type_name};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
 use std::panic::{self, AssertUnwindSafe};
@@ -11,8 +11,8 @@ use std::thread::{self, ThreadId};
 use bevy_app::App;
 use bevy_ecs::resource::Resource;
 use bevy_ecs::schedule::{
-    InternedSystemSet, IntoScheduleConfigs, NodeId, Schedule, ScheduleConfigs, ScheduleLabel,
-    SingleThreadedExecutor, SystemSet,
+    InternedSystemSet, IntoScheduleConfigs, IntoSystemSet, Schedule, ScheduleConfigs,
+    ScheduleLabel, SingleThreadedExecutor, SystemCondition, SystemSet,
 };
 use bevy_ecs::system::{
     Adapt, AdapterSystem, FunctionSystem, IntoSystem, NonSendMarker, PipeSystem, RunSystemError,
@@ -27,6 +27,87 @@ static NEXT_REGISTRY_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Type marker for the primary Dear ImGui pass.
 pub enum ImguiPrimaryPass {}
+
+/// Failure to create, query, or configure a private Dear ImGui pass.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ImguiPassError {
+    /// Explicit App shutdown permanently closed the integration.
+    AppTerminated,
+    /// The App previously owned a pass registry that application code removed.
+    PassRegistryMissing,
+    /// Process-wide pass registry identities were exhausted.
+    RegistryIdExhausted,
+    /// This App exhausted its private pass identities.
+    PassIdExhausted,
+    /// The pass handle belongs to another Bevy App.
+    ForeignApp {
+        /// Rust brand of the rejected handle.
+        pass: &'static str,
+    },
+    /// The handle's Rust type no longer matches its private runtime identity.
+    InvalidBrand {
+        /// Rust brand of the rejected handle.
+        pass: &'static str,
+    },
+    /// The pass identity is not registered in this App.
+    UnknownPass {
+        /// Rust brand of the rejected handle.
+        pass: &'static str,
+    },
+    /// A bound system belongs to another runtime pass of the same Rust brand.
+    SystemPassMismatch {
+        /// Rust brand shared by both runtime passes.
+        pass: &'static str,
+        /// App-local identity of the target runtime pass.
+        expected_runtime: u64,
+        /// App-local identity carried by the rejected system configuration.
+        actual_runtime: u64,
+    },
+}
+
+impl fmt::Display for ImguiPassError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AppTerminated => formatter
+                .write_str("the Dear ImGui integration is terminal after explicit App shutdown"),
+            Self::PassRegistryMissing => formatter.write_str(
+                "the App's private Dear ImGui pass registry was removed after it was claimed",
+            ),
+            Self::RegistryIdExhausted => {
+                formatter.write_str("Dear ImGui pass registry identities are exhausted")
+            }
+            Self::PassIdExhausted => {
+                formatter.write_str("Dear ImGui pass identities are exhausted for this App")
+            }
+            Self::ForeignApp { pass } => {
+                write!(formatter, "Dear ImGui pass '{pass}' belongs to another App")
+            }
+            Self::InvalidBrand { pass } => {
+                write!(
+                    formatter,
+                    "Dear ImGui pass '{pass}' has an invalid Rust brand"
+                )
+            }
+            Self::UnknownPass { pass } => {
+                write!(
+                    formatter,
+                    "Dear ImGui pass '{pass}' is not registered in this App"
+                )
+            }
+            Self::SystemPassMismatch {
+                pass,
+                expected_runtime,
+                actual_runtime,
+            } => write!(
+                formatter,
+                "Dear ImGui system bound to runtime pass {actual_runtime} ('{pass}') cannot be registered in runtime pass {expected_runtime}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ImguiPassError {}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct PassKey(u64);
@@ -78,23 +159,38 @@ impl<P: 'static> ImguiPass<P> {
         self.identity
     }
 
-    /// Bind a frame-input system to this pass so Bevy can configure it like any other system.
+    /// Bind a frame-input system to this exact private pass.
     ///
-    /// Pass the returned system to [`crate::ImguiAppExt::add_imgui_systems`]. Tuples and every
-    /// standard [`IntoScheduleConfigs`] modifier remain available after binding.
+    /// Pass the returned configuration to [`crate::ImguiAppExt::add_imgui_systems`]. The sealed
+    /// [`IntoImguiSystemConfigs`] trait provides the usual Bevy ordering, set, condition, and
+    /// chaining modifiers without allowing the adapted system to enter an ordinary Bevy schedule.
     #[must_use]
-    pub fn system<S>(&self, system: S) -> ImguiSystem<P, S> {
-        ImguiSystem {
-            pass: self.identity,
-            active: Arc::clone(&self.active),
+    pub fn system<S, M>(&self, system: S) -> ImguiSystemConfigs<P>
+    where
+        S: IntoSystem<ImguiFrame<'static, P>, (), M> + 'static,
+        M: 'static,
+    {
+        let system = IntoSystem::into_system(system);
+        let name = system.name();
+        let adapted = AdapterSystem::new(
+            ImguiFrameAdapter {
+                pass: self.identity,
+                active: Arc::clone(&self.active),
+                _brand: PhantomData,
+            },
             system,
+            name.clone(),
+        );
+        let main_thread: MainThreadGateSystem =
+            IntoSystem::into_system(require_main_thread as fn(NonSendMarker));
+        let configs = PipeSystem::new(main_thread, adapted, name).into_configs();
+        ImguiSystemConfigs {
+            identities: vec![self.identity],
+            configs,
             _brand: PhantomData,
         }
     }
 }
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, SystemSet)]
-struct ImguiPassBindingSet(PassIdentity);
 
 impl<P: 'static> Clone for ImguiPass<P> {
     fn clone(&self) -> Self {
@@ -115,50 +211,184 @@ impl<P: 'static> fmt::Debug for ImguiPass<P> {
     }
 }
 
-/// A Dear ImGui frame-input system bound to one private pass.
+/// One or more Dear ImGui systems sealed to a private pass.
 ///
-/// This implements [`IntoScheduleConfigs`] with unit input, so callers can use Bevy's normal
-/// system configuration API before registering it with
-/// [`crate::ImguiAppExt::add_imgui_systems`].
-pub struct ImguiSystem<P: 'static, S> {
-    pass: PassIdentity,
-    active: Arc<ActiveFrameControl>,
-    system: S,
+/// This type deliberately does not implement Bevy's [`IntoScheduleConfigs`]. It can only be
+/// consumed by [`crate::ImguiAppExt::add_imgui_systems`], which validates its exact App and pass
+/// identity before modifying the private runner.
+///
+/// ```compile_fail
+/// use bevy_app::App;
+/// use dear_imgui_bevy::ImguiAppExt;
+///
+/// fn ordinary_bevy_system() {}
+///
+/// let mut app = App::new();
+/// let pass = app.imgui_primary_pass().unwrap();
+/// app.add_imgui_systems(&pass, ordinary_bevy_system);
+/// ```
+pub struct ImguiSystemConfigs<P: 'static> {
+    identities: Vec<PassIdentity>,
+    configs: ScheduleConfigs<ScheduleSystem>,
     _brand: PhantomData<fn() -> P>,
 }
 
 type MainThreadGateSystem = FunctionSystem<fn(NonSendMarker), (), (), fn(NonSendMarker)>;
 
-#[doc(hidden)]
-pub struct ImguiSystemMarker<P, M>(PhantomData<fn() -> (P, M)>);
-
-impl<P, S, M> IntoScheduleConfigs<ScheduleSystem, ImguiSystemMarker<P, M>> for ImguiSystem<P, S>
-where
-    P: 'static,
-    S: IntoSystem<ImguiFrame<'static, P>, (), M> + 'static,
-    M: 'static,
-{
-    fn into_configs(self) -> ScheduleConfigs<ScheduleSystem> {
-        let system = IntoSystem::into_system(self.system);
-        let name = system.name();
-        let adapted = AdapterSystem::new(
-            ImguiFrameAdapter {
-                pass: self.pass,
-                active: self.active,
-                _brand: PhantomData,
-            },
-            system,
-            name.clone(),
-        );
-        let main_thread: MainThreadGateSystem =
-            IntoSystem::into_system(require_main_thread as fn(NonSendMarker));
-        PipeSystem::new(main_thread, adapted, name).in_set(ImguiPassBindingSet(self.pass))
+impl<P: 'static> ImguiSystemConfigs<P> {
+    fn map_configs(
+        mut self,
+        map: impl FnOnce(ScheduleConfigs<ScheduleSystem>) -> ScheduleConfigs<ScheduleSystem>,
+    ) -> Self {
+        self.configs = map(self.configs);
+        self
     }
 }
 
+mod sealed {
+    pub trait Sealed<P: 'static> {}
+}
+
+/// Convert pass-bound systems into one private-runner configuration.
+///
+/// The trait is sealed so applications cannot forge pass ownership metadata. It intentionally
+/// mirrors the common Bevy configuration modifiers while keeping the resulting system out of
+/// public schedules.
+pub trait IntoImguiSystemConfigs<P: 'static>: sealed::Sealed<P> + Sized {
+    #[doc(hidden)]
+    fn into_imgui_system_configs(self) -> ImguiSystemConfigs<P>;
+
+    /// Add these systems to `set` inside the private pass runner.
+    fn in_set(self, set: impl SystemSet) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.in_set(set))
+    }
+
+    /// Run these systems before every system in `set`.
+    fn before<M>(self, set: impl IntoSystemSet<M>) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.before(set))
+    }
+
+    /// Run these systems after every system in `set`.
+    fn after<M>(self, set: impl IntoSystemSet<M>) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.after(set))
+    }
+
+    /// Run before `set` without inserting deferred-command barriers.
+    fn before_ignore_deferred<M>(self, set: impl IntoSystemSet<M>) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.before_ignore_deferred(set))
+    }
+
+    /// Run after `set` without inserting deferred-command barriers.
+    fn after_ignore_deferred<M>(self, set: impl IntoSystemSet<M>) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.after_ignore_deferred(set))
+    }
+
+    /// Evaluate a cloned condition independently for every contained system.
+    fn distributive_run_if<M>(
+        self,
+        condition: impl SystemCondition<M> + Clone,
+    ) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.distributive_run_if(condition))
+    }
+
+    /// Evaluate one condition for this complete configuration.
+    fn run_if<M>(self, condition: impl SystemCondition<M>) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.run_if(condition))
+    }
+
+    /// Suppress ambiguity diagnostics against `set`.
+    fn ambiguous_with<M>(self, set: impl IntoSystemSet<M>) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(|configs| configs.ambiguous_with(set))
+    }
+
+    /// Suppress every ambiguity diagnostic for these systems.
+    fn ambiguous_with_all(self) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(ScheduleConfigs::ambiguous_with_all)
+    }
+
+    /// Chain each successive configuration with normal deferred-command barriers.
+    fn chain(self) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(ScheduleConfigs::chain)
+    }
+
+    /// Chain each successive configuration without deferred-command barriers.
+    fn chain_ignore_deferred(self) -> ImguiSystemConfigs<P> {
+        self.into_imgui_system_configs()
+            .map_configs(ScheduleConfigs::chain_ignore_deferred)
+    }
+}
+
+impl<P: 'static> sealed::Sealed<P> for ImguiSystemConfigs<P> {}
+
+impl<P: 'static> IntoImguiSystemConfigs<P> for ImguiSystemConfigs<P> {
+    fn into_imgui_system_configs(self) -> ImguiSystemConfigs<P> {
+        self
+    }
+}
+
+macro_rules! impl_imgui_system_config_tuple {
+    ($($name:ident),+ $(,)?) => {
+        impl<P: 'static, $($name),+> sealed::Sealed<P> for ($($name,)+)
+        where
+            $($name: IntoImguiSystemConfigs<P>,)+
+        {}
+
+        impl<P: 'static, $($name),+> IntoImguiSystemConfigs<P> for ($($name,)+)
+        where
+            $($name: IntoImguiSystemConfigs<P>,)+
+        {
+            #[allow(non_snake_case)]
+            fn into_imgui_system_configs(self) -> ImguiSystemConfigs<P> {
+                let ($($name,)+) = self;
+                let mut identities = Vec::new();
+                $(
+                    let config = $name.into_imgui_system_configs();
+                    identities.extend(config.identities.iter().copied());
+                    let $name = config.configs;
+                )+
+                ImguiSystemConfigs {
+                    identities,
+                    configs: ($($name,)+).into_configs(),
+                    _brand: PhantomData,
+                }
+            }
+        }
+    };
+}
+
+impl_imgui_system_config_tuple!(A);
+impl_imgui_system_config_tuple!(A, B);
+impl_imgui_system_config_tuple!(A, B, C);
+impl_imgui_system_config_tuple!(A, B, C, D);
+impl_imgui_system_config_tuple!(A, B, C, D, E);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Q);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Q, R);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Q, R, T);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Q, R, T, U);
+impl_imgui_system_config_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Q, R, T, U, V);
+
 /// Internal unit-input adapter that injects the frame owned by its private pass runner.
-#[doc(hidden)]
-pub struct ImguiFrameAdapter<P: 'static> {
+struct ImguiFrameAdapter<P: 'static> {
     pass: PassIdentity,
     active: Arc<ActiveFrameControl>,
     _brand: PhantomData<fn() -> P>,
@@ -228,8 +458,19 @@ fn require_main_thread(_marker: NonSendMarker) {}
 /// fn draw_b(_frame: ImguiFrame<'_, PassB>) {}
 ///
 /// let mut app = App::new();
-/// let pass_a = app.declare_imgui_pass::<PassA>();
+/// let pass_a = app.declare_imgui_pass::<PassA>().unwrap();
 /// app.add_imgui_systems(&pass_a, pass_a.system(draw_b));
+/// ```
+///
+/// ```compile_fail
+/// use bevy_app::{App, Update};
+/// use dear_imgui_bevy::{ImguiAppExt, ImguiFrame};
+///
+/// fn draw(_frame: ImguiFrame<'_>) {}
+///
+/// let mut app = App::new();
+/// let pass = app.imgui_primary_pass().unwrap();
+/// app.add_systems(Update, pass.system(draw));
 /// ```
 pub struct ImguiFrame<'frame, P: 'static = ImguiPrimaryPass> {
     ui: &'frame Ui,
@@ -388,39 +629,8 @@ impl PassRunner {
         Self { schedule }
     }
 
-    fn add_systems<M>(
-        &mut self,
-        pass: PassIdentity,
-        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
-    ) {
-        let existing_systems = self
-            .schedule
-            .graph()
-            .systems
-            .iter()
-            .map(|(system_key, _, _)| system_key)
-            .collect::<HashSet<_>>();
+    fn add_systems(&mut self, systems: ScheduleConfigs<ScheduleSystem>) {
         self.schedule.add_systems(systems);
-
-        let graph = self.schedule.graph();
-        let binding = ImguiPassBindingSet(pass).intern();
-        let binding_node = graph.system_sets.get_key(binding).map(NodeId::Set);
-        for (system_key, system, _) in graph
-            .systems
-            .iter()
-            .filter(|(system_key, _, _)| !existing_systems.contains(system_key))
-        {
-            assert!(
-                binding_node.is_some_and(|binding_node| {
-                    graph
-                        .hierarchy()
-                        .graph()
-                        .contains_edge(binding_node, NodeId::System(system_key))
-                }),
-                "Dear ImGui system '{}' is not bound to this exact pass",
-                system.name()
-            );
-        }
     }
 
     fn configure_sets<M>(&mut self, sets: impl IntoScheduleConfigs<InternedSystemSet, M>) {
@@ -439,13 +649,12 @@ pub(crate) struct ImguiPassRegistry {
 }
 
 impl ImguiPassRegistry {
-    fn new(lifecycle: ImguiAppLifecycle) -> Self {
-        let registry_id = NEXT_REGISTRY_ID.fetch_add(1, Ordering::Relaxed);
-        assert_ne!(
-            registry_id,
-            u64::MAX,
-            "Dear ImGui pass registry IDs exhausted"
-        );
+    fn new(lifecycle: ImguiAppLifecycle) -> Result<Self, ImguiPassError> {
+        let registry_id = NEXT_REGISTRY_ID
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .map_err(|_| ImguiPassError::RegistryIdExhausted)?;
         let mut registry = Self {
             registry_id,
             next_key: 1,
@@ -455,21 +664,33 @@ impl ImguiPassRegistry {
             active: Arc::new(ActiveFrameControl::default()),
             lifecycle,
         };
-        registry.primary = registry.allocate::<ImguiPrimaryPass>().identity.key;
-        registry
+        registry.primary = registry.allocate::<ImguiPrimaryPass>()?.identity.key;
+        Ok(registry)
     }
 
-    fn declare<P: 'static>(&mut self) -> ImguiPass<P> {
+    fn ensure_active(&self) -> Result<(), ImguiPassError> {
+        if self.lifecycle.is_terminal() {
+            Err(ImguiPassError::AppTerminated)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn declare<P: 'static>(&mut self) -> Result<ImguiPass<P>, ImguiPassError> {
+        self.ensure_active()?;
         self.allocate::<P>()
     }
 
-    fn primary_pass(&self) -> ImguiPass<ImguiPrimaryPass> {
-        let (brand, brand_name) = self
-            .identities
-            .get(&self.primary)
-            .copied()
-            .expect("the pass registry must retain its primary pass");
-        ImguiPass::from_identity(
+    fn primary_pass(&self) -> Result<ImguiPass<ImguiPrimaryPass>, ImguiPassError> {
+        self.ensure_active()?;
+        let (brand, brand_name) =
+            self.identities
+                .get(&self.primary)
+                .copied()
+                .ok_or(ImguiPassError::UnknownPass {
+                    pass: type_name::<ImguiPrimaryPass>(),
+                })?;
+        Ok(ImguiPass::from_identity(
             PassIdentity {
                 registry_id: self.registry_id,
                 key: self.primary,
@@ -477,20 +698,20 @@ impl ImguiPassRegistry {
                 brand_name,
             },
             Arc::clone(&self.active),
-        )
+        ))
     }
 
-    fn allocate<P: 'static>(&mut self) -> ImguiPass<P> {
+    fn allocate<P: 'static>(&mut self) -> Result<ImguiPass<P>, ImguiPassError> {
         let brand = TypeId::of::<P>();
         let key = PassKey(self.next_key);
         self.next_key = self
             .next_key
             .checked_add(1)
-            .expect("Dear ImGui pass IDs exhausted");
+            .ok_or(ImguiPassError::PassIdExhausted)?;
         let brand_name = type_name::<P>();
         self.identities.insert(key, (brand, brand_name));
         self.runners.insert(key, PassRunner::new(key));
-        ImguiPass::from_identity(
+        Ok(ImguiPass::from_identity(
             PassIdentity {
                 registry_id: self.registry_id,
                 key,
@@ -498,60 +719,79 @@ impl ImguiPassRegistry {
                 brand_name,
             },
             Arc::clone(&self.active),
-        )
+        ))
     }
 
-    fn validate<P: 'static>(&self, pass: &ImguiPass<P>) {
-        assert_eq!(
-            pass.identity.registry_id, self.registry_id,
-            "Dear ImGui pass handle belongs to another App"
-        );
-        assert_eq!(
-            pass.identity.brand,
-            TypeId::of::<P>(),
-            "Dear ImGui pass handle has an invalid type brand"
-        );
-        assert_eq!(
-            self.identities.get(&pass.identity.key),
-            Some(&(pass.identity.brand, pass.identity.brand_name)),
-            "Dear ImGui pass handle is not registered in this App"
-        );
+    fn validate<P: 'static>(&self, pass: &ImguiPass<P>) -> Result<(), ImguiPassError> {
+        self.ensure_active()?;
+        if pass.identity.registry_id != self.registry_id {
+            return Err(ImguiPassError::ForeignApp {
+                pass: pass.identity.brand_name,
+            });
+        }
+        if pass.identity.brand != TypeId::of::<P>() {
+            return Err(ImguiPassError::InvalidBrand {
+                pass: pass.identity.brand_name,
+            });
+        }
+        if self.identities.get(&pass.identity.key)
+            != Some(&(pass.identity.brand, pass.identity.brand_name))
+        {
+            return Err(ImguiPassError::UnknownPass {
+                pass: pass.identity.brand_name,
+            });
+        }
+        Ok(())
     }
 
-    fn add_systems<P, M>(
+    fn add_systems<P>(
         &mut self,
         pass: &ImguiPass<P>,
-        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
-    ) where
+        systems: ImguiSystemConfigs<P>,
+    ) -> Result<(), ImguiPassError>
+    where
         P: 'static,
     {
-        assert!(
-            !self.lifecycle.is_terminal(),
-            "Dear ImGui App lifecycle is terminal"
-        );
-        self.validate(pass);
+        self.validate(pass)?;
+        for identity in &systems.identities {
+            if identity.registry_id != self.registry_id {
+                return Err(ImguiPassError::ForeignApp {
+                    pass: identity.brand_name,
+                });
+            }
+            if *identity != pass.identity {
+                return Err(ImguiPassError::SystemPassMismatch {
+                    pass: pass.identity.brand_name,
+                    expected_runtime: pass.identity.key.0,
+                    actual_runtime: identity.key.0,
+                });
+            }
+        }
         self.runners
             .get_mut(&pass.identity.key)
-            .expect("a declared Dear ImGui pass must retain its private runner")
-            .add_systems(pass.identity, systems);
+            .ok_or(ImguiPassError::UnknownPass {
+                pass: pass.identity.brand_name,
+            })?
+            .add_systems(systems.configs);
+        Ok(())
     }
 
     fn configure_sets<P, M>(
         &mut self,
         pass: &ImguiPass<P>,
         sets: impl IntoScheduleConfigs<InternedSystemSet, M>,
-    ) where
+    ) -> Result<(), ImguiPassError>
+    where
         P: 'static,
     {
-        assert!(
-            !self.lifecycle.is_terminal(),
-            "Dear ImGui App lifecycle is terminal"
-        );
-        self.validate(pass);
+        self.validate(pass)?;
         self.runners
             .get_mut(&pass.identity.key)
-            .expect("a declared Dear ImGui pass must retain its private runner")
+            .ok_or(ImguiPassError::UnknownPass {
+                pass: pass.identity.brand_name,
+            })?
             .configure_sets(sets);
+        Ok(())
     }
 
     fn take_runner(&mut self, pass: PassIdentity) -> (PassRunner, Arc<ActiveFrameControl>) {
@@ -575,62 +815,81 @@ impl ImguiPassRegistry {
     }
 }
 
-pub(crate) fn install_pass_registry(app: &mut App) {
+pub(crate) fn install_pass_registry(app: &mut App) -> Result<(), ImguiPassError> {
     if !app.world().contains_resource::<ImguiAppLifecycle>() {
         app.init_resource::<ImguiAppLifecycle>();
     }
     let lifecycle = app.world().resource::<ImguiAppLifecycle>().clone();
-    assert!(
-        !lifecycle.is_terminal(),
-        "Dear ImGui App lifecycle is terminal"
-    );
-    if app.world().get_non_send::<ImguiPassRegistry>().is_none() {
-        app.insert_non_send(ImguiPassRegistry::new(lifecycle));
+    if lifecycle.is_terminal() {
+        return Err(ImguiPassError::AppTerminated);
     }
+    if app.world().get_non_send::<ImguiPassRegistry>().is_some() {
+        return if lifecycle.pass_registry_claimed() {
+            Ok(())
+        } else {
+            Err(ImguiPassError::PassRegistryMissing)
+        };
+    }
+    if lifecycle.pass_registry_claimed() {
+        return Err(ImguiPassError::PassRegistryMissing);
+    }
+    let registry = ImguiPassRegistry::new(lifecycle.clone())?;
+    if !lifecycle.try_claim_pass_registry() {
+        return Err(ImguiPassError::PassRegistryMissing);
+    }
+    app.insert_non_send(registry);
+    Ok(())
 }
 
-pub(crate) fn declare_pass<P: 'static>(app: &mut App) -> ImguiPass<P> {
-    install_pass_registry(app);
+pub(crate) fn declare_pass<P: 'static>(app: &mut App) -> Result<ImguiPass<P>, ImguiPassError> {
+    install_pass_registry(app)?;
     app.world_mut()
         .get_non_send_mut::<ImguiPassRegistry>()
         .expect("Dear ImGui pass registry was just installed")
         .declare::<P>()
 }
 
-pub(crate) fn primary_pass(app: &mut App) -> ImguiPass<ImguiPrimaryPass> {
-    install_pass_registry(app);
+pub(crate) fn primary_pass(app: &mut App) -> Result<ImguiPass<ImguiPrimaryPass>, ImguiPassError> {
+    install_pass_registry(app)?;
     app.world()
         .get_non_send::<ImguiPassRegistry>()
         .expect("Dear ImGui pass registry was just installed")
         .primary_pass()
 }
 
-pub(crate) fn add_systems<P, M>(
+pub(crate) fn add_systems<P>(
     app: &mut App,
     pass: &ImguiPass<P>,
-    systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
-) where
+    systems: impl IntoImguiSystemConfigs<P>,
+) -> Result<(), ImguiPassError>
+where
     P: 'static,
 {
-    install_pass_registry(app);
+    let systems = systems.into_imgui_system_configs();
+    install_pass_registry(app)?;
     app.world_mut()
         .get_non_send_mut::<ImguiPassRegistry>()
         .expect("Dear ImGui pass registry was just installed")
-        .add_systems(pass, systems);
+        .add_systems(pass, systems)
 }
 
 pub(crate) fn configure_sets<P, M>(
     app: &mut App,
     pass: &ImguiPass<P>,
     sets: impl IntoScheduleConfigs<InternedSystemSet, M>,
-) where
+) -> Result<(), ImguiPassError>
+where
     P: 'static,
 {
-    install_pass_registry(app);
+    install_pass_registry(app)?;
     app.world_mut()
         .get_non_send_mut::<ImguiPassRegistry>()
         .expect("Dear ImGui pass registry was just installed")
-        .configure_sets(pass, sets);
+        .configure_sets(pass, sets)
+}
+
+pub(crate) fn remove_pass_registry(app: &mut App) {
+    drop(app.world_mut().remove_non_send::<ImguiPassRegistry>());
 }
 
 pub(crate) fn existing_registry_id(world: &World) -> Option<u64> {

--- a/backends/dear-imgui-bevy/src/context/platform.rs
+++ b/backends/dear-imgui-bevy/src/context/platform.rs
@@ -182,14 +182,12 @@ pub(super) fn sync_context_platform_feedback(
     debug_assert_eq!(ui.context_id(), context_id);
     #[cfg(feature = "render")]
     {
-        let _ = host_window;
-        let default_window = world
-            .get_resource::<crate::input::ImguiContextInputMetrics>()
-            .and_then(|metrics| metrics.get(context_id))
-            .map(|metrics| metrics.host_window);
-        let cursor_target = world
-            .get_resource::<ImguiInputState>()
-            .and_then(|state| state.platform_cursor_window_for_context(context_id, default_window));
+        let Some(host_window) = host_window else {
+            return;
+        };
+        let cursor_target = world.get_resource::<ImguiInputState>().and_then(|state| {
+            state.platform_cursor_window_for_context(context_id, Some(host_window))
+        });
         let Some(cursor_target) = cursor_target else {
             return;
         };
@@ -327,20 +325,13 @@ pub(super) fn record_context_platform_ime_feedback(
     world: &mut World,
     context_id: imgui::ContextId,
     host_window: Option<Entity>,
+    input_enabled: bool,
     context_raw: *mut imgui::sys::ImGuiContext,
 ) {
     // SAFETY: the serial driver retains the owning active Context and keeps its frame open for
     // this call. The raw pointer was captured immediately before `Context::frame()`.
     let ime_data = unsafe { &(*context_raw).PlatformImeData };
     let uses_desktop_coordinates = native_viewports_enabled_for_frame(context_raw);
-    let input_enabled = world
-        .get_resource::<crate::route::ImguiResolvedRoutes>()
-        .is_some_and(|routes| {
-            routes.input_routes().iter().any(|route| {
-                route.context_id() == context_id
-                    && !matches!(route.policy(), crate::route::ImguiInputPolicy::Disabled)
-            })
-        });
     if !input_enabled {
         return;
     }

--- a/backends/dear-imgui-bevy/src/context/plugin.rs
+++ b/backends/dear-imgui-bevy/src/context/plugin.rs
@@ -102,6 +102,12 @@ pub enum ImguiPluginInstallError {
     ContextRegistryMissing,
     /// A registry exists without the App lifecycle claim that owns it.
     ContextRegistryOwnershipMissing,
+    /// The App lifecycle still owns a private pass registry that application code removed.
+    PassRegistryMissing,
+    /// A private pass registry exists without its App lifecycle ownership claim.
+    PassRegistryOwnershipMissing,
+    /// The private pass registry could not be created or queried.
+    PassRegistry(super::ImguiPassError),
     /// The Context registry and pass registry came from different Apps.
     ForeignPassRegistry,
     /// Core Context construction failed before App mutation began.
@@ -132,6 +138,13 @@ impl fmt::Display for ImguiPluginInstallError {
             Self::ContextRegistryOwnershipMissing => formatter.write_str(
                 "ImguiContexts exists without the App lifecycle ownership claim",
             ),
+            Self::PassRegistryMissing => formatter.write_str(
+                "the private Dear ImGui pass registry was removed after App admission",
+            ),
+            Self::PassRegistryOwnershipMissing => formatter.write_str(
+                "the private Dear ImGui pass registry exists without its App lifecycle ownership claim",
+            ),
+            Self::PassRegistry(error) => error.fmt(formatter),
             Self::ForeignPassRegistry => formatter.write_str(
                 "ImguiContexts was created with pass handles from another Bevy App",
             ),
@@ -150,6 +163,7 @@ impl std::error::Error for ImguiPluginInstallError {
             Self::DriverSchedule(error) => Some(error),
             Self::ContextCreation(error) => Some(error),
             Self::ContextPreflight(error) => Some(error),
+            Self::PassRegistry(error) => Some(error),
             _ => None,
         }
     }
@@ -169,6 +183,19 @@ impl ImguiPlugin {
             .world()
             .get_resource::<super::lifecycle::ImguiAppLifecycle>()
             .cloned();
+        let pass_registry_exists = super::pass::existing_registry_id(app.world()).is_some();
+        match lifecycle.as_ref() {
+            Some(lifecycle) if pass_registry_exists && !lifecycle.pass_registry_claimed() => {
+                return Err(ImguiPluginInstallError::PassRegistryOwnershipMissing);
+            }
+            Some(lifecycle) if !pass_registry_exists && lifecycle.pass_registry_claimed() => {
+                return Err(ImguiPluginInstallError::PassRegistryMissing);
+            }
+            None if pass_registry_exists => {
+                return Err(ImguiPluginInstallError::PassRegistryOwnershipMissing);
+            }
+            _ => {}
+        }
         if lifecycle
             .as_ref()
             .is_some_and(super::lifecycle::ImguiAppLifecycle::is_terminal)
@@ -195,11 +222,11 @@ impl ImguiPlugin {
             let lifecycle = lifecycle
                 .as_ref()
                 .ok_or(ImguiPluginInstallError::ContextRegistryOwnershipMissing)?;
-            if !lifecycle.registry_claimed() {
+            if !lifecycle.context_registry_claimed() {
                 return Err(ImguiPluginInstallError::ContextRegistryOwnershipMissing);
             }
             let pass_registry_id = super::pass::existing_registry_id(app.world())
-                .ok_or(ImguiPluginInstallError::ForeignPassRegistry)?;
+                .ok_or(ImguiPluginInstallError::PassRegistryMissing)?;
             if app
                 .world()
                 .get_non_send::<ImguiContexts>()
@@ -235,7 +262,7 @@ impl ImguiPlugin {
         } else {
             if lifecycle
                 .as_ref()
-                .is_some_and(super::lifecycle::ImguiAppLifecycle::registry_claimed)
+                .is_some_and(super::lifecycle::ImguiAppLifecycle::context_registry_claimed)
             {
                 return Err(ImguiPluginInstallError::ContextRegistryMissing);
             }
@@ -251,10 +278,14 @@ impl ImguiPlugin {
         })
     }
 
-    fn commit_installation(&self, app: &mut App, prepared: PreparedImguiInstallation) {
-        super::pass::install_pass_registry(app);
+    fn commit_installation(
+        &self,
+        app: &mut App,
+        prepared: PreparedImguiInstallation,
+    ) -> Result<(), super::ImguiPassError> {
+        super::pass::install_pass_registry(app)?;
         if let Some(primary) = prepared.primary {
-            let primary_pass = super::pass::primary_pass(app);
+            let primary_pass = super::pass::primary_pass(app)?;
             let lifecycle = super::pass::lifecycle(app.world());
             app.insert_non_send(ImguiContexts::with_primary(
                 primary,
@@ -282,6 +313,7 @@ impl ImguiPlugin {
         viewport::install_viewport_bridge(app);
         refresh_backend_contract(app, self.config.clone(), render_integration_installed)
             .expect("installation preflight must make backend attachment infallible");
+        Ok(())
     }
 }
 
@@ -294,7 +326,8 @@ impl Plugin for ImguiPlugin {
         let prepared = self
             .prepare_installation(app)
             .unwrap_or_else(|error| panic!("ImguiPlugin installation failed: {error}"));
-        self.commit_installation(app, prepared);
+        self.commit_installation(app, prepared)
+            .unwrap_or_else(|error| panic!("ImguiPlugin installation failed: {error}"));
     }
 
     fn finish(&self, _app: &mut App) {
@@ -331,7 +364,9 @@ pub(crate) fn try_install_imgui(
         return Err(ImguiPluginInstallError::PluginLifecycleClosed);
     }
     let prepared = plugin.prepare_installation(app)?;
-    plugin.commit_installation(app, prepared);
+    plugin
+        .commit_installation(app, prepared)
+        .map_err(ImguiPluginInstallError::PassRegistry)?;
     app.add_plugins(plugin.already_installed());
     Ok(app)
 }

--- a/backends/dear-imgui-bevy/src/context/registry.rs
+++ b/backends/dear-imgui-bevy/src/context/registry.rs
@@ -8,7 +8,7 @@ use dear_imgui_rs::{Context, ContextId, SuspendedContext};
 use super::lifecycle::ImguiAppLifecycle;
 use super::{
     ContextOwner, ImguiContextRemovalPendingReason, ImguiContextRetirementSink, ImguiPass,
-    ImguiPrimaryPass, PassIdentity,
+    ImguiPassError, ImguiPrimaryPass, PassIdentity,
 };
 
 /// Generation-qualified identity of one managed Context retirement request.
@@ -161,6 +161,8 @@ impl ImguiContextConfig {
 pub enum ImguiContextError {
     /// Explicit shutdown committed this App's terminal Dear ImGui lifecycle.
     AppTerminated,
+    /// The App's private pass registry could not serve Context admission.
+    PassRegistry(ImguiPassError),
     /// The App already owns a Context registry.
     ContextRegistryAlreadyInstalled,
     /// No registered Context has this process identity.
@@ -271,6 +273,7 @@ impl fmt::Display for ImguiContextError {
         match self {
             Self::AppTerminated => formatter
                 .write_str("the Dear ImGui integration is terminal after explicit App shutdown"),
+            Self::PassRegistry(error) => error.fmt(formatter),
             Self::ContextRegistryAlreadyInstalled => {
                 formatter.write_str("the Bevy App already owns a Dear ImGui Context registry")
             }
@@ -396,6 +399,7 @@ impl std::error::Error for ImguiContextError {
             Self::ScopedActivation { source, .. } => Some(source),
             Self::FontAtlasMode { source, .. } => Some(source),
             Self::ContextCreation(error) => Some(error),
+            Self::PassRegistry(error) => Some(error),
             Self::RemovalPending { reason, .. } => Some(reason),
             _ => None,
         }
@@ -504,7 +508,7 @@ impl ImguiContexts {
             "the Dear ImGui App lifecycle is terminal"
         );
         assert!(
-            lifecycle.try_claim_registry(),
+            lifecycle.try_claim_context_registry(),
             "the Bevy App already created its Dear ImGui Context registry"
         );
         let primary_id = primary.id();
@@ -537,11 +541,14 @@ impl ImguiContexts {
     }
 
     /// Return the primary Context identity.
+    ///
+    /// Explicit App shutdown makes the retained registry terminal, so callers cannot confuse a
+    /// completed lifecycle with an active registry that temporarily has no primary Context.
+    /// Returns [`ImguiContextError::AppTerminated`] in that terminal state.
     #[must_use]
-    pub fn primary_id(&self) -> Option<ContextId> {
-        (!self.lifecycle.is_terminal())
-            .then_some(self.primary)
-            .flatten()
+    pub fn primary_id(&self) -> Result<Option<ContextId>, ImguiContextError> {
+        self.ensure_active()?;
+        Ok(self.primary)
     }
 
     /// Select an existing idle Context as the primary input and fallback-window target.
@@ -575,23 +582,25 @@ impl ImguiContexts {
     /// A managed-retirement tombstone remains visible until its matching
     /// [`ImguiContextRetired`] completion is emitted, although the private driver no longer opens
     /// frames for it.
-    pub fn ids(&self) -> impl ExactSizeIterator<Item = ContextId> + '_ {
-        let order = if self.lifecycle.is_terminal() {
-            &self.order[0..0]
-        } else {
-            self.order.as_slice()
-        };
-        order.iter().copied()
+    ///
+    /// Returns [`ImguiContextError::AppTerminated`] after explicit App shutdown.
+    pub fn ids(&self) -> Result<impl ExactSizeIterator<Item = ContextId> + '_, ImguiContextError> {
+        self.ensure_active()?;
+        Ok(self.order.iter().copied())
     }
 
     /// Return whether this registry recognizes `context_id`.
+    ///
+    /// Returns [`ImguiContextError::AppTerminated`] after explicit App shutdown.
     #[must_use]
-    pub fn contains(&self, context_id: ContextId) -> bool {
-        !self.lifecycle.is_terminal() && self.slots.contains_key(&context_id)
+    pub fn contains(&self, context_id: ContextId) -> Result<bool, ImguiContextError> {
+        self.ensure_active()?;
+        Ok(self.slots.contains_key(&context_id))
     }
 
     /// Return a Context's latest completed frame index.
     pub fn frame_index(&self, context_id: ContextId) -> Result<u64, ImguiContextError> {
+        self.ensure_active()?;
         self.slots
             .get(&context_id)
             .map(|slot| slot.frame_index)
@@ -603,6 +612,7 @@ impl ImguiContexts {
         &self,
         context_id: ContextId,
     ) -> Result<Option<&ImguiContextError>, ImguiContextError> {
+        self.ensure_active()?;
         self.slots
             .get(&context_id)
             .map(|slot| slot.last_error.as_ref())
@@ -1233,7 +1243,7 @@ mod retirement_generation_tests {
     fn stale_retirement_completion_cannot_remove_a_reused_slot_generation() {
         let _guard = imgui_context_guard();
         let mut app = bevy_app::App::new();
-        let primary_pass = super::super::pass::primary_pass(&mut app);
+        let primary_pass = super::super::pass::primary_pass(&mut app).unwrap();
         let lifecycle = super::super::pass::lifecycle(app.world());
         let primary = SuspendedContext::create();
         let context_id = primary.id();
@@ -1248,7 +1258,7 @@ mod retirement_generation_tests {
         slot.retirement = Some(current);
 
         assert!(!contexts.complete_retirement(stale));
-        assert!(contexts.contains(context_id));
+        assert!(contexts.contains(context_id).unwrap());
         assert_eq!(
             contexts
                 .slots

--- a/backends/dear-imgui-bevy/src/context/registry.rs
+++ b/backends/dear-imgui-bevy/src/context/registry.rs
@@ -545,7 +545,6 @@ impl ImguiContexts {
     /// Explicit App shutdown makes the retained registry terminal, so callers cannot confuse a
     /// completed lifecycle with an active registry that temporarily has no primary Context.
     /// Returns [`ImguiContextError::AppTerminated`] in that terminal state.
-    #[must_use]
     pub fn primary_id(&self) -> Result<Option<ContextId>, ImguiContextError> {
         self.ensure_active()?;
         Ok(self.primary)
@@ -592,7 +591,6 @@ impl ImguiContexts {
     /// Return whether this registry recognizes `context_id`.
     ///
     /// Returns [`ImguiContextError::AppTerminated`] after explicit App shutdown.
-    #[must_use]
     pub fn contains(&self, context_id: ContextId) -> Result<bool, ImguiContextError> {
         self.ensure_active()?;
         Ok(self.slots.contains_key(&context_id))

--- a/backends/dear-imgui-bevy/src/context/retirement.rs
+++ b/backends/dear-imgui-bevy/src/context/retirement.rs
@@ -291,7 +291,7 @@ mod retirement_tests {
 
     fn primary_config() -> ImguiContextConfig {
         let mut app = App::new();
-        let pass = crate::context::pass::primary_pass(&mut app);
+        let pass = crate::context::pass::primary_pass(&mut app).unwrap();
         ImguiContextConfig::primary(&pass)
     }
 

--- a/backends/dear-imgui-bevy/src/context/shutdown.rs
+++ b/backends/dear-imgui-bevy/src/context/shutdown.rs
@@ -11,7 +11,8 @@ use bevy_render::pipelined_rendering::RenderExtractApp;
 
 use super::{
     ImguiContextAdmissionError, ImguiContextError, ImguiContextRemovalPendingReason,
-    ImguiContextRetirements, ImguiContexts, ImguiPass, ImguiPrimaryPass,
+    ImguiContextRetirements, ImguiContexts, ImguiPass, ImguiPassError, ImguiPrimaryPass,
+    IntoImguiSystemConfigs,
     plugin::{ImguiPlugin, ImguiPluginInstallError},
 };
 use crate::schedule::ImguiContextDriver;
@@ -31,14 +32,25 @@ pub trait ImguiAppExt {
         plugin: ImguiPlugin,
     ) -> Result<&mut Self, ImguiPluginInstallError>;
 
+    /// Register application-owned input producers before the backend commits one frame's input.
+    ///
+    /// Producers may emit Bevy window, keyboard, pointer, touch, or IME messages and may use
+    /// normal Bevy ordering and run conditions. Their conditions affect only those producer
+    /// systems; the backend-owned input transaction still runs and cannot be suspended through a
+    /// public [`bevy_ecs::schedule::SystemSet`].
+    fn add_imgui_input_producers<M>(
+        &mut self,
+        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+    ) -> &mut Self;
+
     /// Declare a new private Dear ImGui pass branded by `P`.
     ///
     /// Each call creates a distinct runtime pass. `P` prevents accidental cross-brand
     /// registration, while the private runtime key distinguishes multiple passes of one brand.
-    fn declare_imgui_pass<P: 'static>(&mut self) -> ImguiPass<P>;
+    fn declare_imgui_pass<P: 'static>(&mut self) -> Result<ImguiPass<P>, ImguiPassError>;
 
     /// Retrieve the private pass owned by the primary Dear ImGui Context.
-    fn imgui_primary_pass(&mut self) -> ImguiPass<ImguiPrimaryPass>;
+    fn imgui_primary_pass(&mut self) -> Result<ImguiPass<ImguiPrimaryPass>, ImguiPassError>;
 
     /// Adopt a custom suspended Context as this App's initial primary Context.
     ///
@@ -51,14 +63,14 @@ pub trait ImguiAppExt {
 
     /// Register configured unit-input systems in `pass`'s private runner.
     ///
-    /// Bind each frame-input function with [`ImguiPass::system`] first. The supplied Bevy
-    /// [`IntoScheduleConfigs`] is preserved, including ordering, run conditions, system sets, and
-    /// automatically inserted deferred-command barriers.
-    fn add_imgui_systems<P, M>(
+    /// Bind each frame-input function with [`ImguiPass::system`] first. The sealed
+    /// [`IntoImguiSystemConfigs`] surface preserves the usual ordering, run-condition, system-set,
+    /// ambiguity, and deferred-command configuration without exposing an ordinary schedule entry.
+    fn add_imgui_systems<P>(
         &mut self,
         pass: &ImguiPass<P>,
-        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
-    ) -> &mut Self
+        systems: impl IntoImguiSystemConfigs<P>,
+    ) -> Result<&mut Self, ImguiPassError>
     where
         P: 'static;
 
@@ -67,7 +79,7 @@ pub trait ImguiAppExt {
         &mut self,
         pass: &ImguiPass<P>,
         sets: impl IntoScheduleConfigs<InternedSystemSet, M>,
-    ) -> &mut Self
+    ) -> Result<&mut Self, ImguiPassError>
     where
         P: 'static;
 
@@ -144,11 +156,19 @@ impl ImguiAppExt for App {
         super::plugin::try_install_imgui(self, plugin)
     }
 
-    fn declare_imgui_pass<P: 'static>(&mut self) -> ImguiPass<P> {
+    fn add_imgui_input_producers<M>(
+        &mut self,
+        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+    ) -> &mut Self {
+        crate::input::add_input_producers(self, systems);
+        self
+    }
+
+    fn declare_imgui_pass<P: 'static>(&mut self) -> Result<ImguiPass<P>, ImguiPassError> {
         super::pass::declare_pass::<P>(self)
     }
 
-    fn imgui_primary_pass(&mut self) -> ImguiPass<ImguiPrimaryPass> {
+    fn imgui_primary_pass(&mut self) -> Result<ImguiPass<ImguiPrimaryPass>, ImguiPassError> {
         super::pass::primary_pass(self)
     }
 
@@ -166,15 +186,30 @@ impl ImguiAppExt for App {
                 context,
             ));
         }
-        super::pass::install_pass_registry(self);
+        if let Err(error) = super::pass::install_pass_registry(self) {
+            return Err(ImguiContextAdmissionError::new(
+                ImguiContextError::PassRegistry(error),
+                context,
+            ));
+        }
         let lifecycle = super::pass::lifecycle(self.world());
-        if self.world().get_non_send::<ImguiContexts>().is_some() || lifecycle.registry_claimed() {
+        if self.world().get_non_send::<ImguiContexts>().is_some()
+            || lifecycle.context_registry_claimed()
+        {
             return Err(ImguiContextAdmissionError::new(
                 ImguiContextError::ContextRegistryAlreadyInstalled,
                 context,
             ));
         }
-        let primary_pass = super::pass::primary_pass(self);
+        let primary_pass = match super::pass::primary_pass(self) {
+            Ok(pass) => pass,
+            Err(error) => {
+                return Err(ImguiContextAdmissionError::new(
+                    ImguiContextError::PassRegistry(error),
+                    context,
+                ));
+            }
+        };
         self.insert_non_send(ImguiContexts::with_primary(
             context,
             primary_pass,
@@ -183,28 +218,28 @@ impl ImguiAppExt for App {
         Ok(self)
     }
 
-    fn add_imgui_systems<P, M>(
+    fn add_imgui_systems<P>(
         &mut self,
         pass: &ImguiPass<P>,
-        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
-    ) -> &mut Self
+        systems: impl IntoImguiSystemConfigs<P>,
+    ) -> Result<&mut Self, ImguiPassError>
     where
         P: 'static,
     {
-        super::pass::add_systems(self, pass, systems);
-        self
+        super::pass::add_systems(self, pass, systems)?;
+        Ok(self)
     }
 
     fn configure_imgui_sets<P, M>(
         &mut self,
         pass: &ImguiPass<P>,
         sets: impl IntoScheduleConfigs<InternedSystemSet, M>,
-    ) -> &mut Self
+    ) -> Result<&mut Self, ImguiPassError>
     where
         P: 'static,
     {
-        super::pass::configure_sets(self, pass, sets);
-        self
+        super::pass::configure_sets(self, pass, sets)?;
+        Ok(self)
     }
 
     fn shutdown_imgui(&mut self) -> Result<(), ImguiShutdownError> {
@@ -218,6 +253,8 @@ impl ImguiAppExt for App {
         self.world()
             .resource::<super::lifecycle::ImguiAppLifecycle>()
             .commit_terminal();
+
+        super::pass::remove_pass_registry(self);
 
         #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
         let native_windows = crate::viewport::retire_native_viewport_windows(self.world_mut());

--- a/backends/dear-imgui-bevy/src/context/tests/lifecycle.rs
+++ b/backends/dear-imgui-bevy/src/context/tests/lifecycle.rs
@@ -13,7 +13,8 @@ use bevy_time::{Real, Time};
 use bevy_window::{PrimaryWindow, Window, WindowResolution};
 use dear_imgui_bevy::{
     ContextId, ImguiAppExt, ImguiContextConfig, ImguiContextError, ImguiContextRetired,
-    ImguiContexts, ImguiFrame, ImguiPass, ImguiPlugin, ImguiPrimaryPass,
+    ImguiContexts, ImguiFrame, ImguiPass, ImguiPassError, ImguiPlugin, ImguiPrimaryPass,
+    IntoImguiSystemConfigs,
 };
 use std::time::Duration;
 
@@ -108,6 +109,13 @@ fn app_with_primary_window() -> App {
         PrimaryWindow,
     ));
     app
+}
+
+#[cfg(feature = "render")]
+fn resize_primary_window_before_input_commit(mut windows: Query<&mut Window, With<PrimaryWindow>>) {
+    for mut window in &mut windows {
+        window.resolution.set(800.0, 600.0);
+    }
 }
 
 fn record_ui<P: 'static>(frame: ImguiFrame<'_, P>, mut trace: ResMut<LifecycleTrace>) {
@@ -280,23 +288,16 @@ fn trace_imgui(_frame: ImguiFrame<'_>, mut trace: ResMut<MainScheduleTrace>) {
     trace.0.push("imgui");
 }
 
-#[cfg(feature = "render")]
-fn force_input_route_epoch_mismatch(
-    routes: Res<crate::route::ImguiResolvedRoutes>,
-    mut input_metrics: ResMut<crate::input::ImguiContextInputMetrics>,
-) {
-    input_metrics.set_epoch_for_test(routes.epoch().wrapping_add(1));
-}
-
 #[test]
 fn private_context_pass_does_not_collide_with_update() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let pass = app.declare_imgui_pass::<ContextPassA>();
+    let pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
     app.init_resource::<ScheduleNamespaceTrace>()
         .add_systems(Update, record_update_schedule)
         .add_plugins(ImguiPlugin::default());
-    app.add_imgui_systems(&pass, pass.system(record_update_named_ui_pass));
+    app.add_imgui_systems(&pass, pass.system(record_update_named_ui_pass))
+        .unwrap();
 
     app.world_mut()
         .non_send_mut::<ImguiContexts>()
@@ -314,13 +315,15 @@ fn private_context_pass_does_not_collide_with_update() {
 fn public_schedule_can_nest_without_obtaining_another_context_frame() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
-    let pass_b = app.declare_imgui_pass::<ContextPassB>();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let pass_b = app.declare_imgui_pass::<ContextPassB>().unwrap();
     app.init_resource::<NestedScheduleTrace>()
         .add_systems(Update, record_nested_update)
         .add_plugins(ImguiPlugin::default());
-    app.add_imgui_systems(&pass_a, pass_a.system(attempt_nested_schedules));
-    app.add_imgui_systems(&pass_b, pass_b.system(record_nested_context_b));
+    app.add_imgui_systems(&pass_a, pass_a.system(attempt_nested_schedules))
+        .unwrap();
+    app.add_imgui_systems(&pass_b, pass_b.system(record_nested_context_b))
+        .unwrap();
 
     let context_b = {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
@@ -344,8 +347,9 @@ fn dynamic_public_schedule_registration_does_not_expose_imgui_frame() {
     let mut app = app_with_primary_window();
     app.init_resource::<DynamicScheduleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary, primary.system(register_and_run_dynamic_schedule));
+    let primary = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary, primary.system(register_and_run_dynamic_schedule))
+        .unwrap();
 
     app.update();
 
@@ -364,8 +368,9 @@ fn private_pass_preserves_commands_local_state_and_change_detection() {
     app.init_resource::<PassSystemSemantics>()
         .init_resource::<TrackedPassResource>()
         .add_plugins(ImguiPlugin::default());
-    let primary = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary, primary.system(exercise_pass_system_semantics));
+    let primary = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary, primary.system(exercise_pass_system_semantics))
+        .unwrap();
 
     app.update();
     app.update();
@@ -392,7 +397,7 @@ fn private_pass_preserves_bevy_system_configs_and_intermediate_deferred_barriers
     let mut app = app_with_primary_window();
     app.init_resource::<ConfiguredPassTrace>()
         .add_plugins(ImguiPlugin::default());
-    let pass = app.imgui_primary_pass();
+    let pass = app.imgui_primary_pass().unwrap();
     app.configure_imgui_sets(
         &pass,
         (
@@ -400,7 +405,8 @@ fn private_pass_preserves_bevy_system_configs_and_intermediate_deferred_barriers
             ConfiguredPassSet::Observe,
             ConfiguredPassSet::Final,
         ),
-    );
+    )
+    .unwrap();
     app.add_imgui_systems(
         &pass,
         (
@@ -412,13 +418,15 @@ fn private_pass_preserves_bevy_system_configs_and_intermediate_deferred_barriers
             .chain()
             .run_if(|| true)
             .before(ConfiguredPassSet::Final),
-    );
+    )
+    .unwrap();
     app.add_imgui_systems(
         &pass,
         pass.system(finish_configured_pass)
             .in_set(ConfiguredPassSet::Final)
             .after(ConfiguredPassSet::Observe),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -431,7 +439,8 @@ fn private_pass_preserves_bevy_system_configs_and_intermediate_deferred_barriers
         &pass,
         pass.system(record_dynamically_registered_pass)
             .after(ConfiguredPassSet::Final),
-    );
+    )
+    .unwrap();
     app.update();
 
     assert_eq!(
@@ -453,8 +462,10 @@ fn driver_defaults_after_pre_update_and_supports_an_explicit_main_schedule_ancho
         .add_systems(PostUpdate, trace_post_update)
         .add_systems(Last, trace_last)
         .add_plugins(ImguiPlugin::default());
-    let default_pass = default_app.imgui_primary_pass();
-    default_app.add_imgui_systems(&default_pass, default_pass.system(trace_imgui));
+    let default_pass = default_app.imgui_primary_pass().unwrap();
+    default_app
+        .add_imgui_systems(&default_pass, default_pass.system(trace_imgui))
+        .unwrap();
 
     default_app.update();
 
@@ -470,8 +481,10 @@ fn driver_defaults_after_pre_update_and_supports_an_explicit_main_schedule_ancho
         .add_plugins(ImguiPlugin::new(
             crate::ImguiPluginConfig::default().with_driver_after(Update),
         ));
-    let anchored_pass = anchored_app.imgui_primary_pass();
-    anchored_app.add_imgui_systems(&anchored_pass, anchored_pass.system(trace_imgui));
+    let anchored_pass = anchored_app.imgui_primary_pass().unwrap();
+    anchored_app
+        .add_imgui_systems(&anchored_pass, anchored_pass.system(trace_imgui))
+        .unwrap();
 
     anchored_app.update();
 
@@ -483,29 +496,51 @@ fn driver_defaults_after_pre_update_and_supports_an_explicit_main_schedule_ancho
 
 #[cfg(feature = "render")]
 #[test]
-fn driver_fails_the_complete_frame_closed_when_input_and_render_epochs_differ() {
+fn custom_input_producers_commit_into_the_same_context_frame() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let additional_pass = app.declare_imgui_pass::<ContextPassA>();
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default())
-        .add_systems(
-            PreUpdate,
-            force_input_route_epoch_mismatch.after(crate::input::ImguiInputSystems),
+        .add_imgui_input_producers(resize_primary_window_before_input_commit);
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(capture_primary_metrics))
+        .unwrap();
+
+    app.update();
+
+    assert_eq!(
+        app.world().resource::<LifecycleTrace>().display_metrics,
+        [([800.0, 600.0], [1.0, 1.0])],
+        "application input producers must run before the same frame's input commit"
+    );
+}
+
+#[cfg(feature = "render")]
+#[test]
+fn custom_input_producer_conditions_do_not_suspend_context_frames() {
+    let _guard = imgui_context_guard();
+    let mut app = app_with_primary_window();
+    let additional_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    app.init_resource::<LifecycleTrace>()
+        .add_plugins(ImguiPlugin::default())
+        .add_imgui_input_producers(
+            (|| panic!("disabled input producer unexpectedly ran")).run_if(|| false),
         );
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(record_ui::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     app.add_imgui_systems(
         &additional_pass,
         additional_pass.system(record_ui::<ContextPassA>),
-    );
+    )
+    .unwrap();
 
     let (primary, additional) = {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
-        let primary = contexts.primary_id().unwrap();
+        let primary = contexts.primary_id().unwrap().unwrap();
         let additional = contexts
             .create(ImguiContextConfig::new(&additional_pass))
             .unwrap();
@@ -515,15 +550,56 @@ fn driver_fails_the_complete_frame_closed_when_input_and_render_epochs_differ() 
     app.update();
 
     let contexts = app.world().non_send::<ImguiContexts>();
-    assert_eq!(contexts.frame_index(primary).unwrap(), 0);
-    assert_eq!(contexts.frame_index(additional).unwrap(), 0);
-    assert!(app.world().resource::<LifecycleTrace>().visits.is_empty());
+    assert_eq!(contexts.frame_index(primary).unwrap(), 1);
+    assert_eq!(contexts.frame_index(additional).unwrap(), 1);
+    assert_eq!(
+        app.world().resource::<LifecycleTrace>().visits.len(),
+        2,
+        "conditions on an application producer must not disable backend-owned input mapping"
+    );
+}
+
+#[cfg(feature = "render")]
+#[test]
+fn frame_input_transaction_is_consumed_exactly_once() {
+    let _guard = imgui_context_guard();
+    let mut app = app_with_primary_window();
+    app.add_plugins(ImguiPlugin::default());
+    let primary = app
+        .world()
+        .get_non_send::<ImguiContexts>()
+        .unwrap()
+        .primary_id()
+        .unwrap()
+        .unwrap();
+
+    app.update();
     assert_eq!(
         app.world()
-            .resource::<crate::context::ImguiFrameMailbox>()
-            .len(),
-        0,
-        "an epoch mismatch must not publish a partial Context frame"
+            .non_send::<ImguiContexts>()
+            .frame_index(primary)
+            .unwrap(),
+        1
+    );
+
+    app.world_mut()
+        .run_schedule(crate::schedule::ImguiContextDriver);
+    assert_eq!(
+        app.world()
+            .non_send::<ImguiContexts>()
+            .frame_index(primary)
+            .unwrap(),
+        1,
+        "the private driver must not replay the previous input transaction"
+    );
+
+    app.update();
+    assert_eq!(
+        app.world()
+            .non_send::<ImguiContexts>()
+            .frame_index(primary)
+            .unwrap(),
+        2
     );
 }
 
@@ -547,7 +623,9 @@ fn shutdown_converges_a_pending_managed_retirement_once() {
     let primary = app
         .world()
         .get_non_send::<ImguiContexts>()
-        .and_then(ImguiContexts::primary_id)
+        .unwrap()
+        .primary_id()
+        .unwrap()
         .unwrap();
     let mut completions = app
         .world()
@@ -592,7 +670,9 @@ fn plugin_finish_skips_a_context_already_transferred_to_managed_retirement() {
     let primary = app
         .world()
         .get_non_send::<ImguiContexts>()
-        .and_then(ImguiContexts::primary_id)
+        .unwrap()
+        .primary_id()
+        .unwrap()
         .unwrap();
     let mut completions = app
         .world()
@@ -616,6 +696,7 @@ fn plugin_finish_skips_a_context_already_transferred_to_managed_retirement() {
             .get_non_send::<ImguiContexts>()
             .unwrap()
             .contains(primary)
+            .unwrap()
     );
     assert_eq!(
         completions
@@ -631,22 +712,68 @@ fn terminal_shutdown_invalidates_retained_registries_and_rejects_app_scoped_read
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
     app.add_plugins(ImguiPlugin::default());
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    let additional_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
     let primary = app
         .world()
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
     let mut retained = app.world_mut().remove_non_send::<ImguiContexts>().unwrap();
 
     app.shutdown_imgui().unwrap();
 
-    assert_eq!(retained.primary_id(), None);
-    assert_eq!(retained.ids().len(), 0);
+    assert!(matches!(
+        retained.primary_id(),
+        Err(ImguiContextError::AppTerminated)
+    ));
+    assert!(matches!(
+        retained.ids(),
+        Err(ImguiContextError::AppTerminated)
+    ));
+    assert!(matches!(
+        retained.contains(primary),
+        Err(ImguiContextError::AppTerminated)
+    ));
+    assert!(matches!(
+        retained.frame_index(primary),
+        Err(ImguiContextError::AppTerminated)
+    ));
+    assert!(matches!(
+        retained.last_error(primary),
+        Err(ImguiContextError::AppTerminated)
+    ));
     assert!(matches!(
         retained.configure(primary, |_| ()),
         Err(ImguiContextError::AppTerminated)
     ));
+    assert!(matches!(
+        app.declare_imgui_pass::<ContextPassB>(),
+        Err(ImguiPassError::AppTerminated)
+    ));
+    assert!(matches!(
+        app.imgui_primary_pass(),
+        Err(ImguiPassError::AppTerminated)
+    ));
+    assert!(matches!(
+        app.add_imgui_systems(
+            &additional_pass,
+            additional_pass.system(record_ui::<ContextPassA>),
+        ),
+        Err(ImguiPassError::AppTerminated)
+    ));
+    assert!(matches!(
+        app.configure_imgui_sets(&primary_pass, ConfiguredPassSet::Produce),
+        Err(ImguiPassError::AppTerminated)
+    ));
+    assert!(
+        app.world()
+            .get_non_send::<crate::context::pass::ImguiPassRegistry>()
+            .is_none(),
+        "terminal shutdown must release private pass schedules and their systems"
+    );
     let rejected = dear_imgui_rs::SuspendedContext::create();
     let rejected_id = rejected.id();
     let error = match app.adopt_imgui_primary_context(rejected) {
@@ -659,6 +786,36 @@ fn terminal_shutdown_invalidates_retained_registries_and_rejects_app_scoped_read
     app.insert_non_send(retained);
     app.shutdown_imgui()
         .expect("terminal retry must still retire a retained inert registry");
+}
+
+#[test]
+fn removed_pass_registry_is_not_silently_recreated() {
+    let mut app = App::new();
+    let pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
+
+    crate::context::pass::remove_pass_registry(&mut app);
+
+    assert!(matches!(
+        app.declare_imgui_pass::<ContextPassB>(),
+        Err(ImguiPassError::PassRegistryMissing)
+    ));
+    assert!(matches!(
+        app.imgui_primary_pass(),
+        Err(ImguiPassError::PassRegistryMissing)
+    ));
+    assert!(matches!(
+        app.add_imgui_systems(&pass, pass.system(record_ui::<ContextPassA>)),
+        Err(ImguiPassError::PassRegistryMissing)
+    ));
+    assert!(matches!(
+        app.configure_imgui_sets(&pass, ConfiguredPassSet::Produce),
+        Err(ImguiPassError::PassRegistryMissing)
+    ));
+    assert!(
+        app.world()
+            .get_non_send::<crate::context::pass::ImguiPassRegistry>()
+            .is_none()
+    );
 }
 
 #[test]
@@ -705,12 +862,12 @@ fn removing_the_registry_does_not_open_a_second_context_admission() {
 fn primary_promotion_and_replacement_are_transactional() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
-    let pass_b = app.declare_imgui_pass::<ContextPassB>();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let pass_b = app.declare_imgui_pass::<ContextPassB>().unwrap();
     app.add_plugins(ImguiPlugin::default());
     let (initial_primary, context_a) = {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
-        let initial_primary = contexts.primary_id().unwrap();
+        let initial_primary = contexts.primary_id().unwrap().unwrap();
         let context_a = contexts.create(ImguiContextConfig::new(&pass_a)).unwrap();
         (initial_primary, context_a)
     };
@@ -736,7 +893,10 @@ fn primary_promotion_and_replacement_are_transactional() {
     ));
     assert_eq!(duplicate_error.into_context().id(), duplicate_id);
     assert_eq!(
-        app.world().non_send::<ImguiContexts>().primary_id(),
+        app.world()
+            .non_send::<ImguiContexts>()
+            .primary_id()
+            .unwrap(),
         Some(context_a)
     );
 
@@ -750,9 +910,9 @@ fn primary_promotion_and_replacement_are_transactional() {
     assert_eq!(replaced.previous(), Some(context_a));
     assert_eq!(replaced.current(), replacement_id);
     let contexts = app.world().non_send::<ImguiContexts>();
-    assert_eq!(contexts.primary_id(), Some(replacement_id));
+    assert_eq!(contexts.primary_id().unwrap(), Some(replacement_id));
     assert_eq!(
-        contexts.ids().collect::<Vec<_>>(),
+        contexts.ids().unwrap().collect::<Vec<_>>(),
         [initial_primary, context_a, replacement_id]
     );
 }
@@ -761,21 +921,24 @@ fn primary_promotion_and_replacement_are_transactional() {
 fn primary_and_two_additional_contexts_run_in_stable_order_with_independent_frames() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
-    let pass_b = app.declare_imgui_pass::<ContextPassB>();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let pass_b = app.declare_imgui_pass::<ContextPassB>().unwrap();
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(record_ui::<ImguiPrimaryPass>),
-    );
-    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>));
-    app.add_imgui_systems(&pass_b, pass_b.system(record_ui::<ContextPassB>));
+    )
+    .unwrap();
+    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>))
+        .unwrap();
+    app.add_imgui_systems(&pass_b, pass_b.system(record_ui::<ContextPassB>))
+        .unwrap();
 
     let (primary, context_a, context_b, expected_raw) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let primary = contexts.primary_id().unwrap();
+        let primary = contexts.primary_id().unwrap().unwrap();
         let context_a = contexts.create(ImguiContextConfig::new(&pass_a)).unwrap();
         let context_b = contexts.create(ImguiContextConfig::new(&pass_b)).unwrap();
         let mut expected_raw = Vec::new();
@@ -824,7 +987,7 @@ fn primary_and_two_additional_contexts_run_in_stable_order_with_independent_fram
         ]
     );
     let contexts = app.world().get_non_send::<ImguiContexts>().unwrap();
-    assert_eq!(contexts.ids().collect::<Vec<_>>(), trace.expected);
+    assert_eq!(contexts.ids().unwrap().collect::<Vec<_>>(), trace.expected);
     assert_eq!(contexts.frame_index(primary).unwrap(), 2);
     assert_eq!(contexts.frame_index(context_a).unwrap(), 2);
     assert_eq!(contexts.frame_index(context_b).unwrap(), 2);
@@ -835,44 +998,108 @@ fn primary_and_two_additional_contexts_run_in_stable_order_with_independent_fram
 }
 
 #[test]
-#[should_panic(expected = "is not bound to this exact pass")]
-fn private_pass_rejects_a_system_bound_to_another_runtime_pass_during_registration() {
-    let mut app = App::new();
-    let first_pass = app.declare_imgui_pass::<ContextPassA>();
-    let second_pass = app.declare_imgui_pass::<ContextPassA>();
+fn private_pass_rejects_another_runtime_pass_before_mutating_the_runner() {
+    let _guard = imgui_context_guard();
+    let mut app = app_with_primary_window();
+    let first_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let second_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
 
-    app.add_imgui_systems(&second_pass, first_pass.system(record_ui::<ContextPassA>));
+    let error =
+        match app.add_imgui_systems(&second_pass, first_pass.system(record_ui::<ContextPassA>)) {
+            Err(error) => error,
+            Ok(_) => panic!("a system bound to another runtime pass must be rejected"),
+        };
+    let message = error.to_string();
+    match error {
+        ImguiPassError::SystemPassMismatch {
+            expected_runtime,
+            actual_runtime,
+            ..
+        } => assert_ne!(expected_runtime, actual_runtime),
+        other => panic!("expected a runtime pass mismatch, got {other}"),
+    }
+    assert!(message.contains("runtime pass"));
+
+    app.init_resource::<LifecycleTrace>()
+        .add_plugins(ImguiPlugin::default());
+    app.add_imgui_systems(&second_pass, second_pass.system(record_ui::<ContextPassA>))
+        .unwrap();
+    let context = app
+        .world_mut()
+        .non_send_mut::<ImguiContexts>()
+        .create(ImguiContextConfig::new(&second_pass))
+        .unwrap();
+
+    app.update();
+
+    assert_eq!(
+        app.world().resource::<LifecycleTrace>().visits,
+        [(context, 1)],
+        "a rejected system must not remain in the private runner"
+    );
 }
 
 #[test]
-#[should_panic(expected = "is not bound to this exact pass")]
-fn private_pass_rejects_a_system_bound_to_another_brand_during_registration() {
+fn private_pass_rejects_mixed_runtime_passes_before_mutating_the_runner() {
     let mut app = App::new();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
-    let pass_b = app.declare_imgui_pass::<ContextPassB>();
+    let first_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let second_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
 
-    app.add_imgui_systems(&pass_b, pass_a.system(record_ui::<ContextPassA>));
+    let error = match app.add_imgui_systems(
+        &first_pass,
+        (
+            first_pass.system(record_ui::<ContextPassA>),
+            second_pass.system(record_ui::<ContextPassA>),
+        ),
+    ) {
+        Err(error) => error,
+        Ok(_) => panic!("a mixed private-pass tuple must be rejected"),
+    };
+    assert!(matches!(error, ImguiPassError::SystemPassMismatch { .. }));
+    app.add_imgui_systems(&first_pass, first_pass.system(record_ui::<ContextPassA>))
+        .expect("the rejected tuple must leave the target runner configurable");
 }
 
 #[test]
-#[should_panic(expected = "is not bound to this exact pass")]
-fn private_pass_rejects_an_unbound_bevy_system_during_registration() {
-    let mut app = App::new();
-    let pass = app.declare_imgui_pass::<ContextPassA>();
+fn private_pass_rejects_foreign_handles_and_configs_before_mutating_the_runner() {
+    let mut owner_app = App::new();
+    let owner_pass = owner_app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let mut foreign_app = App::new();
+    let foreign_pass = foreign_app.declare_imgui_pass::<ContextPassA>().unwrap();
 
-    app.add_imgui_systems(&pass, || {});
+    let error = match owner_app.add_imgui_systems(
+        &foreign_pass,
+        foreign_pass.system(record_ui::<ContextPassA>),
+    ) {
+        Err(error) => error,
+        Ok(_) => panic!("a foreign pass handle must be rejected"),
+    };
+    assert!(matches!(error, ImguiPassError::ForeignApp { .. }));
+
+    let error = match owner_app
+        .add_imgui_systems(&owner_pass, foreign_pass.system(record_ui::<ContextPassA>))
+    {
+        Err(error) => error,
+        Ok(_) => panic!("a foreign pass configuration must be rejected"),
+    };
+    assert!(matches!(error, ImguiPassError::ForeignApp { .. }));
+    owner_app
+        .add_imgui_systems(&owner_pass, owner_pass.system(record_ui::<ContextPassA>))
+        .expect("the rejected foreign configuration must leave the runner configurable");
 }
 
 #[test]
 fn distinct_passes_with_the_same_brand_drive_independent_contexts() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let first_pass = app.declare_imgui_pass::<ContextPassA>();
-    let second_pass = app.declare_imgui_pass::<ContextPassA>();
+    let first_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let second_pass = app.declare_imgui_pass::<ContextPassA>().unwrap();
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    app.add_imgui_systems(&first_pass, first_pass.system(record_ui::<ContextPassA>));
-    app.add_imgui_systems(&second_pass, second_pass.system(record_ui::<ContextPassA>));
+    app.add_imgui_systems(&first_pass, first_pass.system(record_ui::<ContextPassA>))
+        .unwrap();
+    app.add_imgui_systems(&second_pass, second_pass.system(record_ui::<ContextPassA>))
+        .unwrap();
 
     let (first, second) = {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
@@ -908,8 +1135,9 @@ fn primary_pass_receives_bevy_time_and_logical_window_metrics() {
     app.insert_resource(real_time)
         .init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary, primary.system(capture_primary_metrics));
+    let primary = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary, primary.system(capture_primary_metrics))
+        .unwrap();
 
     app.update();
 
@@ -929,8 +1157,9 @@ fn primary_pass_sanitizes_invalid_window_metrics_before_begin_frame() {
     app.world_mut().spawn((window, PrimaryWindow));
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary, primary.system(capture_primary_metrics));
+    let primary = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary, primary.system(capture_primary_metrics))
+        .unwrap();
 
     app.update();
 
@@ -944,21 +1173,23 @@ fn primary_pass_sanitizes_invalid_window_metrics_before_begin_frame() {
 fn any_live_ui_blocks_raw_mutation_of_every_registered_context() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
-    let missing_pass = app.declare_imgui_pass::<MissingContextPass>();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
+    let missing_pass = app.declare_imgui_pass::<MissingContextPass>().unwrap();
     app.insert_resource(missing_pass);
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(reject_raw_mutation_during_ui),
-    );
-    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>));
+    )
+    .unwrap();
+    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>))
+        .unwrap();
 
     let (primary, context_a) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let primary = contexts.primary_id().unwrap();
+        let primary = contexts.primary_id().unwrap().unwrap();
         let context_a = contexts.create(ImguiContextConfig::new(&pass_a)).unwrap();
         (primary, context_a)
     };
@@ -980,8 +1211,8 @@ fn any_live_ui_blocks_raw_mutation_of_every_registered_context() {
 fn duplicate_pass_and_stale_context_errors_are_typed_and_recover_ownership() {
     let _guard = imgui_context_guard();
     let mut app = App::new();
-    let primary_pass = app.imgui_primary_pass();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
     let lifecycle = crate::context::pass::lifecycle(app.world());
     let mut contexts = ImguiContexts::with_primary(
         dear_imgui_rs::SuspendedContext::create(),
@@ -1014,9 +1245,9 @@ fn duplicate_pass_and_stale_context_errors_are_typed_and_recover_ownership() {
 fn pass_from_another_app_is_rejected_without_consuming_the_context() {
     let _guard = imgui_context_guard();
     let mut foreign_app = App::new();
-    let foreign_pass = foreign_app.declare_imgui_pass::<ContextPassA>();
+    let foreign_pass = foreign_app.declare_imgui_pass::<ContextPassA>().unwrap();
     let mut owner_app = App::new();
-    let primary_pass = owner_app.imgui_primary_pass();
+    let primary_pass = owner_app.imgui_primary_pass().unwrap();
     let lifecycle = crate::context::pass::lifecycle(owner_app.world());
     let mut contexts = ImguiContexts::with_primary(
         dear_imgui_rs::SuspendedContext::create(),
@@ -1035,15 +1266,15 @@ fn pass_from_another_app_is_rejected_without_consuming_the_context() {
         ImguiContextError::ForeignPass { .. }
     ));
     assert_eq!(error.into_context().id(), rejected_id);
-    assert!(!contexts.contains(rejected_id));
+    assert!(!contexts.contains(rejected_id).unwrap());
 }
 
 #[test]
 fn additional_multi_viewport_config_can_be_registered_before_backend_attachment() {
     let _guard = imgui_context_guard();
     let mut app = App::new();
-    let primary_pass = app.imgui_primary_pass();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
     let lifecycle = crate::context::pass::lifecycle(app.world());
     let mut contexts = ImguiContexts::with_primary(
         dear_imgui_rs::SuspendedContext::create(),
@@ -1061,7 +1292,7 @@ fn additional_multi_viewport_config_can_be_registered_before_backend_attachment(
         .expect("multi-viewport configuration should be retained until backend attachment");
 
     assert_eq!(admitted, additional_id);
-    assert!(contexts.contains(additional_id));
+    assert!(contexts.contains(additional_id).unwrap());
     assert_eq!(
         contexts
             .try_remove_immediately(additional_id)
@@ -1077,7 +1308,7 @@ fn attached_backend_rejects_unavailable_native_multi_viewport_without_consuming_
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
     app.add_plugins(ImguiPlugin::default());
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
     let additional = dear_imgui_rs::SuspendedContext::create();
     let additional_id = additional.id();
 
@@ -1100,6 +1331,7 @@ fn attached_backend_rejects_unavailable_native_multi_viewport_without_consuming_
         !app.world()
             .non_send::<ImguiContexts>()
             .contains(additional_id)
+            .unwrap()
     );
 }
 
@@ -1107,23 +1339,25 @@ fn attached_backend_rejects_unavailable_native_multi_viewport_without_consuming_
 fn empty_pass_is_context_local_and_does_not_stop_later_contexts() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let empty_pass = app.declare_imgui_pass::<MissingContextPass>();
-    let healthy_pass = app.declare_imgui_pass::<ContextPassB>();
+    let empty_pass = app.declare_imgui_pass::<MissingContextPass>().unwrap();
+    let healthy_pass = app.declare_imgui_pass::<ContextPassB>().unwrap();
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(record_ui::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     app.add_imgui_systems(
         &healthy_pass,
         healthy_pass.system(record_ui::<ContextPassB>),
-    );
+    )
+    .unwrap();
 
     let (primary, missing, healthy) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let primary = contexts.primary_id().unwrap();
+        let primary = contexts.primary_id().unwrap().unwrap();
         let missing = contexts
             .create(ImguiContextConfig::new(&empty_pass))
             .unwrap();
@@ -1159,6 +1393,7 @@ fn headless_driver_reports_managed_font_atlas_conflicts() {
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
     let consumer = app
         .world_mut()
@@ -1170,6 +1405,7 @@ fn headless_driver_reports_managed_font_atlas_conflicts() {
         .unwrap()
         .expect("the test should acquire a managed renderer consumer");
 
+    app.world_mut().run_schedule(PreUpdate);
     crate::context::drive_imgui_contexts(app.world_mut());
 
     assert!(matches!(
@@ -1224,15 +1460,18 @@ fn pass_panic_reinserts_the_private_runner_and_leaves_no_context_active() {
     app.init_resource::<PanicOnce>()
         .init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(panic_once));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(panic_once))
+        .unwrap();
     let primary = app
         .world()
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
 
+    app.world_mut().run_schedule(PreUpdate);
     let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         crate::context::drive_imgui_contexts(app.world_mut());
     }));
@@ -1244,9 +1483,10 @@ fn pass_panic_reinserts_the_private_runner_and_leaves_no_context_active() {
     );
     {
         let contexts = app.world().get_non_send::<ImguiContexts>().unwrap();
-        assert!(contexts.contains(primary));
+        assert!(contexts.contains(primary).unwrap());
         assert_eq!(contexts.frame_index(primary).unwrap(), 0);
     }
+    app.world_mut().run_schedule(PreUpdate);
     crate::context::drive_imgui_contexts(app.world_mut());
     assert_eq!(
         app.world()
@@ -1276,16 +1516,18 @@ fn primary_without_a_window_does_not_advance_or_replay_a_frame() {
     let mut app = App::new();
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(record_ui::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     let primary = app
         .world()
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
 
     app.update();
@@ -1305,14 +1547,15 @@ fn primary_without_a_window_does_not_advance_or_replay_a_frame() {
 fn removing_the_primary_context_does_not_stop_an_additional_context() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
     app.init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>));
+    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>))
+        .unwrap();
 
     let (primary, additional) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let primary = contexts.primary_id().unwrap();
+        let primary = contexts.primary_id().unwrap().unwrap();
         let additional = contexts.create(ImguiContextConfig::new(&pass_a)).unwrap();
         (primary, additional)
     };
@@ -1338,7 +1581,7 @@ fn removing_the_primary_context_does_not_stop_an_additional_context() {
     app.update();
 
     let contexts = app.world().get_non_send::<ImguiContexts>().unwrap();
-    assert_eq!(contexts.primary_id(), None);
+    assert_eq!(contexts.primary_id().unwrap(), None);
     assert_eq!(contexts.frame_index(additional).unwrap(), 1);
     assert_eq!(
         app.world().resource::<LifecycleTrace>().visits,
@@ -1367,21 +1610,23 @@ fn removing_the_primary_context_does_not_stop_an_additional_context() {
 fn context_removal_abandons_unextracted_snapshot_without_pausing_another_context() {
     let _guard = imgui_context_guard();
     let mut app = app_with_primary_window();
-    let pass_a = app.declare_imgui_pass::<ContextPassA>();
+    let pass_a = app.declare_imgui_pass::<ContextPassA>().unwrap();
     app.add_plugins(ExtractPlugin::default())
         .init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(record_ui::<ImguiPrimaryPass>),
-    );
-    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>));
+    )
+    .unwrap();
+    app.add_imgui_systems(&pass_a, pass_a.system(record_ui::<ContextPassA>))
+        .unwrap();
     app.sub_app_mut(RenderApp).update_schedule = Some(Render.intern());
 
     let (context_a, context_b) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let context_a = contexts.primary_id().unwrap();
+        let context_a = contexts.primary_id().unwrap().unwrap();
         let context_b = contexts.create(ImguiContextConfig::new(&pass_a)).unwrap();
         (context_a, context_b)
     };
@@ -1448,7 +1693,7 @@ fn context_removal_abandons_unextracted_snapshot_without_pausing_another_context
     app.update();
 
     let contexts = app.world().get_non_send::<ImguiContexts>().unwrap();
-    assert!(!contexts.contains(context_a));
+    assert!(!contexts.contains(context_a).unwrap());
     assert_eq!(contexts.frame_index(context_b).unwrap(), 3);
     let extracted = app
         .sub_app(RenderApp)
@@ -1482,11 +1727,12 @@ fn removed_registry_retires_a_context_with_an_unextracted_snapshot() {
     app.add_plugins(ExtractPlugin::default())
         .init_resource::<LifecycleTrace>()
         .add_plugins(ImguiPlugin::default());
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(record_ui::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     app.sub_app_mut(RenderApp).update_schedule = Some(Render.intern());
 
     let context_id = app
@@ -1494,6 +1740,7 @@ fn removed_registry_retires_a_context_with_an_unextracted_snapshot() {
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
     let destroyed = Rc::new(Cell::new(false));
     app.world_mut()

--- a/backends/dear-imgui-bevy/src/input/mod.rs
+++ b/backends/dear-imgui-bevy/src/input/mod.rs
@@ -47,7 +47,7 @@ pub(crate) use feedback::map_imgui_mouse_cursor;
 #[cfg(not(feature = "render"))]
 pub(crate) use primary::primary_window_input_system;
 #[cfg(feature = "render")]
-pub(crate) use route::{ImguiContextInputMetrics, ImguiInputFrameMetrics};
+pub(crate) use route::{ImguiFrameInputSlot, ImguiInputFrameMetrics};
 #[cfg(feature = "render")]
 use routing::routed_window_input_system;
 pub(crate) use state::ImguiInputState;
@@ -86,9 +86,12 @@ type RoutedInputWindowComponents = (
     Option<&'static ImguiViewportOwner>,
 );
 
-/// System set that injects Bevy window input into Dear ImGui IO.
 #[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ImguiInputSystems;
+pub(crate) enum ImguiInputPipelineSystems {
+    PlatformLifecycle,
+    Producers,
+    Commit,
+}
 
 pub(crate) fn install_input_mapping(app: &mut App) {
     #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
@@ -109,14 +112,35 @@ pub(crate) fn install_input_mapping(app: &mut App) {
         .init_resource::<ImguiInputState>()
         .init_resource::<ImguiInputCapture>();
     #[cfg(feature = "render")]
-    app.init_resource::<ImguiContextInputMetrics>().add_systems(
+    app.init_resource::<ImguiFrameInputSlot>();
+    app.configure_sets(
         PreUpdate,
-        routed_window_input_system.in_set(ImguiInputSystems),
+        (
+            ImguiInputPipelineSystems::PlatformLifecycle,
+            ImguiInputPipelineSystems::Producers,
+            ImguiInputPipelineSystems::Commit,
+        )
+            .chain(),
+    );
+    #[cfg(feature = "render")]
+    app.add_systems(
+        PreUpdate,
+        routed_window_input_system.in_set(ImguiInputPipelineSystems::Commit),
     );
     #[cfg(not(feature = "render"))]
     app.add_systems(
         PreUpdate,
-        primary_window_input_system.in_set(ImguiInputSystems),
+        primary_window_input_system.in_set(ImguiInputPipelineSystems::Commit),
+    );
+}
+
+pub(crate) fn add_input_producers<M>(
+    app: &mut App,
+    systems: impl IntoScheduleConfigs<bevy_ecs::system::ScheduleSystem, M>,
+) {
+    app.add_systems(
+        PreUpdate,
+        systems.in_set(ImguiInputPipelineSystems::Producers),
     );
 }
 

--- a/backends/dear-imgui-bevy/src/input/primary.rs
+++ b/backends/dear-imgui-bevy/src/input/primary.rs
@@ -39,7 +39,7 @@ pub(crate) fn primary_window_input_system(
         discard_all_unread_messages(&mut messages);
         return;
     };
-    let Some(primary_id) = contexts.primary_id() else {
+    let Ok(Some(primary_id)) = contexts.primary_id() else {
         *capture = ImguiInputCapture::default();
         discard_all_unread_messages(&mut messages);
         return;

--- a/backends/dear-imgui-bevy/src/input/route.rs
+++ b/backends/dear-imgui-bevy/src/input/route.rs
@@ -6,7 +6,7 @@ use bevy_ecs::prelude::{Entity, Resource};
 use bevy_math::{Rect, Vec2};
 use dear_imgui_rs::{self as imgui, ContextId};
 
-use crate::route::ImguiInputPolicy;
+use crate::route::{ImguiInputPolicy, ImguiRenderRouteEpoch};
 
 #[cfg(test)]
 use super::ImguiInputWindowState;
@@ -19,34 +19,75 @@ pub(crate) struct ImguiInputFrameMetrics {
     pub(crate) framebuffer_scale: [f32; 2],
 }
 
-#[derive(Resource, Clone, Debug, Default)]
-pub(crate) struct ImguiContextInputMetrics {
-    /// Resolver epoch whose input routes produced `contexts`.
-    epoch: u64,
+/// A complete input transaction prepared for one Dear ImGui driver run.
+///
+/// The transaction intentionally has no `Default` or `Clone` implementation.  A producer must
+/// publish the route snapshot, Context metrics, and platform-feedback authority together, and the
+/// driver consumes that publication exactly once. This prevents a route epoch from being paired
+/// with metrics or cursor/IME permissions from a different schedule run and prevents a missed
+/// input schedule from replaying the previous frame.
+#[derive(Debug)]
+pub(crate) struct ImguiFrameInput {
+    routes: ImguiRenderRouteEpoch,
     contexts: HashMap<ContextId, ImguiInputFrameMetrics>,
+    platform_feedback_hosts: HashMap<ContextId, Entity>,
 }
 
-impl ImguiContextInputMetrics {
-    pub(crate) const fn epoch(&self) -> u64 {
-        self.epoch
+impl ImguiFrameInput {
+    pub(crate) fn new(
+        routes: ImguiRenderRouteEpoch,
+        contexts: HashMap<ContextId, ImguiInputFrameMetrics>,
+        platform_feedback_hosts: HashMap<ContextId, Entity>,
+    ) -> Self {
+        Self {
+            routes,
+            contexts,
+            platform_feedback_hosts,
+        }
+    }
+
+    pub(crate) const fn render_routes(&self) -> &ImguiRenderRouteEpoch {
+        &self.routes
     }
 
     pub(crate) fn get(&self, context_id: ContextId) -> Option<ImguiInputFrameMetrics> {
         self.contexts.get(&context_id).copied()
     }
 
-    pub(super) fn replace(
-        &mut self,
-        epoch: u64,
-        contexts: HashMap<ContextId, ImguiInputFrameMetrics>,
-    ) {
-        self.epoch = epoch;
-        self.contexts = contexts;
+    pub(crate) fn platform_feedback_host(&self, context_id: ContextId) -> Option<Entity> {
+        self.platform_feedback_hosts.get(&context_id).copied()
+    }
+}
+
+#[derive(Debug, Default, Resource)]
+pub(crate) struct ImguiFrameInputSlot {
+    ready: Option<ImguiFrameInput>,
+    #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
+    latest_hosts: HashMap<ContextId, Entity>,
+}
+
+impl ImguiFrameInputSlot {
+    pub(crate) fn publish(&mut self, input: ImguiFrameInput) {
+        #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
+        {
+            self.latest_hosts.clear();
+            self.latest_hosts.extend(
+                input
+                    .contexts
+                    .iter()
+                    .map(|(context_id, metrics)| (*context_id, metrics.host_window)),
+            );
+        }
+        self.ready = Some(input);
     }
 
-    #[cfg(test)]
-    pub(crate) fn set_epoch_for_test(&mut self, epoch: u64) {
-        self.epoch = epoch;
+    pub(crate) fn take(&mut self) -> Option<ImguiFrameInput> {
+        self.ready.take()
+    }
+
+    #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
+    pub(crate) fn latest_host(&self, context_id: ContextId) -> Option<Entity> {
+        self.latest_hosts.get(&context_id).copied()
     }
 }
 

--- a/backends/dear-imgui-bevy/src/input/routing.rs
+++ b/backends/dear-imgui-bevy/src/input/routing.rs
@@ -27,8 +27,8 @@ use super::event_ingest::collect_raw_winit_pointer_events;
 use super::event_ingest::{OrderedPointerEvent, append_typed_pointer_event};
 use super::events::{ImguiInputMessageReaders, discard_all_unread_messages};
 use super::route::{
-    ImguiContextInputMetrics, ImguiInputFrameMetrics, ImguiInputSlot, ImguiRoutedWindowState,
-    RoutedInputState, RoutedInputTarget,
+    ImguiFrameInput, ImguiFrameInputSlot, ImguiInputFrameMetrics, ImguiInputSlot,
+    ImguiRoutedWindowState, RoutedInputState, RoutedInputTarget,
 };
 use super::state::{ImguiInputState, ImguiInputWindow};
 
@@ -43,7 +43,7 @@ pub(super) fn routed_window_input_system(
     contexts: Option<NonSendMut<ImguiContexts>>,
     mut input_state: ResMut<ImguiInputState>,
     mut capture: ResMut<ImguiInputCapture>,
-    mut input_metrics: ResMut<ImguiContextInputMetrics>,
+    mut frame_input: ResMut<ImguiFrameInputSlot>,
     mut messages: ImguiInputMessageReaders,
 ) {
     let Some(mut contexts) = contexts else {
@@ -51,11 +51,27 @@ pub(super) fn routed_window_input_system(
         crate::viewport::native_window::release_pointer_capture();
         *input_state = ImguiInputState::default();
         *capture = ImguiInputCapture::default();
-        *input_metrics = ImguiContextInputMetrics::default();
+        frame_input.publish(ImguiFrameInput::new(
+            resolved_routes.render_epoch(),
+            HashMap::new(),
+            HashMap::new(),
+        ));
         discard_all_unread_messages(&mut messages);
         return;
     };
-    let primary_context = contexts.primary_id();
+    let Ok(primary_context) = contexts.primary_id() else {
+        #[cfg(all(feature = "multi-viewport", not(target_arch = "wasm32")))]
+        crate::viewport::native_window::release_pointer_capture();
+        *input_state = ImguiInputState::default();
+        *capture = ImguiInputCapture::default();
+        frame_input.publish(ImguiFrameInput::new(
+            resolved_routes.render_epoch(),
+            HashMap::new(),
+            HashMap::new(),
+        ));
+        discard_all_unread_messages(&mut messages);
+        return;
+    };
     input_state.routed.primary_context = primary_context;
     input_state.routed.primary_window = windows
         .iter()
@@ -115,7 +131,7 @@ pub(super) fn routed_window_input_system(
             continue;
         }
         if primary_window.is_some()
-            || !contexts.contains(context_id)
+            || !matches!(contexts.contains(context_id), Ok(true))
             || !input_enabled_contexts.contains(&context_id)
             || declared_slots.contains(&ImguiInputSlot {
                 context_id,
@@ -159,6 +175,16 @@ pub(super) fn routed_window_input_system(
         .map(|target| (target.context_id, target.host_window))
         .collect::<Vec<_>>();
     capture.begin_routes(primary_context, &capture_routes);
+
+    let mut platform_feedback_hosts = HashMap::new();
+    for target in targets
+        .iter()
+        .filter(|target| !matches!(target.policy, ImguiInputPolicy::Disabled))
+    {
+        platform_feedback_hosts
+            .entry(target.context_id)
+            .or_insert(target.host_window);
+    }
 
     let mut unavailable_contexts = HashSet::new();
     release_stale_routed_input(
@@ -418,7 +444,11 @@ pub(super) fn routed_window_input_system(
         crate::viewport::native_window::release_pointer_capture();
     }
     capture.finish_routes();
-    input_metrics.replace(resolved_routes.epoch(), context_metrics);
+    frame_input.publish(ImguiFrameInput::new(
+        resolved_routes.render_epoch(),
+        context_metrics,
+        platform_feedback_hosts,
+    ));
 }
 
 #[cfg(feature = "render")]

--- a/backends/dear-imgui-bevy/src/input/tests/input.rs
+++ b/backends/dear-imgui-bevy/src/input/tests/input.rs
@@ -151,6 +151,7 @@ fn app_with_primary_window_in(mut app: App, plugin: ImguiPlugin) -> (App, Entity
             .world()
             .non_send::<ImguiContexts>()
             .primary_id()
+            .expect("Context registry must be active")
             .expect("ImguiPlugin should install a primary Context");
         let region = {
             let window = app
@@ -227,6 +228,7 @@ fn configure_primary<T>(app: &mut App, configure: impl FnOnce(&mut imgui::Contex
         .expect("ImguiPlugin should install the Context registry");
     let primary_id = contexts
         .primary_id()
+        .expect("Context registry must be active")
         .expect("ImguiPlugin should install a primary Context");
     contexts
         .configure(primary_id, configure)
@@ -238,6 +240,7 @@ fn primary_context_id(app: &App) -> ContextId {
     app.world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("ImguiPlugin should install a primary Context")
 }
 
@@ -316,6 +319,7 @@ fn routed_input_app() -> (App, ContextId, Entity, Entity) {
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("ImguiPlugin should install a primary Context");
     let mut primary_window = Window {
         resolution: WindowResolution::new(640, 480),
@@ -335,8 +339,9 @@ fn routed_input_app() -> (App, ContextId, Entity, Entity) {
 
 #[cfg(feature = "render")]
 fn add_routed_input_context(app: &mut App) -> (ContextId, ImguiPass<RoutedInputSecondaryUi>) {
-    let pass = app.declare_imgui_pass::<RoutedInputSecondaryUi>();
-    app.add_imgui_systems(&pass, pass.system(empty_routed_input_ui));
+    let pass = app.declare_imgui_pass::<RoutedInputSecondaryUi>().unwrap();
+    app.add_imgui_systems(&pass, pass.system(empty_routed_input_ui))
+        .unwrap();
     let context_id = app
         .world_mut()
         .non_send_mut::<ImguiContexts>()
@@ -772,11 +777,12 @@ fn input_platform_feedback_updates_primary_window_cursor_and_ime_state() {
     let (mut app, primary) = app_with_primary_window();
     app.world_mut().get_mut::<Window>(primary).unwrap().position =
         WindowPosition::At(IVec2::new(100, 150));
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_text_cursor_and_ime::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -822,11 +828,12 @@ fn input_platform_feedback_updates_secondary_viewport_window_cursor_and_ime_stat
             position: Vec2::new(10.0, 20.0),
             delta: None,
         });
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_text_cursor_and_secondary_viewport_ime),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -873,11 +880,12 @@ fn input_platform_feedback_routes_cursor_independently_from_ime_viewport() {
             position: Vec2::new(11.0, 22.0),
             delta: None,
         });
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_primary_cursor_and_secondary_viewport_ime),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -923,11 +931,12 @@ fn input_disabled_route_suppresses_native_viewport_ime() {
         .entity_mut(route.0)
         .insert(route.1.with_policy(ImguiInputPolicy::Disabled));
     app.world_mut().run_schedule(PostUpdate);
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_primary_cursor_and_secondary_viewport_ime),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -976,7 +985,8 @@ fn input_platform_feedback_enables_ime_for_a_focused_secondary_context_route() {
     app.add_imgui_systems(
         &secondary_pass,
         secondary_pass.system(request_text_cursor_and_ime::<RoutedInputSecondaryUi>),
-    );
+    )
+    .unwrap();
 
     app.world_mut()
         .resource_mut::<Messages<WindowFocused>>()
@@ -1047,12 +1057,14 @@ fn input_platform_feedback_follows_the_current_exclusive_pointer_owner() {
         right,
     ));
     resolve_routed_input(&mut app);
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(request_hidden_cursor));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(request_hidden_cursor))
+        .unwrap();
     app.add_imgui_systems(
         &secondary_pass,
         secondary_pass.system(request_text_cursor_only::<RoutedInputSecondaryUi>),
-    );
+    )
+    .unwrap();
 
     app.world_mut()
         .resource_mut::<Messages<CursorMoved>>()
@@ -1113,11 +1125,12 @@ fn input_platform_feedback_targets_input_host_independently_of_render_host() {
         input_region,
     ));
     resolve_routed_input(&mut app);
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_text_cursor_only::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     app.world_mut()
         .resource_mut::<Messages<CursorMoved>>()
         .write(CursorMoved {
@@ -1162,11 +1175,12 @@ fn input_platform_feedback_does_not_enable_ime_for_a_disabled_route() {
             .with_policy(ImguiInputPolicy::Disabled),
     );
     resolve_routed_input(&mut app);
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_text_cursor_and_ime::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -1207,11 +1221,12 @@ fn input_platform_feedback_ignores_render_only_context_without_hover_ownership()
     app.world_mut()
         .spawn(ImguiRenderRoute::new(secondary_context, camera));
     resolve_routed_input(&mut app);
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_text_cursor_and_ime::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     app.world_mut()
         .resource_mut::<Messages<CursorMoved>>()
         .write(CursorMoved {
@@ -1248,8 +1263,9 @@ fn input_platform_feedback_hides_os_cursor_when_imgui_draws_software_cursor() {
     app.world_mut()
         .entity_mut(primary)
         .insert(CursorIcon::from(SystemCursorIcon::Pointer));
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(request_software_cursor));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(request_software_cursor))
+        .unwrap();
 
     app.update();
 
@@ -1269,8 +1285,9 @@ fn input_platform_feedback_hides_os_cursor_when_imgui_requests_no_cursor() {
     app.world_mut()
         .entity_mut(primary)
         .insert(CursorIcon::from(SystemCursorIcon::Pointer));
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(request_hidden_cursor));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(request_hidden_cursor))
+        .unwrap();
 
     app.update();
 
@@ -1290,8 +1307,9 @@ fn input_platform_feedback_restores_cursor_on_previous_hovered_window() {
     let fixture =
         create_native_viewport_window(&mut app, imgui::Id::from(0x503), Window::default());
     let secondary = fixture.window();
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(request_software_cursor));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(request_software_cursor))
+        .unwrap();
 
     app.world_mut()
         .resource_mut::<Messages<CursorMoved>>()
@@ -1959,11 +1977,12 @@ fn input_equal_viewport_ids_remain_scoped_to_their_context_windows() {
     let _guard = imgui_context_guard();
     let (mut app, primary_host) = app_with_primary_window_and_native_viewports();
     let primary_context = primary_context_id(&app);
-    let secondary_pass = app.declare_imgui_pass::<RoutedInputSecondaryUi>();
+    let secondary_pass = app.declare_imgui_pass::<RoutedInputSecondaryUi>().unwrap();
     app.add_imgui_systems(
         &secondary_pass,
         secondary_pass.system(empty_routed_input_ui),
-    );
+    )
+    .unwrap();
     let secondary_context = app
         .world_mut()
         .non_send_mut::<ImguiContexts>()
@@ -2566,6 +2585,7 @@ fn primary_capture_queries_follow_legacy_primary_input_without_render_routes() {
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("ImguiPlugin should install a primary Context");
     configure_primary(&mut app, |_| unsafe {
         let io = imgui::sys::igGetIO_Nil();
@@ -3365,11 +3385,12 @@ fn capture_decision_remains_stable_for_the_input_batch_that_update_consumes() {
     ));
     resolve_routed_input(&mut app);
 
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(request_pointer_capture_next_frame),
-    );
+    )
+    .unwrap();
     app.init_resource::<ScopedCaptureRunCount>().add_systems(
         Update,
         count_scoped_capture.run_if(imgui_context_wants_pointer_input(primary_context)),

--- a/backends/dear-imgui-bevy/src/lib.rs
+++ b/backends/dear-imgui-bevy/src/lib.rs
@@ -23,8 +23,12 @@
 //!     .add_systems(Startup, |mut commands: Commands| {
 //!         commands.spawn(Camera2d);
 //!     });
-//! let primary_pass = app.imgui_primary_pass();
-//! app.add_imgui_systems(&primary_pass, primary_pass.system(draw_ui)).run();
+//! let primary_pass = app
+//!     .imgui_primary_pass()
+//!     .expect("the private pass registry must be active");
+//! app.add_imgui_systems(&primary_pass, primary_pass.system(draw_ui))
+//!     .expect("the system must be bound to this App and pass");
+//! app.run();
 //! ```
 //!
 //! Advanced targets use explicit render and input route entities:
@@ -38,7 +42,10 @@
 //!     contexts: NonSend<ImguiContexts>,
 //!     cameras: Query<Entity, With<Camera>>,
 //! ) {
-//!     let context = contexts.primary_id().expect("the plugin installs a primary Context");
+//!     let context = contexts
+//!         .primary_id()
+//!         .expect("the Context registry must be active")
+//!         .expect("the plugin installs a primary Context");
 //!     let camera = cameras.single().expect("this example has one camera");
 //!     commands.spawn((
 //!         ImguiRenderRoute::new(context, camera),
@@ -83,6 +90,10 @@
 //! use dear_imgui_bevy::input::{ImguiInputState, primary_window_input_system};
 //! ```
 //!
+//! ```compile_fail
+//! use dear_imgui_bevy::input::ImguiInputSystems;
+//! ```
+//!
 //! Native viewport markers are read through accessors rather than copied or field-projected:
 //!
 //! ```compile_fail
@@ -114,8 +125,9 @@ pub use self::context::ImguiRendererOwnershipError;
 pub use self::context::{
     ImguiAppExt, ImguiContextAdmissionError, ImguiContextConfig, ImguiContextError,
     ImguiContextRemovalPendingReason, ImguiContextRetired, ImguiContextRetirementId,
-    ImguiContextScopeError, ImguiContexts, ImguiFrame, ImguiPass, ImguiPlugin, ImguiPluginConfig,
-    ImguiPluginInstallError, ImguiPrimaryChange, ImguiPrimaryPass, ImguiShutdownError, ImguiSystem,
+    ImguiContextScopeError, ImguiContexts, ImguiFrame, ImguiPass, ImguiPassError, ImguiPlugin,
+    ImguiPluginConfig, ImguiPluginInstallError, ImguiPrimaryChange, ImguiPrimaryPass,
+    ImguiShutdownError, ImguiSystemConfigs, IntoImguiSystemConfigs,
 };
 #[cfg(feature = "render")]
 pub use self::render::ImguiRenderSystems;

--- a/backends/dear-imgui-bevy/src/prelude.rs
+++ b/backends/dear-imgui-bevy/src/prelude.rs
@@ -3,15 +3,15 @@
 pub use crate::context::{
     ImguiAppExt, ImguiContextAdmissionError, ImguiContextConfig, ImguiContextError,
     ImguiContextRetired, ImguiContextRetirementId, ImguiContexts, ImguiFrame, ImguiPass,
-    ImguiPluginInstallError, ImguiPrimaryChange, ImguiPrimaryPass, ImguiShutdownError, ImguiSystem,
+    ImguiPassError, ImguiPluginInstallError, ImguiPrimaryChange, ImguiPrimaryPass,
+    ImguiShutdownError, ImguiSystemConfigs, IntoImguiSystemConfigs,
 };
 pub use crate::input::{
-    ImguiInputCapture, ImguiInputCaptureState, ImguiInputSystems,
-    imgui_context_wants_keyboard_input, imgui_context_wants_pointer_input,
-    imgui_context_wants_text_input, imgui_primary_wants_keyboard_input,
-    imgui_primary_wants_pointer_input, imgui_primary_wants_text_input,
-    imgui_window_wants_keyboard_input, imgui_window_wants_pointer_input,
-    imgui_window_wants_text_input,
+    ImguiInputCapture, ImguiInputCaptureState, imgui_context_wants_keyboard_input,
+    imgui_context_wants_pointer_input, imgui_context_wants_text_input,
+    imgui_primary_wants_keyboard_input, imgui_primary_wants_pointer_input,
+    imgui_primary_wants_text_input, imgui_window_wants_keyboard_input,
+    imgui_window_wants_pointer_input, imgui_window_wants_text_input,
 };
 pub use crate::viewport::{
     ImguiViewportCamera, ImguiViewportId, ImguiViewportInstanceId, ImguiViewportWindow,

--- a/backends/dear-imgui-bevy/src/render/mod.rs
+++ b/backends/dear-imgui-bevy/src/render/mod.rs
@@ -392,7 +392,7 @@ mod tests {
         app.add_plugins(bevy_render::extract_plugin::ExtractPlugin::default());
         app.sub_app_mut(RenderApp).update_schedule = Some(Render.intern());
         app.add_plugins(crate::ImguiPlugin::default());
-        let recovery_pass = app.declare_imgui_pass::<RecoveryContextPass>();
+        let recovery_pass = app.declare_imgui_pass::<RecoveryContextPass>().unwrap();
         app.world_mut().spawn((Window::default(), PrimaryWindow));
 
         let (context_a, context_b) = {
@@ -400,7 +400,7 @@ mod tests {
                 .world_mut()
                 .get_non_send_mut::<crate::ImguiContexts>()
                 .unwrap();
-            let context_a = contexts.primary_id().unwrap();
+            let context_a = contexts.primary_id().unwrap().unwrap();
             let context_b = contexts
                 .create(crate::ImguiContextConfig::new(&recovery_pass))
                 .unwrap();
@@ -482,6 +482,7 @@ mod tests {
             .get_non_send::<crate::ImguiContexts>()
             .unwrap()
             .primary_id()
+            .unwrap()
             .unwrap();
         let releases = app.world().resource::<ImguiRendererReleases>().clone();
 
@@ -506,6 +507,7 @@ mod tests {
             .get_non_send::<crate::ImguiContexts>()
             .unwrap()
             .primary_id()
+            .unwrap()
             .unwrap();
         let viewport_id = imgui::Id::from(0xA11);
         assert!(
@@ -555,7 +557,8 @@ mod tests {
             app.world()
                 .get_non_send::<crate::ImguiContexts>()
                 .unwrap()
-                .contains(primary_id),
+                .contains(primary_id)
+                .unwrap(),
             "a pending removal must retain Context ownership for retry"
         );
         let requested = releases.requested_releases();
@@ -611,7 +614,8 @@ mod tests {
             !app.world()
                 .get_non_send::<crate::ImguiContexts>()
                 .unwrap()
-                .contains(primary_id),
+                .contains(primary_id)
+                .unwrap(),
             "a completed retry must remove exactly the requested Context"
         );
     }
@@ -1273,6 +1277,7 @@ mod tests {
             .get_non_send::<crate::ImguiContexts>()
             .expect("ImguiPlugin should install the Context registry")
             .primary_id()
+            .expect("Context registry must be active")
             .expect("ImguiPlugin should install the primary Context");
         app.world_mut()
             .get_non_send_mut::<crate::ImguiContexts>()

--- a/backends/dear-imgui-bevy/src/render/tests/render_extract.rs
+++ b/backends/dear-imgui-bevy/src/render/tests/render_extract.rs
@@ -52,6 +52,7 @@ fn primary_context_id(app: &App) -> imgui::ContextId {
     app.world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("ImguiPlugin should install a primary Context")
 }
 
@@ -62,6 +63,7 @@ fn configure_primary<T>(app: &mut App, configure: impl FnOnce(&mut imgui::Contex
         .expect("ImguiPlugin should install the Context registry");
     let primary_id = contexts
         .primary_id()
+        .expect("Context registry must be active")
         .expect("ImguiPlugin should install a primary Context");
     contexts
         .configure(primary_id, configure)
@@ -69,11 +71,12 @@ fn configure_primary<T>(app: &mut App, configure: impl FnOnce(&mut imgui::Contex
 }
 
 fn add_secondary_context(app: &mut App) -> imgui::ContextId {
-    let secondary_pass = app.declare_imgui_pass::<SecondaryContextPass>();
+    let secondary_pass = app.declare_imgui_pass::<SecondaryContextPass>().unwrap();
     app.add_imgui_systems(
         &secondary_pass,
         secondary_pass.system(draw_secondary_legacy_texture),
-    );
+    )
+    .unwrap();
     let secondary_id = app
         .world_mut()
         .non_send_mut::<ImguiContexts>()
@@ -277,8 +280,9 @@ fn draw_secondary_legacy_texture(frame: ImguiFrame<'_, SecondaryContextPass>) {
 }
 
 fn add_primary_legacy_draw_system(app: &mut App) {
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(draw_legacy_texture));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(draw_legacy_texture))
+        .unwrap();
 }
 
 #[test]
@@ -286,8 +290,9 @@ fn render_extract_moves_context_owned_managed_frame_and_commits_once() {
     let _guard = imgui_context_guard();
     let (mut app, primary_window, camera, texture_id) = app_with_primary_window();
     let context_id = primary_context_id(&app);
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(draw_managed_texture));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(draw_managed_texture))
+        .unwrap();
 
     app.update();
 
@@ -709,6 +714,7 @@ fn render_extract_prefers_an_explicit_route_over_auto_primary() {
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("the primary Context should exist");
     let primary_target =
         NormalizedRenderTarget::Window(WindowRef::Entity(primary_window).normalize(None).unwrap());
@@ -778,6 +784,7 @@ fn render_extract_preserves_explicit_route_viewport_for_render_pass() {
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("the primary Context should exist");
     let primary_target =
         NormalizedRenderTarget::Window(WindowRef::Entity(primary_window).normalize(None).unwrap());
@@ -981,6 +988,7 @@ fn render_extract_reports_a_stale_render_view_without_retargeting() {
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("the primary Context should exist");
     let primary_target =
         NormalizedRenderTarget::Window(WindowRef::Entity(primary_window).normalize(None).unwrap());
@@ -1046,6 +1054,7 @@ fn render_extract_rejects_output_mode_and_schedule_drift_after_route_resolution(
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("the primary Context should exist");
     let primary_target =
         NormalizedRenderTarget::Window(WindowRef::Entity(primary_window).normalize(None).unwrap());
@@ -1121,6 +1130,7 @@ fn render_extract_reports_a_missing_render_view_without_replaying_an_old_target(
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("the primary Context should exist");
     let missing_camera = app
         .world_mut()
@@ -1212,7 +1222,7 @@ fn renderer_prepare_routes_secondary_viewport_and_rejects_relocated_camera_marke
     });
 
     app.init_resource::<SecondaryViewportRouteState>();
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(
@@ -1237,7 +1247,8 @@ fn renderer_prepare_routes_secondary_viewport_and_rejects_relocated_camera_marke
                     });
             },
         ),
-    );
+    )
+    .unwrap();
 
     app.update();
     let secondary_viewport_id = app

--- a/backends/dear-imgui-bevy/src/render/tests/texture.rs
+++ b/backends/dear-imgui-bevy/src/render/tests/texture.rs
@@ -85,6 +85,7 @@ fn app_with_render_world() -> App {
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
     app.world_mut()
         .get_non_send_mut::<ImguiContexts>()
@@ -144,6 +145,7 @@ fn register_managed_texture(app: &mut App) -> imgui::ManagedTextureId {
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
     let texture_id = app
         .world_mut()
@@ -205,8 +207,9 @@ fn managed_texture_create_request_repeats_after_gpu_retry() {
     let mut app = app_with_render_world();
     let texture_id = register_managed_texture(&mut app);
     let primary_id = texture_id.context_id();
-    let primary_pass = app.imgui_primary_pass();
-    app.add_imgui_systems(&primary_pass, primary_pass.system(draw_managed_texture));
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    app.add_imgui_systems(&primary_pass, primary_pass.system(draw_managed_texture))
+        .unwrap();
 
     app.update();
 
@@ -275,14 +278,15 @@ fn managed_texture_create_request_repeats_after_gpu_retry() {
 fn managed_texture_requests_and_lifecycles_are_isolated_by_context() {
     let _guard = imgui_context_guard();
     let mut app = app_with_render_world();
-    let primary_pass = app.imgui_primary_pass();
-    let secondary_pass = app.declare_imgui_pass::<SecondaryUi>();
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    let secondary_pass = app.declare_imgui_pass::<SecondaryUi>().unwrap();
 
     let primary_id = app
         .world()
         .get_non_send::<ImguiContexts>()
         .unwrap()
         .primary_id()
+        .unwrap()
         .unwrap();
     let secondary_id = app
         .world_mut()
@@ -326,11 +330,13 @@ fn managed_texture_requests_and_lifecycles_are_isolated_by_context() {
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_context_managed_texture::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     app.add_imgui_systems(
         &secondary_pass,
         secondary_pass.system(draw_context_managed_texture::<SecondaryUi>),
-    );
+    )
+    .unwrap();
 
     let camera = {
         let world = app.world_mut();
@@ -504,11 +510,12 @@ fn bevy_image_leases_register_as_stable_imgui_texture_ids_and_extract() {
     assert!(texture.is_strong());
     drop(registered_again);
     app.insert_resource(BevyImageTexture { texture });
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_bevy_image::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -535,14 +542,15 @@ fn bevy_image_leases_register_as_stable_imgui_texture_ids_and_extract() {
 fn one_bevy_image_lease_can_draw_from_two_contexts() {
     let _guard = imgui_context_guard();
     let mut app = app_with_render_world();
-    let primary_pass = app.imgui_primary_pass();
-    let secondary_pass = app.declare_imgui_pass::<SecondaryUi>();
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    let secondary_pass = app.declare_imgui_pass::<SecondaryUi>().unwrap();
 
     let primary_id = app
         .world()
         .get_non_send::<ImguiContexts>()
         .expect("ImguiPlugin should install the primary Context")
         .primary_id()
+        .expect("Context registry must be active")
         .expect("ImguiPlugin should create the primary Context");
     let secondary_id = app
         .world_mut()
@@ -569,11 +577,13 @@ fn one_bevy_image_lease_can_draw_from_two_contexts() {
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_bevy_image::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
     app.add_imgui_systems(
         &secondary_pass,
         secondary_pass.system(draw_bevy_image::<SecondaryUi>),
-    );
+    )
+    .unwrap();
 
     let camera = {
         let world = app.world_mut();
@@ -697,11 +707,12 @@ fn weak_bevy_image_leases_use_the_fallback_and_publish_a_recoverable_diagnostic(
     let texture_id = texture.id();
     assert!(texture.is_weak());
     app.insert_resource(BevyImageTexture { texture });
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_bevy_image::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
 
     app.update();
 
@@ -758,11 +769,12 @@ fn a_lease_dropped_during_ui_submission_survives_the_in_flight_snapshot() {
         .register_weak(AssetId::<Image>::invalid());
     let texture_id = texture.id();
     app.insert_resource(OneShotBevyImageTexture(Some(texture)));
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_and_release_bevy_image),
-    );
+    )
+    .unwrap();
 
     app.update();
     assert!(
@@ -841,11 +853,12 @@ fn render_target_texture_images_can_be_registered_and_drawn_as_imgui_viewports()
         .expect("Assets::add should return a retaining Bevy handle");
     let texture_id = texture.id();
     app.insert_resource(BevyImageTexture { texture });
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_bevy_image::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
 
     app.update();
 

--- a/backends/dear-imgui-bevy/src/route/resolver.rs
+++ b/backends/dear-imgui-bevy/src/route/resolver.rs
@@ -101,7 +101,8 @@ pub(super) fn resolve_imgui_routes(
     let registered_contexts = params
         .contexts
         .as_deref()
-        .map(|contexts| contexts.ids().collect::<HashSet<_>>())
+        .and_then(|contexts| contexts.ids().ok())
+        .map(|ids| ids.collect::<HashSet<_>>())
         .unwrap_or_default();
     let mut cameras = params
         .cameras
@@ -140,7 +141,7 @@ pub(super) fn resolve_imgui_routes(
         primary_context: params
             .contexts
             .as_deref()
-            .and_then(ImguiContexts::primary_id),
+            .and_then(|contexts| contexts.primary_id().ok().flatten()),
         primary_windows: &primary_windows,
         windows: &windows,
         images,

--- a/backends/dear-imgui-bevy/src/route/tests/routing.rs
+++ b/backends/dear-imgui-bevy/src/route/tests/routing.rs
@@ -41,11 +41,12 @@ fn primary_context(app: &App) -> dear_imgui_bevy::ContextId {
     app.world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("test registry must remain active")
         .expect("test registry must retain its primary Context")
 }
 
 fn add_secondary_context(app: &mut App) -> dear_imgui_bevy::ContextId {
-    let pass = app.declare_imgui_pass::<SecondaryUi>();
+    let pass = app.declare_imgui_pass::<SecondaryUi>().unwrap();
     app.world_mut()
         .non_send_mut::<ImguiContexts>()
         .create(ImguiContextConfig::new(&pass))

--- a/backends/dear-imgui-bevy/src/viewport/ecs.rs
+++ b/backends/dear-imgui-bevy/src/viewport/ecs.rs
@@ -740,7 +740,7 @@ pub(super) fn cleanup_secondary_viewports_when_host_is_unavailable(
     host_queries: SecondaryViewportHostQueries,
     contexts: Option<NonSendMut<crate::ImguiContexts>>,
     bridge: NonSend<ImguiViewportBridge>,
-    #[cfg(feature = "render")] input_metrics: Res<crate::input::ImguiContextInputMetrics>,
+    #[cfg(feature = "render")] frame_input: Res<crate::input::ImguiFrameInputSlot>,
     #[cfg(feature = "render")] resolved_routes: Res<crate::route::ImguiResolvedRoutes>,
 ) {
     let Some(mut contexts) = contexts else {
@@ -753,7 +753,7 @@ pub(super) fn cleanup_secondary_viewports_when_host_is_unavailable(
         .map(|event| event.window)
         .collect::<HashSet<_>>();
     #[cfg(feature = "render")]
-    let primary_context = contexts.primary_id();
+    let primary_context = contexts.primary_id().ok().flatten();
 
     for context_bridge in bridge.contexts() {
         let context_id = context_bridge.context_id;
@@ -766,11 +766,7 @@ pub(super) fn cleanup_secondary_viewports_when_host_is_unavailable(
                     .input_route(context_id)
                     .map(crate::route::ImguiResolvedInputRoute::host_window)
             })
-            .or_else(|| {
-                input_metrics
-                    .get(context_id)
-                    .map(|metrics| metrics.host_window)
-            })
+            .or_else(|| frame_input.latest_host(context_id))
             .or_else(|| {
                 (Some(context_id) == primary_context)
                     .then_some(primary_window)

--- a/backends/dear-imgui-bevy/src/viewport/runtime.rs
+++ b/backends/dear-imgui-bevy/src/viewport/runtime.rs
@@ -733,7 +733,8 @@ pub(crate) fn install_viewport_bridge(app: &mut App) {
         app.add_message::<WindowOccluded>();
         app.add_systems(
             PreUpdate,
-            sync_os_viewport_lifecycle_events.before(crate::input::ImguiInputSystems),
+            sync_os_viewport_lifecycle_events
+                .in_set(crate::input::ImguiInputPipelineSystems::PlatformLifecycle),
         );
         app.add_systems(
             crate::schedule::ImguiContextDriver,

--- a/backends/dear-imgui-bevy/src/viewport/tests/viewport.rs
+++ b/backends/dear-imgui-bevy/src/viewport/tests/viewport.rs
@@ -99,8 +99,9 @@ fn empty_secondary_viewport_ui(_frame: ImguiFrame<'_, SecondaryViewportPass>) {}
 
 #[cfg(feature = "multi-viewport")]
 fn declare_secondary_viewport_pass(app: &mut App) -> ImguiPass<SecondaryViewportPass> {
-    let pass = app.declare_imgui_pass::<SecondaryViewportPass>();
-    app.add_imgui_systems(&pass, pass.system(empty_secondary_viewport_ui));
+    let pass = app.declare_imgui_pass::<SecondaryViewportPass>().unwrap();
+    app.add_imgui_systems(&pass, pass.system(empty_secondary_viewport_ui))
+        .unwrap();
     pass
 }
 
@@ -191,6 +192,7 @@ fn primary_context_id(app: &App) -> imgui::ContextId {
         .get_non_send::<ImguiContexts>()
         .expect("plugin should install the ImGui Context registry")
         .primary_id()
+        .expect("ImGui Context registry must be active")
         .expect("plugin should install a primary ImGui Context")
 }
 
@@ -250,7 +252,7 @@ fn additional_context_can_enable_native_viewports_when_primary_does_not() {
 
     let (primary_id, secondary_id) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let primary_id = contexts.primary_id().unwrap();
+        let primary_id = contexts.primary_id().unwrap().unwrap();
         let secondary_id = contexts
             .create(ImguiContextConfig::new(&secondary_pass).with_multi_viewport(true))
             .expect("native viewport infrastructure should be available per Context");
@@ -455,11 +457,12 @@ fn create_live_secondary_viewport(app: &mut App) -> (imgui::Id, Entity) {
         context.io_mut().set_config_viewports_no_auto_merge(true);
     });
     app.insert_resource(SubmitLiveSecondaryViewport(true));
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(submit_live_secondary_viewport),
-    );
+    )
+    .unwrap();
     // NoAutoMerge makes the UI window deterministically request its own native viewport. The
     // first frame creates it; the second lets Dear ImGui publish the platform window mapping.
     app.update();

--- a/backends/dear-imgui-bevy/tests/plugin.rs
+++ b/backends/dear-imgui-bevy/tests/plugin.rs
@@ -76,8 +76,9 @@ fn plugin_registers_the_primary_registry_and_private_driver_schedule() {
         .expect("plugin must install a non-send Context registry");
     let primary = contexts
         .primary_id()
+        .expect("default registry must be active")
         .expect("default registry needs a primary");
-    assert_eq!(contexts.ids().collect::<Vec<_>>(), vec![primary]);
+    assert_eq!(contexts.ids().unwrap().collect::<Vec<_>>(), vec![primary]);
 
     let schedules = app.world().resource::<Schedules>();
     assert!(
@@ -102,7 +103,9 @@ fn fallible_installation_registers_the_plugin_and_rejects_a_duplicate_transactio
     let primary = app
         .world()
         .get_non_send::<ImguiContexts>()
-        .and_then(ImguiContexts::primary_id)
+        .expect("successful installation must retain its Context registry")
+        .primary_id()
+        .expect("successful installation must retain an active Context registry")
         .expect("successful installation must retain its primary Context");
 
     let error = install_error(
@@ -115,7 +118,9 @@ fn fallible_installation_registers_the_plugin_and_rejects_a_duplicate_transactio
     assert_eq!(
         app.world()
             .get_non_send::<ImguiContexts>()
-            .and_then(ImguiContexts::primary_id),
+            .expect("duplicate validation must preserve the Context registry")
+            .primary_id()
+            .expect("duplicate validation must preserve an active registry"),
         Some(primary),
         "duplicate validation must leave the installed registry unchanged"
     );
@@ -261,7 +266,7 @@ fn fallible_installation_rejects_unavailable_native_viewports_before_app_mutatio
 fn plugin_adopts_an_app_scoped_registry_without_replacing_its_primary_context() {
     let _guard = imgui_context_guard();
     let mut app = App::new();
-    let additional_pass = app.declare_imgui_pass::<AdditionalPass>();
+    let additional_pass = app.declare_imgui_pass::<AdditionalPass>().unwrap();
     let primary = dear_imgui_rs::SuspendedContext::create();
     let primary_id = primary.id();
     app.adopt_imgui_primary_context(primary).unwrap();
@@ -276,9 +281,9 @@ fn plugin_adopts_an_app_scoped_registry_without_replacing_its_primary_context() 
     app.add_plugins(ImguiPlugin::new(config));
 
     let contexts = app.world().get_non_send::<ImguiContexts>().unwrap();
-    assert_eq!(contexts.primary_id(), Some(primary_id));
+    assert_eq!(contexts.primary_id().unwrap(), Some(primary_id));
     assert_eq!(
-        contexts.ids().collect::<Vec<_>>(),
+        contexts.ids().unwrap().collect::<Vec<_>>(),
         vec![primary_id, additional_id]
     );
     let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
@@ -329,7 +334,8 @@ fn removing_a_context_clears_only_backend_state_owned_by_bevy() {
         app.world()
             .get_non_send::<ImguiContexts>()
             .unwrap()
-            .primary_id(),
+            .primary_id()
+            .unwrap(),
         None
     );
 }
@@ -375,7 +381,7 @@ fn app_with_render_schedule() -> App {
 fn managed_shared_font_atlas_admission_fails_before_backend_fields_are_mutated() {
     let _guard = imgui_context_guard();
     let mut app = app_with_render_schedule();
-    let additional_pass = app.declare_imgui_pass::<AdditionalPass>();
+    let additional_pass = app.declare_imgui_pass::<AdditionalPass>().unwrap();
     let atlas = dear_imgui_rs::SharedFontAtlas::create();
     let primary =
         dear_imgui_rs::SuspendedContext::try_create_with_shared_font_atlas(atlas.clone()).unwrap();
@@ -431,7 +437,7 @@ fn managed_shared_font_atlas_admission_fails_before_backend_fields_are_mutated()
 fn later_renderer_admission_failure_leaves_earlier_font_atlas_unclaimed() {
     let _guard = imgui_context_guard();
     let mut app = app_with_render_schedule();
-    let additional_pass = app.declare_imgui_pass::<AdditionalPass>();
+    let additional_pass = app.declare_imgui_pass::<AdditionalPass>().unwrap();
     let primary_atlas = dear_imgui_rs::SharedFontAtlas::create();
     let primary =
         dear_imgui_rs::SuspendedContext::try_create_with_shared_font_atlas(primary_atlas.clone())
@@ -502,20 +508,21 @@ fn later_renderer_admission_failure_leaves_earlier_font_atlas_unclaimed() {
 fn renderer_ownership_drift_fails_closed_and_removal_can_be_repaired() {
     let _guard = imgui_context_guard();
     let mut app = app_with_render_schedule();
-    let additional_pass = app.declare_imgui_pass::<AdditionalPass>();
+    let additional_pass = app.declare_imgui_pass::<AdditionalPass>().unwrap();
     app.world_mut().spawn((Window::default(), PrimaryWindow));
     app.init_resource::<UiErrorTrace>();
     app.add_imgui_systems(
         &additional_pass,
         additional_pass.system(observe_additional_context),
-    );
+    )
+    .unwrap();
     app.add_plugins(ImguiPlugin::default());
     let stale = dear_imgui_rs::SuspendedContext::create();
     let stale_id = stale.id();
     drop(stale);
     let (primary_id, additional_id) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let primary_id = contexts.primary_id().unwrap();
+        let primary_id = contexts.primary_id().unwrap().unwrap();
         let additional_id = contexts
             .create(ImguiContextConfig::new(&additional_pass))
             .unwrap();
@@ -659,12 +666,12 @@ fn renderer_ownership_drift_fails_closed_and_removal_can_be_repaired() {
 fn renderer_ownership_drift_blocks_shutdown_before_registry_removal_and_can_be_repaired() {
     let _guard = imgui_context_guard();
     let mut app = app_with_render_schedule();
-    let additional_pass = app.declare_imgui_pass::<AdditionalPass>();
+    let additional_pass = app.declare_imgui_pass::<AdditionalPass>().unwrap();
     app.world_mut().spawn((Window::default(), PrimaryWindow));
     app.add_plugins(ImguiPlugin::default());
     let (primary_id, additional_id) = {
         let mut contexts = app.world_mut().get_non_send_mut::<ImguiContexts>().unwrap();
-        let primary_id = contexts.primary_id().unwrap();
+        let primary_id = contexts.primary_id().unwrap().unwrap();
         let additional_id = contexts
             .create(ImguiContextConfig::new(&additional_pass))
             .unwrap();
@@ -704,6 +711,7 @@ fn renderer_ownership_drift_blocks_shutdown_before_registry_removal_and_can_be_r
             .get_non_send::<ImguiContexts>()
             .unwrap()
             .ids()
+            .unwrap()
             .collect::<Vec<_>>(),
         vec![primary_id, additional_id],
         "a later Context failure must preserve every preflighted Context"

--- a/backends/dear-imgui-bevy/tests/render_composition.rs
+++ b/backends/dear-imgui-bevy/tests/render_composition.rs
@@ -148,7 +148,10 @@ fn post_process_and_imgui_pixels_coexist_across_camera_msaa_and_hdr_modes() {
 
     {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
-        let primary = contexts.primary_id().expect("primary Context must exist");
+        let primary = contexts
+            .primary_id()
+            .expect("Context registry must be active")
+            .expect("primary Context must exist");
         contexts
             .configure(primary, |context| {
                 let _ = context.set_ini_filename::<std::path::PathBuf>(None);
@@ -331,16 +334,18 @@ fn multiple_contexts_compose_in_route_order_on_one_camera() {
     .init_resource::<CompositionReadbacks>()
     .add_observer(collect_readback);
 
-    let primary_pass = app.imgui_primary_pass();
-    let secondary_pass = app.declare_imgui_pass::<SameCameraSecondaryPass>();
+    let primary_pass = app.imgui_primary_pass().unwrap();
+    let secondary_pass = app.declare_imgui_pass::<SameCameraSecondaryPass>().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_primary_context_fixture),
     )
-    .add_imgui_systems(
+    .unwrap();
+    app.add_imgui_systems(
         &secondary_pass,
         secondary_pass.system(draw_secondary_context_fixture),
-    );
+    )
+    .unwrap();
 
     app.world_mut().spawn((
         Window {
@@ -352,7 +357,10 @@ fn multiple_contexts_compose_in_route_order_on_one_camera() {
 
     let (primary, secondary) = {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
-        let primary = contexts.primary_id().expect("primary Context must exist");
+        let primary = contexts
+            .primary_id()
+            .expect("Context registry must be active")
+            .expect("primary Context must exist");
         contexts
             .configure(primary, |context| {
                 let _ = context.set_ini_filename::<std::path::PathBuf>(None);
@@ -443,11 +451,12 @@ fn render_ui_order(order: ImguiUiRenderOrder, expectation: CompositionExpectatio
     .init_resource::<CompositionReadbacks>()
     .add_observer(collect_readback);
 
-    let primary_pass = app.imgui_primary_pass();
+    let primary_pass = app.imgui_primary_pass().unwrap();
     app.add_imgui_systems(
         &primary_pass,
         primary_pass.system(draw_composition_fixture::<ImguiPrimaryPass>),
-    );
+    )
+    .unwrap();
 
     app.world_mut().spawn((
         Window {
@@ -458,7 +467,10 @@ fn render_ui_order(order: ImguiUiRenderOrder, expectation: CompositionExpectatio
     ));
     {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
-        let primary = contexts.primary_id().expect("primary Context must exist");
+        let primary = contexts
+            .primary_id()
+            .expect("Context registry must be active")
+            .expect("primary Context must exist");
         contexts
             .configure(primary, |context| {
                 let _ = context.set_ini_filename::<std::path::PathBuf>(None);
@@ -481,6 +493,7 @@ fn render_ui_order(order: ImguiUiRenderOrder, expectation: CompositionExpectatio
         .world()
         .non_send::<ImguiContexts>()
         .primary_id()
+        .expect("Context registry must be active")
         .expect("primary Context must exist");
     app.world_mut()
         .spawn(ImguiRenderRoute::new(primary, camera));
@@ -593,11 +606,12 @@ fn spawn_case(app: &mut App, kind: CameraKind, msaa: Msaa, hdr: bool) {
         }
         entity.id()
     };
-    let pass = app.declare_imgui_pass::<CompositionPass>();
+    let pass = app.declare_imgui_pass::<CompositionPass>().unwrap();
     app.add_imgui_systems(
         &pass,
         pass.system(draw_composition_fixture::<CompositionPass>),
-    );
+    )
+    .unwrap();
     let context_id = {
         let mut contexts = app.world_mut().non_send_mut::<ImguiContexts>();
         let context_id = contexts

--- a/backends/dear-imgui-sdl3/CHANGELOG.md
+++ b/backends/dear-imgui-sdl3/CHANGELOG.md
@@ -8,10 +8,7 @@ The format follows Keep a Changelog and Semantic Versioning.
 
 ### Changed
 
-- SDL callback applications now enqueue pointer-free `Sdl3CallbackEvent` values through
-  `Sdl3CallbackEventHandoff` and replay them with the owning backend's
-  `process_callback_event`. Queue poisoning and caught callback panics are reported without
-  dropping events that have not been processed.
+- SDL callback applications now call `Sdl3CallbackEventHandoff::drain` and inspect the returned atomic `Sdl3CallbackEventBatch` before replaying retained events with the owning backend's `process_callback_event`; the former `try_drain` and `Sdl3CallbackEventQueue` surface was removed. Every distinct queue fault is retained in observation order, and bounded O(1) state-event coalescing prevents sustained callback traffic from starving ordered input.
 - The official OpenGL3 and SDL_GPU renderer owners now consume `FrameToken` through backend-owned
   viewport transactions. Managed-texture reconciliation, capability-aware secondary-window work,
   and ordered fault collection are no longer assembled from public `consumer`, `reconcile_frame`,

--- a/backends/dear-imgui-sdl3/README.md
+++ b/backends/dear-imgui-sdl3/README.md
@@ -212,10 +212,16 @@ APIs of interest (see `src/lib.rs` for full docs):
 - `Sdl3CallbackEventHandoff` and `process_callback_event(...)`:
   the safe main-callback path. `push_from_callback(...)` is the single unsafe enqueue boundary: it
   copies every transient payload consumed by the official backend, catches callback-path panics,
-  and makes failures available through `try_drain()` without unwinding through SDL's C ABI. Call
-  `try_drain()` on the main thread and pass each owned event directly to the backend owner; a
-  reported fault leaves queued events available for the next iteration. There is no unchecked
-  drain or separate handoff-fault polling path in the normal API.
+  and contains failures without unwinding through SDL's C ABI. Call `drain()` on the main thread,
+  inspect the returned batch's `faults()`, and pass each owned event directly to the backend owner.
+  Callback events not consumed by the official Dear ImGui backend remain observable as inert
+  application summaries without retaining transient SDL pointers.
+  Events and failures are detached atomically, so sustained overflow cannot starve retained input
+  or lifecycle events. The handoff is bounded; high-frequency motion, geometry, and display state
+  is coalesced by native identity while ordered input and lifecycle events retain reserved capacity.
+  `QueueOverflow` reports any event loss without creating another unbounded fault queue. Use
+  `with_capacity(...)` when the default capacity does not match the application's callback cadence.
+  There is no unchecked drain or separate handoff-fault polling path in the normal API.
 - `unsafe process_raw_event(&mut Context, &SDL_Event)`:
   the low-level escape hatch for foreign event loops. Callback-mode applications should use the
   owned handoff instead of reconstructing and replaying the raw union themselves.

--- a/backends/dear-imgui-sdl3/src/callback_events.rs
+++ b/backends/dear-imgui-sdl3/src/callback_events.rs
@@ -1191,7 +1191,7 @@ mod tests {
         assert_eq!(handoff.ordered_reserve, ORDERED_RESERVE);
         let mut model = VecDeque::new();
         let mut dropped_events = 0usize;
-        let mut random = 0x5eed_cafe_d15c_a11u64;
+        let mut random = 0x05ee_dcaf_ed15_ca11_u64;
 
         for timestamp in 0..5_000u64 {
             random = random

--- a/backends/dear-imgui-sdl3/src/callback_events.rs
+++ b/backends/dear-imgui-sdl3/src/callback_events.rs
@@ -4,7 +4,7 @@
 //! remain main-thread-bound. This module copies the exact SDL payloads consumed by the official
 //! backend before the callback returns and defers processing to the main thread.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -27,6 +27,8 @@ use sdl3_sys::keycode::SDLK_ESCAPE;
 #[cfg(test)]
 use sdl3_sys::video::SDL_DisplayID;
 use sdl3_sys::video::SDL_WindowID;
+
+const DEFAULT_CALLBACK_EVENT_CAPACITY: usize = 1024;
 
 fn dispose_panic_payload_without_unwinding(mut payload: Box<dyn std::any::Any + Send>) {
     const MAX_DROP_ATTEMPTS: usize = 8;
@@ -53,6 +55,24 @@ pub enum Sdl3CallbackEventHandoffError {
     /// A previous panic poisoned the event queue.
     #[error("SDL3 callback event queue was poisoned; queued events were recovered")]
     QueuePoisoned,
+    /// The bounded callback queue could not retain every event.
+    #[error("SDL3 callback event queue overflowed; {dropped_events} event(s) were dropped")]
+    QueueOverflow {
+        /// Number of events dropped since the previous overflow report.
+        dropped_events: usize,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum CoalescingKey {
+    MouseMotion(u32),
+    WindowMoved(u32),
+    WindowResized(u32),
+    WindowPixelSizeChanged(u32),
+    DisplayOrientation(u32),
+    DisplayMoved(u32),
+    DisplayContentScaleChanged(u32),
+    DisplayUsableBoundsChanged(u32),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -217,6 +237,48 @@ impl Sdl3CallbackEvent {
         Self { application, imgui }
     }
 
+    fn coalescing_key(&self) -> Option<CoalescingKey> {
+        match &self.imgui {
+            Some(ImGuiEvent::MouseMotion(event)) => {
+                Some(CoalescingKey::MouseMotion(event.windowID.0))
+            }
+            Some(ImGuiEvent::Window(event)) => match event.r#type {
+                SDL_EVENT_WINDOW_MOVED => Some(CoalescingKey::WindowMoved(event.windowID.0)),
+                SDL_EVENT_WINDOW_RESIZED => Some(CoalescingKey::WindowResized(event.windowID.0)),
+                _ => None,
+            },
+            Some(ImGuiEvent::Display(event)) => match event.r#type {
+                SDL_EVENT_DISPLAY_ORIENTATION => {
+                    Some(CoalescingKey::DisplayOrientation(event.displayID.0))
+                }
+                SDL_EVENT_DISPLAY_MOVED => Some(CoalescingKey::DisplayMoved(event.displayID.0)),
+                SDL_EVENT_DISPLAY_CONTENT_SCALE_CHANGED => {
+                    Some(CoalescingKey::DisplayContentScaleChanged(event.displayID.0))
+                }
+                SDL_EVENT_DISPLAY_USABLE_BOUNDS_CHANGED => {
+                    Some(CoalescingKey::DisplayUsableBoundsChanged(event.displayID.0))
+                }
+                _ => None,
+            },
+            Some(
+                ImGuiEvent::MouseWheel(_)
+                | ImGuiEvent::MouseButton(_)
+                | ImGuiEvent::TextInput { .. }
+                | ImGuiEvent::Keyboard(_)
+                | ImGuiEvent::GamepadDevice(_),
+            ) => None,
+            None => match self.application {
+                ApplicationEvent::WindowPixelSizeChanged { window_id } => {
+                    Some(CoalescingKey::WindowPixelSizeChanged(window_id))
+                }
+                ApplicationEvent::Quit
+                | ApplicationEvent::Escape
+                | ApplicationEvent::WindowCloseRequested { .. }
+                | ApplicationEvent::Other => None,
+            },
+        }
+    }
+
     pub(crate) fn with_raw_event<R>(&self, callback: impl FnOnce(Option<&SDL_Event>) -> R) -> R {
         let raw = match &self.imgui {
             Some(ImGuiEvent::MouseMotion(event)) => Some(SDL_Event { motion: *event }),
@@ -259,13 +321,297 @@ impl Sdl3CallbackEvent {
     }
 }
 
-/// A main-thread-owned FIFO batch drained from [`Sdl3CallbackEventHandoff`].
-#[derive(Default)]
-pub struct Sdl3CallbackEventQueue {
-    events: VecDeque<Sdl3CallbackEvent>,
+struct CallbackEventNode {
+    event: Sdl3CallbackEvent,
+    previous: Option<usize>,
+    next: Option<usize>,
+    coalescible_previous: Option<usize>,
+    coalescible_next: Option<usize>,
+    coalescing_key: Option<CoalescingKey>,
 }
 
-impl Sdl3CallbackEventQueue {
+/// A bounded insertion-ordered queue with O(1) state-event coalescing and eviction.
+#[derive(Default)]
+struct CallbackEventQueue {
+    slots: Vec<Option<CallbackEventNode>>,
+    free_slots: Vec<usize>,
+    head: Option<usize>,
+    tail: Option<usize>,
+    coalescible_head: Option<usize>,
+    coalescible_tail: Option<usize>,
+    coalescing: HashMap<CoalescingKey, usize>,
+}
+
+impl CallbackEventQueue {
+    fn len(&self) -> usize {
+        self.slots.len() - self.free_slots.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+
+    fn coalescible_len(&self) -> usize {
+        self.coalescing.len()
+    }
+
+    fn find_coalescible(&self, key: CoalescingKey) -> Option<usize> {
+        self.coalescing.get(&key).copied()
+    }
+
+    fn oldest_coalescible(&self) -> Option<usize> {
+        self.coalescible_head
+    }
+
+    fn push_back(&mut self, event: Sdl3CallbackEvent) {
+        let coalescing_key = event.coalescing_key();
+        let index = if let Some(index) = self.free_slots.pop() {
+            debug_assert!(self.slots[index].is_none());
+            index
+        } else {
+            self.slots.push(None);
+            self.slots.len() - 1
+        };
+        let previous = self.tail;
+        let coalescible_previous = coalescing_key.and(self.coalescible_tail);
+        self.slots[index] = Some(CallbackEventNode {
+            event,
+            previous,
+            next: None,
+            coalescible_previous,
+            coalescible_next: None,
+            coalescing_key,
+        });
+
+        if let Some(previous) = previous {
+            self.node_mut(previous).next = Some(index);
+        } else {
+            self.head = Some(index);
+        }
+        self.tail = Some(index);
+
+        if let Some(key) = coalescing_key {
+            if let Some(previous) = coalescible_previous {
+                self.node_mut(previous).coalescible_next = Some(index);
+            } else {
+                self.coalescible_head = Some(index);
+            }
+            self.coalescible_tail = Some(index);
+            debug_assert!(self.coalescing.insert(key, index).is_none());
+        }
+    }
+
+    fn replace_and_move_to_back(&mut self, index: usize, event: Sdl3CallbackEvent) {
+        debug_assert_eq!(
+            self.node(index).coalescing_key,
+            event.coalescing_key(),
+            "a coalescing slot must retain its key"
+        );
+        self.node_mut(index).event = event;
+        self.move_to_back(index);
+        self.move_coalescible_to_back(index);
+    }
+
+    fn move_to_back(&mut self, index: usize) {
+        if self.tail == Some(index) {
+            return;
+        }
+        let (previous, next) = {
+            let node = self.node(index);
+            (node.previous, node.next)
+        };
+        if let Some(previous) = previous {
+            self.node_mut(previous).next = next;
+        } else {
+            self.head = next;
+        }
+        if let Some(next) = next {
+            self.node_mut(next).previous = previous;
+        }
+
+        let previous = self.tail;
+        {
+            let node = self.node_mut(index);
+            node.previous = previous;
+            node.next = None;
+        }
+        if let Some(previous) = previous {
+            self.node_mut(previous).next = Some(index);
+        } else {
+            self.head = Some(index);
+        }
+        self.tail = Some(index);
+    }
+
+    fn move_coalescible_to_back(&mut self, index: usize) {
+        if self.coalescible_tail == Some(index) {
+            return;
+        }
+        let (previous, next) = {
+            let node = self.node(index);
+            (node.coalescible_previous, node.coalescible_next)
+        };
+        if let Some(previous) = previous {
+            self.node_mut(previous).coalescible_next = next;
+        } else {
+            self.coalescible_head = next;
+        }
+        if let Some(next) = next {
+            self.node_mut(next).coalescible_previous = previous;
+        }
+
+        let previous = self.coalescible_tail;
+        {
+            let node = self.node_mut(index);
+            node.coalescible_previous = previous;
+            node.coalescible_next = None;
+        }
+        if let Some(previous) = previous {
+            self.node_mut(previous).coalescible_next = Some(index);
+        } else {
+            self.coalescible_head = Some(index);
+        }
+        self.coalescible_tail = Some(index);
+    }
+
+    fn remove(&mut self, index: usize) -> Sdl3CallbackEvent {
+        let (previous, next, coalescible_previous, coalescible_next, coalescing_key) = {
+            let node = self.node(index);
+            (
+                node.previous,
+                node.next,
+                node.coalescible_previous,
+                node.coalescible_next,
+                node.coalescing_key,
+            )
+        };
+
+        if let Some(previous) = previous {
+            self.node_mut(previous).next = next;
+        } else {
+            self.head = next;
+        }
+        if let Some(next) = next {
+            self.node_mut(next).previous = previous;
+        } else {
+            self.tail = previous;
+        }
+
+        if let Some(key) = coalescing_key {
+            if let Some(previous) = coalescible_previous {
+                self.node_mut(previous).coalescible_next = coalescible_next;
+            } else {
+                self.coalescible_head = coalescible_next;
+            }
+            if let Some(next) = coalescible_next {
+                self.node_mut(next).coalescible_previous = coalescible_previous;
+            } else {
+                self.coalescible_tail = coalescible_previous;
+            }
+            debug_assert_eq!(self.coalescing.remove(&key), Some(index));
+        }
+
+        let node = self.slots[index]
+            .take()
+            .expect("callback event queue links must reference occupied slots");
+        self.free_slots.push(index);
+        node.event
+    }
+
+    fn pop_front(&mut self) -> Option<Sdl3CallbackEvent> {
+        self.head.map(|index| self.remove(index))
+    }
+
+    fn node(&self, index: usize) -> &CallbackEventNode {
+        self.slots[index]
+            .as_ref()
+            .expect("callback event queue links must reference occupied slots")
+    }
+
+    fn node_mut(&mut self, index: usize) -> &mut CallbackEventNode {
+        self.slots[index]
+            .as_mut()
+            .expect("callback event queue links must reference occupied slots")
+    }
+
+    #[cfg(test)]
+    fn assert_invariants(&self) {
+        use std::collections::HashSet;
+
+        let occupied = self
+            .slots
+            .iter()
+            .enumerate()
+            .filter_map(|(index, node)| node.as_ref().map(|_| index))
+            .collect::<HashSet<_>>();
+        let free = self.free_slots.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(free.len(), self.free_slots.len(), "free slots repeat");
+        assert!(occupied.is_disjoint(&free), "occupied slot is also free");
+        assert_eq!(occupied.len() + free.len(), self.slots.len());
+        assert_eq!(occupied.len(), self.len());
+
+        let mut linked = HashSet::new();
+        let mut previous = None;
+        let mut current = self.head;
+        while let Some(index) = current {
+            assert!(linked.insert(index), "event links contain a cycle");
+            let node = self.node(index);
+            assert_eq!(node.previous, previous);
+            previous = Some(index);
+            current = node.next;
+        }
+        assert_eq!(previous, self.tail);
+        assert_eq!(linked, occupied, "event links do not cover every node");
+
+        let mut coalescible = HashSet::new();
+        let mut previous = None;
+        let mut current = self.coalescible_head;
+        while let Some(index) = current {
+            assert!(
+                coalescible.insert(index),
+                "coalescible links contain a cycle"
+            );
+            let node = self.node(index);
+            assert!(node.coalescing_key.is_some());
+            assert_eq!(node.coalescible_previous, previous);
+            previous = Some(index);
+            current = node.coalescible_next;
+        }
+        assert_eq!(previous, self.coalescible_tail);
+        assert_eq!(coalescible.len(), self.coalescing.len());
+
+        for (index, node) in self.slots.iter().enumerate() {
+            let Some(node) = node else {
+                continue;
+            };
+            match node.coalescing_key {
+                Some(key) => {
+                    assert!(coalescible.contains(&index));
+                    assert_eq!(self.coalescing.get(&key), Some(&index));
+                }
+                None => {
+                    assert!(!coalescible.contains(&index));
+                    assert_eq!(node.coalescible_previous, None);
+                    assert_eq!(node.coalescible_next, None);
+                }
+            }
+        }
+    }
+}
+
+/// A main-thread-owned callback batch drained from [`Sdl3CallbackEventHandoff`].
+///
+/// Events and deferred callback failures are detached atomically. Inspect [`Self::faults`] before
+/// processing the events when callback failures are fatal to the application. Retained input and
+/// lifecycle events remain available in this batch even when the callback path overflowed or
+/// recovered a poisoned lock.
+#[must_use = "callback batches contain events and faults that must be handled"]
+pub struct Sdl3CallbackEventBatch {
+    events: CallbackEventQueue,
+    faults: Vec<Sdl3CallbackEventHandoffError>,
+}
+
+impl Sdl3CallbackEventBatch {
     /// Take the next event for main-thread processing.
     pub fn pop(&mut self) -> Option<Sdl3CallbackEvent> {
         self.events.pop_front()
@@ -280,9 +626,24 @@ impl Sdl3CallbackEventQueue {
     pub fn len(&self) -> usize {
         self.events.len()
     }
+
+    /// Iterate over every deferred failure detached with this event batch.
+    pub fn faults(&self) -> impl ExactSizeIterator<Item = Sdl3CallbackEventHandoffError> + '_ {
+        self.faults.iter().copied()
+    }
+
+    /// Return the first deferred failure, if any.
+    pub fn first_fault(&self) -> Option<Sdl3CallbackEventHandoffError> {
+        self.faults.first().copied()
+    }
+
+    /// Return whether the callback path reported any deferred failures.
+    pub fn has_faults(&self) -> bool {
+        !self.faults.is_empty()
+    }
 }
 
-impl Iterator for Sdl3CallbackEventQueue {
+impl Iterator for Sdl3CallbackEventBatch {
     type Item = Sdl3CallbackEvent;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -295,27 +656,101 @@ impl Iterator for Sdl3CallbackEventQueue {
     }
 }
 
-impl ExactSizeIterator for Sdl3CallbackEventQueue {}
+impl ExactSizeIterator for Sdl3CallbackEventBatch {}
+
+#[derive(Default)]
+struct FaultLatch {
+    faults: VecDeque<Sdl3CallbackEventHandoffError>,
+}
+
+impl FaultLatch {
+    fn record(&mut self, fault: Sdl3CallbackEventHandoffError) {
+        match fault {
+            Sdl3CallbackEventHandoffError::CallbackPanicked
+            | Sdl3CallbackEventHandoffError::QueuePoisoned => {
+                if !self.faults.contains(&fault) {
+                    self.faults.push_back(fault);
+                }
+            }
+            Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events } => {
+                if let Some(Sdl3CallbackEventHandoffError::QueueOverflow {
+                    dropped_events: accumulated,
+                }) = self.faults.iter_mut().find(|fault| {
+                    matches!(fault, Sdl3CallbackEventHandoffError::QueueOverflow { .. })
+                }) {
+                    *accumulated = accumulated.saturating_add(dropped_events);
+                } else {
+                    self.faults.push_back(fault);
+                }
+            }
+        }
+        debug_assert!(self.faults.len() <= 3);
+    }
+
+    fn drain(&mut self) -> Vec<Sdl3CallbackEventHandoffError> {
+        self.faults.drain(..).collect()
+    }
+}
 
 #[derive(Default)]
 struct CallbackHandoffState {
-    events: Sdl3CallbackEventQueue,
-    faults: VecDeque<Sdl3CallbackEventHandoffError>,
+    events: CallbackEventQueue,
+    faults: FaultLatch,
+}
+
+impl CallbackHandoffState {
+    fn enqueue(&mut self, event: Sdl3CallbackEvent, capacity: usize, ordered_reserve: usize) {
+        let coalescing_key = event.coalescing_key();
+        if let Some(key) = coalescing_key
+            && let Some(index) = self.events.find_coalescible(key)
+        {
+            self.events.replace_and_move_to_back(index, event);
+            return;
+        }
+
+        let coalescible_limit = capacity.saturating_sub(ordered_reserve);
+        if coalescing_key.is_some() {
+            if self.events.len() < capacity && self.events.coalescible_len() < coalescible_limit {
+                self.events.push_back(event);
+            } else {
+                self.record_overflow(1);
+            }
+            return;
+        }
+
+        if self.events.len() == capacity {
+            if let Some(index) = self.events.oldest_coalescible() {
+                self.events.remove(index);
+                self.record_overflow(1);
+            } else {
+                self.record_overflow(1);
+                return;
+            }
+        }
+        self.events.push_back(event);
+    }
+
+    fn record_overflow(&mut self, dropped_events: usize) {
+        self.faults
+            .record(Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events });
+    }
 }
 
 /// Thread-safe handoff from `SDL_AppEvent` to main-thread event processing.
 ///
 /// The callback path owns transient SDL payloads immediately and contains unwind-capable Rust
-/// panics. [`Self::try_drain`] reports a contained failure before releasing the retained events.
+/// panics. [`Self::drain`] atomically releases retained events and any deferred failures, so a
+/// continuously busy callback cannot starve main-thread event processing by repeatedly reporting
+/// new failures first.
 pub struct Sdl3CallbackEventHandoff {
+    capacity: usize,
+    ordered_reserve: usize,
     state: Mutex<CallbackHandoffState>,
 }
 
 impl Default for Sdl3CallbackEventHandoff {
     fn default() -> Self {
-        Self {
-            state: Mutex::new(CallbackHandoffState::default()),
-        }
+        Self::with_capacity(DEFAULT_CALLBACK_EVENT_CAPACITY)
     }
 }
 
@@ -323,15 +758,39 @@ impl fmt::Debug for Sdl3CallbackEventHandoff {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Sdl3CallbackEventHandoff")
+            .field("capacity", &self.capacity)
+            .field("ordered_reserve", &self.ordered_reserve)
             .finish_non_exhaustive()
     }
 }
 
 impl Sdl3CallbackEventHandoff {
+    /// Create a bounded callback handoff.
+    ///
+    /// One quarter of the capacity, with at least one slot, is reserved for ordered events such as
+    /// key, text, button, focus, close, and quit notifications. High-frequency state events are
+    /// coalesced by native window or display identity and cannot consume that reserve.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `capacity` is zero.
+    pub fn with_capacity(capacity: usize) -> Self {
+        assert!(
+            capacity > 0,
+            "SDL3 callback event capacity must be non-zero"
+        );
+        let ordered_reserve = capacity.div_ceil(4).max(1);
+        Self {
+            capacity,
+            ordered_reserve,
+            state: Mutex::new(CallbackHandoffState::default()),
+        }
+    }
+
     /// Copy one event before SDL invalidates its callback payload.
     ///
     /// This is the only unsafe operation required by the normal SDL callback-mode integration.
-    /// The method catches unwind-capable Rust panics and defers them to [`Self::try_drain`] so
+    /// The method catches unwind-capable Rust panics and defers them to [`Self::drain`] so
     /// unwinding never crosses the C callback ABI. A failed event is not queued.
     ///
     /// # Safety
@@ -342,13 +801,15 @@ impl Sdl3CallbackEventHandoff {
     /// returns, and the event must belong to the SDL runtime used by the backend that will process
     /// it.
     pub unsafe fn push_from_callback(&self, raw: &SDL_Event) {
-        self.enqueue_with(|| unsafe { Sdl3CallbackEvent::from_callback_raw(raw) });
+        self.enqueue_with(|| Some(unsafe { Sdl3CallbackEvent::from_callback_raw(raw) }));
     }
 
-    fn enqueue_with(&self, make_event: impl FnOnce() -> Sdl3CallbackEvent) {
+    fn enqueue_with(&self, make_event: impl FnOnce() -> Option<Sdl3CallbackEvent>) {
         let result = catch_unwind(AssertUnwindSafe(|| {
-            let event = make_event();
-            self.lock_state().events.events.push_back(event);
+            if let Some(event) = make_event() {
+                self.lock_state()
+                    .enqueue(event, self.capacity, self.ordered_reserve);
+            }
         }));
         if let Err(payload) = result {
             self.record_fault(Sdl3CallbackEventHandoffError::CallbackPanicked);
@@ -356,16 +817,17 @@ impl Sdl3CallbackEventHandoff {
         }
     }
 
-    /// Return a main-thread-owned event batch after reporting any earlier callback failure.
+    /// Atomically detach the current events and deferred callback failures.
     ///
-    /// When this returns an error, queued events remain available. Handle the error and retry on
-    /// the next iteration to preserve FIFO delivery.
-    pub fn try_drain(&self) -> Result<Sdl3CallbackEventQueue, Sdl3CallbackEventHandoffError> {
+    /// Ordered input and lifecycle events preserve FIFO delivery; high-frequency state events
+    /// retain only their latest position in that order. Faults do not block access to retained
+    /// events, and events or faults arriving after this operation starts belong to a later batch.
+    pub fn drain(&self) -> Sdl3CallbackEventBatch {
         let mut state = self.lock_state();
-        if let Some(fault) = state.faults.pop_front() {
-            return Err(fault);
+        Sdl3CallbackEventBatch {
+            events: std::mem::take(&mut state.events),
+            faults: state.faults.drain(),
         }
-        Ok(std::mem::take(&mut state.events))
     }
 
     fn lock_state(&self) -> MutexGuard<'_, CallbackHandoffState> {
@@ -376,14 +838,14 @@ impl Sdl3CallbackEventHandoff {
                 let mut state = poisoned.into_inner();
                 state
                     .faults
-                    .push_back(Sdl3CallbackEventHandoffError::QueuePoisoned);
+                    .record(Sdl3CallbackEventHandoffError::QueuePoisoned);
                 state
             }
         }
     }
 
     fn record_fault(&self, fault: Sdl3CallbackEventHandoffError) {
-        self.lock_state().faults.push_back(fault);
+        self.lock_state().faults.record(fault);
     }
 }
 
@@ -406,6 +868,32 @@ mod tests {
         }
     }
 
+    fn quit_event(timestamp: u64) -> SDL_Event {
+        SDL_Event {
+            quit: sdl3_sys::events::SDL_QuitEvent {
+                r#type: SDL_EVENT_QUIT,
+                reserved: 0,
+                timestamp,
+            },
+        }
+    }
+
+    fn mouse_motion_event(timestamp: u64, x: f32) -> SDL_Event {
+        mouse_motion_event_for(7, timestamp, x)
+    }
+
+    fn mouse_motion_event_for(window_id: u32, timestamp: u64, x: f32) -> SDL_Event {
+        SDL_Event {
+            motion: SDL_MouseMotionEvent {
+                r#type: SDL_EVENT_MOUSE_MOTION,
+                timestamp,
+                windowID: SDL_WindowID(window_id),
+                x,
+                ..Default::default()
+            },
+        }
+    }
+
     #[test]
     fn text_input_is_owned_before_the_callback_returns() {
         let mut queue = thread::spawn(|| {
@@ -415,7 +903,7 @@ mod tests {
             // SAFETY: `raw` has the active text member and its pointer remains valid here.
             unsafe { handoff.push_from_callback(&raw) };
             drop(source);
-            handoff.try_drain().unwrap()
+            handoff.drain()
         })
         .join()
         .expect("callback worker must not panic");
@@ -429,7 +917,7 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_pointer_payload_is_not_replayed() {
+    fn unsupported_pointer_payload_is_retained_as_an_inert_application_event() {
         let source = CString::new("file manager").unwrap();
         let data = CString::new("C:/tmp/queued.txt").unwrap();
         let raw = SDL_Event {
@@ -444,17 +932,28 @@ mod tests {
                 data: data.as_ptr(),
             },
         };
-        let handoff = Sdl3CallbackEventHandoff::default();
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(2);
         // SAFETY: `raw` has the active drop member and both pointers remain valid here.
         unsafe { handoff.push_from_callback(&raw) };
         drop((source, data));
 
-        handoff
-            .try_drain()
-            .unwrap()
+        let quit = quit_event(43);
+        // SAFETY: `quit` has the active pointer-free quit member.
+        unsafe { handoff.push_from_callback(&quit) };
+
+        let mut events = handoff.drain();
+        assert_eq!(events.len(), 2);
+        let inert = events
             .pop()
-            .expect("event must be queued")
-            .with_raw_event(|raw| assert!(raw.is_none()));
+            .expect("unsupported event summary must be retained");
+        assert!(!inert.requests_exit(7));
+        inert.with_raw_event(|raw| assert!(raw.is_none()));
+        assert!(
+            events
+                .pop()
+                .expect("quit must use the available slot")
+                .requests_exit(7)
+        );
     }
 
     #[test]
@@ -474,8 +973,7 @@ mod tests {
         unsafe { handoff.push_from_callback(&raw) };
 
         handoff
-            .try_drain()
-            .unwrap()
+            .drain()
             .pop()
             .expect("event must be queued")
             .with_raw_event(|raw| {
@@ -516,7 +1014,7 @@ mod tests {
             handoff.push_from_callback(&close);
         }
 
-        let mut queue = handoff.try_drain().unwrap();
+        let mut queue = handoff.drain();
         assert!(
             queue
                 .pop()
@@ -546,11 +1044,7 @@ mod tests {
         .join()
         .expect("callback worker must not panic");
 
-        let event = handoff
-            .try_drain()
-            .unwrap()
-            .pop()
-            .expect("event must cross threads");
+        let event = handoff.drain().pop().expect("event must cross threads");
         assert!(event.requests_exit(1));
     }
 
@@ -566,7 +1060,7 @@ mod tests {
         };
         // SAFETY: `first` has the active quit member and contains no pointer payload.
         unsafe { handoff.push_from_callback(&first) };
-        let mut first_batch = handoff.try_drain().unwrap();
+        let mut first_batch = handoff.drain();
 
         let callback_handoff = Arc::clone(&handoff);
         thread::spawn(move || {
@@ -584,7 +1078,7 @@ mod tests {
         .expect("the next callback must not wait for a retained batch");
 
         assert!(first_batch.pop().is_some());
-        assert!(handoff.try_drain().unwrap().pop().is_some());
+        assert!(handoff.drain().pop().is_some());
     }
 
     #[test]
@@ -593,29 +1087,249 @@ mod tests {
 
         handoff.enqueue_with(|| panic!("synthetic callback copy failure"));
 
-        assert!(matches!(
-            handoff.try_drain(),
-            Err(Sdl3CallbackEventHandoffError::CallbackPanicked)
-        ));
-        assert!(handoff.try_drain().unwrap().is_empty());
+        let batch = handoff.drain();
+        assert_eq!(
+            batch.first_fault(),
+            Some(Sdl3CallbackEventHandoffError::CallbackPanicked)
+        );
+        assert!(batch.is_empty());
     }
 
     #[test]
-    fn independent_callback_failures_are_reported_in_fifo_order() {
+    fn repeated_callback_failures_are_latched_without_unbounded_growth() {
         let handoff = Sdl3CallbackEventHandoff::default();
 
         handoff.enqueue_with(|| panic!("first synthetic callback copy failure"));
         handoff.enqueue_with(|| panic!("second synthetic callback copy failure"));
 
-        assert!(matches!(
-            handoff.try_drain(),
-            Err(Sdl3CallbackEventHandoffError::CallbackPanicked)
-        ));
-        assert!(matches!(
-            handoff.try_drain(),
-            Err(Sdl3CallbackEventHandoffError::CallbackPanicked)
-        ));
-        assert!(handoff.try_drain().unwrap().is_empty());
+        let batch = handoff.drain();
+        assert_eq!(
+            batch.faults().collect::<Vec<_>>(),
+            vec![Sdl3CallbackEventHandoffError::CallbackPanicked]
+        );
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn high_frequency_state_events_coalesce_at_their_latest_ordered_position() {
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(4);
+        let first_motion = mouse_motion_event(1, 10.0);
+        let quit = quit_event(2);
+        let latest_motion = mouse_motion_event(3, 30.0);
+        // SAFETY: all unions name their active pointer-free members.
+        unsafe {
+            handoff.push_from_callback(&first_motion);
+            handoff.push_from_callback(&quit);
+            handoff.push_from_callback(&latest_motion);
+        }
+
+        let mut events = handoff.drain();
+        assert_eq!(events.len(), 2);
+        assert!(
+            events
+                .pop()
+                .expect("quit must remain ordered")
+                .requests_exit(7)
+        );
+        events
+            .pop()
+            .expect("latest mouse motion must be retained")
+            .with_raw_event(|raw| {
+                let raw = raw.expect("mouse motion is consumed by the ImGui backend");
+                assert_eq!(unsafe { raw.motion.x }, 30.0);
+                assert_eq!(unsafe { raw.motion.timestamp }, 3);
+            });
+    }
+
+    #[test]
+    fn high_frequency_state_events_reuse_their_indexed_queue_slot() {
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(4);
+        for timestamp in 0..10_000 {
+            let motion = mouse_motion_event(timestamp, timestamp as f32);
+            // SAFETY: the union names its active pointer-free motion member.
+            unsafe { handoff.push_from_callback(&motion) };
+        }
+
+        {
+            let state = handoff.state.lock().unwrap();
+            assert_eq!(state.events.len(), 1);
+            assert_eq!(state.events.slots.len(), 1);
+            assert_eq!(state.events.coalescible_len(), 1);
+        }
+
+        let mut batch = handoff.drain();
+        batch
+            .pop()
+            .expect("the latest mouse motion must be retained")
+            .with_raw_event(|raw| {
+                let raw = raw.expect("mouse motion is consumed by the ImGui backend");
+                assert_eq!(unsafe { raw.motion.timestamp }, 9_999);
+                assert_eq!(unsafe { raw.motion.x }, 9_999.0);
+            });
+    }
+
+    #[test]
+    fn indexed_queue_matches_a_reference_model_under_mixed_operations() {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum ModelEvent {
+            Motion { window_id: u32, timestamp: u64 },
+            Quit,
+        }
+
+        impl ModelEvent {
+            fn coalescing_key(self) -> Option<u32> {
+                match self {
+                    Self::Motion { window_id, .. } => Some(window_id),
+                    Self::Quit => None,
+                }
+            }
+        }
+
+        const CAPACITY: usize = 7;
+        const ORDERED_RESERVE: usize = 2;
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(CAPACITY);
+        assert_eq!(handoff.ordered_reserve, ORDERED_RESERVE);
+        let mut model = VecDeque::new();
+        let mut dropped_events = 0usize;
+        let mut random = 0x5eed_cafe_d15c_a11u64;
+
+        for timestamp in 0..5_000u64 {
+            random = random
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1);
+            let event = if random % 4 == 0 {
+                ModelEvent::Quit
+            } else {
+                ModelEvent::Motion {
+                    window_id: ((random >> 8) % 6) as u32 + 1,
+                    timestamp,
+                }
+            };
+
+            if let Some(key) = event.coalescing_key() {
+                if let Some(index) = model
+                    .iter()
+                    .position(|queued: &ModelEvent| queued.coalescing_key() == Some(key))
+                {
+                    model.remove(index);
+                    model.push_back(event);
+                } else {
+                    let coalescible = model
+                        .iter()
+                        .filter(|queued| queued.coalescing_key().is_some())
+                        .count();
+                    if model.len() < CAPACITY
+                        && coalescible < CAPACITY.saturating_sub(ORDERED_RESERVE)
+                    {
+                        model.push_back(event);
+                    } else {
+                        dropped_events += 1;
+                    }
+                }
+            } else {
+                let mut retain = true;
+                if model.len() == CAPACITY {
+                    if let Some(index) = model
+                        .iter()
+                        .position(|queued| queued.coalescing_key().is_some())
+                    {
+                        model.remove(index);
+                        dropped_events += 1;
+                    } else {
+                        dropped_events += 1;
+                        retain = false;
+                    }
+                }
+                if retain {
+                    model.push_back(event);
+                }
+            }
+
+            let raw = match event {
+                ModelEvent::Motion {
+                    window_id,
+                    timestamp,
+                } => mouse_motion_event_for(window_id, timestamp, timestamp as f32),
+                ModelEvent::Quit => quit_event(timestamp),
+            };
+            // SAFETY: both generated unions name active pointer-free members.
+            unsafe { handoff.push_from_callback(&raw) };
+            handoff.state.lock().unwrap().events.assert_invariants();
+        }
+
+        let batch = handoff.drain();
+        let faults = batch.faults().collect::<Vec<_>>();
+        assert_eq!(
+            faults,
+            vec![Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events }]
+        );
+        let actual = batch
+            .map(|event| match event.imgui {
+                Some(ImGuiEvent::MouseMotion(raw)) => ModelEvent::Motion {
+                    window_id: raw.windowID.0,
+                    timestamp: raw.timestamp,
+                },
+                None if event.application == ApplicationEvent::Quit => ModelEvent::Quit,
+                _ => panic!("model generated an unexpected SDL callback event"),
+            })
+            .collect::<VecDeque<_>>();
+        assert_eq!(actual, model);
+    }
+
+    #[test]
+    fn ordered_events_evict_coalescible_state_before_overflowing() {
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(2);
+        let motion = mouse_motion_event(1, 10.0);
+        let first_quit = quit_event(2);
+        let second_quit = quit_event(3);
+        // SAFETY: all unions name their active pointer-free members.
+        unsafe {
+            handoff.push_from_callback(&motion);
+            handoff.push_from_callback(&first_quit);
+            handoff.push_from_callback(&second_quit);
+        }
+
+        let events = handoff.drain();
+        assert_eq!(
+            events.first_fault(),
+            Some(Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events: 1 })
+        );
+        assert_eq!(events.len(), 2);
+        assert!(events.into_iter().all(|event| event.requests_exit(7)));
+    }
+
+    #[test]
+    fn ordered_events_do_not_consume_the_coalescible_budget() {
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(4);
+        for timestamp in 1..=3 {
+            let event = quit_event(timestamp);
+            // SAFETY: the union names its active pointer-free quit member.
+            unsafe { handoff.push_from_callback(&event) };
+        }
+        let motion = mouse_motion_event(4, 24.0);
+        // SAFETY: the union names its active pointer-free motion member.
+        unsafe { handoff.push_from_callback(&motion) };
+
+        assert_eq!(handoff.drain().len(), 4);
+    }
+
+    #[test]
+    fn a_full_ordered_queue_reports_and_drops_new_events_without_growing() {
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(1);
+        let first = quit_event(1);
+        let second = quit_event(2);
+        // SAFETY: both unions name their active pointer-free quit member.
+        unsafe {
+            handoff.push_from_callback(&first);
+            handoff.push_from_callback(&second);
+        }
+
+        let batch = handoff.drain();
+        assert_eq!(
+            batch.first_fault(),
+            Some(Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events: 1 })
+        );
+        assert_eq!(batch.len(), 1);
     }
 
     #[test]
@@ -634,14 +1348,14 @@ mod tests {
         }));
 
         assert!(result.is_ok());
-        assert!(matches!(
-            handoff.try_drain(),
-            Err(Sdl3CallbackEventHandoffError::CallbackPanicked)
-        ));
+        assert_eq!(
+            handoff.drain().first_fault(),
+            Some(Sdl3CallbackEventHandoffError::CallbackPanicked)
+        );
     }
 
     #[test]
-    fn checked_drain_reports_fault_without_discarding_later_events() {
+    fn drain_detaches_faults_and_events_together() {
         let handoff = Sdl3CallbackEventHandoff::default();
         handoff.enqueue_with(|| panic!("synthetic callback copy failure"));
         let raw = SDL_Event {
@@ -654,16 +1368,81 @@ mod tests {
         // SAFETY: `raw` has the active quit member and contains no pointer payload.
         unsafe { handoff.push_from_callback(&raw) };
 
-        assert!(matches!(
-            handoff.try_drain(),
-            Err(Sdl3CallbackEventHandoffError::CallbackPanicked)
-        ));
-        let event = handoff
-            .try_drain()
-            .expect("the retained queue must remain drainable")
-            .pop()
-            .expect("the valid event must be retained");
+        let mut batch = handoff.drain();
+        assert_eq!(
+            batch.first_fault(),
+            Some(Sdl3CallbackEventHandoffError::CallbackPanicked)
+        );
+        let event = batch.pop().expect("the valid event must be retained");
         assert!(event.requests_exit(1));
+    }
+
+    #[test]
+    fn repeated_overflow_cannot_starve_retained_events() {
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(1);
+        let first = quit_event(1);
+        let dropped = quit_event(2);
+        // SAFETY: both unions name their active pointer-free quit member.
+        unsafe {
+            handoff.push_from_callback(&first);
+            handoff.push_from_callback(&dropped);
+        }
+
+        let mut first_batch = handoff.drain();
+
+        let second = quit_event(3);
+        let also_dropped = quit_event(4);
+        // SAFETY: both unions name their active pointer-free quit member.
+        unsafe {
+            handoff.push_from_callback(&second);
+            handoff.push_from_callback(&also_dropped);
+        }
+
+        assert_eq!(
+            first_batch.first_fault(),
+            Some(Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events: 1 })
+        );
+        assert!(
+            first_batch
+                .pop()
+                .expect("the first retained event must remain available")
+                .requests_exit(7)
+        );
+
+        let mut second_batch = handoff.drain();
+        assert_eq!(
+            second_batch.first_fault(),
+            Some(Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events: 1 })
+        );
+        assert!(
+            second_batch
+                .pop()
+                .expect("the next retained event must make progress")
+                .requests_exit(7)
+        );
+    }
+
+    #[test]
+    fn one_batch_retains_all_distinct_fault_kinds_in_observation_order() {
+        let handoff = Sdl3CallbackEventHandoff::with_capacity(1);
+        let first = quit_event(1);
+        let dropped = quit_event(2);
+        // SAFETY: both unions name their active pointer-free quit member.
+        unsafe {
+            handoff.push_from_callback(&first);
+            handoff.push_from_callback(&dropped);
+        }
+        handoff.enqueue_with(|| panic!("synthetic callback copy failure"));
+
+        let batch = handoff.drain();
+        assert_eq!(
+            batch.faults().collect::<Vec<_>>(),
+            vec![
+                Sdl3CallbackEventHandoffError::QueueOverflow { dropped_events: 1 },
+                Sdl3CallbackEventHandoffError::CallbackPanicked,
+            ]
+        );
+        assert!(batch.has_faults());
     }
 
     #[test]
@@ -677,10 +1456,11 @@ mod tests {
         .join();
         assert!(result.is_err());
 
-        assert!(matches!(
-            handoff.try_drain(),
-            Err(Sdl3CallbackEventHandoffError::QueuePoisoned)
-        ));
-        assert!(handoff.try_drain().unwrap().is_empty());
+        let batch = handoff.drain();
+        assert_eq!(
+            batch.first_fault(),
+            Some(Sdl3CallbackEventHandoffError::QueuePoisoned)
+        );
+        assert!(batch.is_empty());
     }
 }

--- a/backends/dear-imgui-sdl3/src/lib.rs
+++ b/backends/dear-imgui-sdl3/src/lib.rs
@@ -141,8 +141,8 @@ pub use self::backend::{
     SdlGpu3PreparedViewportFrame, SdlGpu3RenderPassFrame, SdlGpu3RendererBackend,
 };
 pub use self::callback_events::{
-    Sdl3CallbackEvent, Sdl3CallbackEventHandoff, Sdl3CallbackEventHandoffError,
-    Sdl3CallbackEventQueue,
+    Sdl3CallbackEvent, Sdl3CallbackEventBatch, Sdl3CallbackEventHandoff,
+    Sdl3CallbackEventHandoffError,
 };
 #[cfg(feature = "multi-viewport")]
 pub use self::core::Sdl3VulkanSurfaceError;

--- a/backends/dear-imgui-winit/Cargo.toml
+++ b/backends/dear-imgui-winit/Cargo.toml
@@ -35,6 +35,13 @@ windows-sys = { workspace = true, features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "std",
+    "NSView",
+    "NSWindow",
+] }
+
 [features]
 default = []
 # Enable multi-viewport support (WIP). Declared to silence cfg warnings; kept off by default.

--- a/backends/dear-imgui-winit/Cargo.toml
+++ b/backends/dear-imgui-winit/Cargo.toml
@@ -38,6 +38,7 @@ windows-sys = { workspace = true, features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3", default-features = false, features = [
     "std",
+    "NSResponder",
     "NSView",
     "NSWindow",
 ] }

--- a/backends/dear-imgui-winit/README.md
+++ b/backends/dear-imgui-winit/README.md
@@ -203,7 +203,9 @@ parallel values; a callback `Result` is never discarded by a later platform fail
 integrations may call `drain_viewport_faults()` after a native pass that is not already wrapped by
 `with_event_loop`. First-party routes perform both steps automatically. Ordinary `handle_event` and
 owner methods surface the oldest pending fault before entering Winit. Explicit shutdown is
-idempotent and reports cleanup failures.
+idempotent and reports cleanup failures. A failed viewport remains marked for closure after Dear
+ImGui clears callback request flags, and the failure is retired only when that exact native
+viewport ownership generation is destroyed or replaced.
 Dropping the owner without the mutable Context leaves native cleanup with the Context attachment,
 so teardown still passes through the core open-frame normalization path.
 Explicit shutdown returns `WinitPlatformError::RendererShutdownRequired` while a renderer callback
@@ -246,7 +248,8 @@ PlatformIO state is published because Wayland cannot provide the desktop-space w
 required by Dear ImGui. Runtime construction likewise rejects non-desktop targets; the supported
 window systems are Windows, macOS, and Linux/X11. Windows and macOS honor
 `NO_FOCUS_ON_APPEARING` by creating secondary windows inactive and deciding focus from the final
-flags at show time. Linux/X11 accepts that flag without rejecting the viewport, but its window
+flags at show time. The macOS path uses AppKit's non-activating `orderFront` operation instead of
+Winit's activating `set_visible(true)` implementation. Linux/X11 accepts that flag without rejecting the viewport, but its window
 manager controls the final focus behavior. `NO_FOCUS_ON_CLICK` is accepted as a platform policy:
 Windows installs a native `WM_MOUSEACTIVATE` hook that returns `MA_NOACTIVATE`, while platforms
 without an equivalent Winit hook treat it as best effort. Live decoration and top-most changes are

--- a/backends/dear-imgui-winit/src/multi_viewport/callbacks.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/callbacks.rs
@@ -3,11 +3,11 @@ use super::coordinates::{
 };
 use super::native_cursor_hittest::{
     MouseCaptureTransfer, focus_and_raise_window, raise_window_without_activation,
-    transfer_mouse_capture,
+    show_window_without_activation, transfer_mouse_capture,
 };
 use super::registry::{
-    insert_viewport_data, preflight_viewport_ownership, remove_viewport_data, with_current_runtime,
-    with_viewport_data,
+    clear_failed_viewport, insert_viewport_data, preflight_viewport_ownership,
+    record_failed_viewport, remove_viewport_data, with_current_runtime, with_viewport_data,
 };
 use super::runtime::RuntimeControl;
 use super::viewport_data::{ViewportData, ViewportWindowPolicy};
@@ -197,10 +197,7 @@ pub(super) fn record_viewport_failure(
     error: WinitPlatformError,
 ) {
     control.record_fault(error);
-    if !viewport.is_null() {
-        // SAFETY: callback callers pass a live viewport from the currently bound Context.
-        unsafe { (*viewport).PlatformRequestClose = true };
-    }
+    record_failed_viewport(control, viewport);
 }
 
 fn sync_window_policy(

--- a/backends/dear-imgui-winit/src/multi_viewport/callbacks/window.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/callbacks/window.rs
@@ -71,6 +71,7 @@ pub(in super::super) unsafe extern "C" fn winit_create_window(
             if vp.is_null() {
                 return;
             }
+            clear_failed_viewport(control, vp);
 
             let Some(event_loop) = control.active_event_loop() else {
                 record_viewport_failure(control, vp, WinitPlatformError::EventLoopUnavailable);
@@ -222,6 +223,7 @@ pub(in super::super) unsafe extern "C" fn winit_destroy_window(
         if vp.is_null() {
             return;
         }
+        clear_failed_viewport(control, vp);
         if let Some(Err(error)) = with_viewport_data(control, vp, |data| {
             if data.is_main() {
                 return Ok(());
@@ -267,15 +269,21 @@ pub(in super::super) unsafe extern "C" fn winit_show_window(
                 record_viewport_failure(control, vp, error);
                 return;
             }
-            data.window().set_visible(true);
             if should_focus_on_show(policy) {
+                data.window().set_visible(true);
                 if let Err(error) = request_platform_window_focus(control, data.window()) {
                     record_viewport_failure(control, vp, error);
                 }
-            } else if !policy.cursor_hittest
-                && let Err(error) = raise_window_without_activation(data.window())
-            {
-                record_viewport_failure(control, vp, error);
+            } else {
+                if let Err(error) = show_window_without_activation(data.window()) {
+                    record_viewport_failure(control, vp, error);
+                    return;
+                }
+                if !policy.cursor_hittest
+                    && let Err(error) = raise_window_without_activation(data.window())
+                {
+                    record_viewport_failure(control, vp, error);
+                }
             }
         });
     });

--- a/backends/dear-imgui-winit/src/multi_viewport/native_cursor_hittest.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/native_cursor_hittest.rs
@@ -118,9 +118,27 @@ pub(super) fn raise_window_without_activation(window: &Window) -> Result<(), Win
         windows::raise_window_without_activation(window)
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        macos::raise_window_without_activation(window)
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
         let _ = window;
+        Ok(())
+    }
+}
+
+pub(super) fn show_window_without_activation(window: &Window) -> Result<(), WinitPlatformError> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::raise_window_without_activation(window)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        window.set_visible(true);
         Ok(())
     }
 }
@@ -134,6 +152,45 @@ pub(super) fn focus_and_raise_window(window: &Window) -> Result<(), WinitPlatfor
     #[cfg(not(target_os = "windows"))]
     {
         window.focus_window();
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use objc2_app_kit::NSView;
+    use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use winit::window::Window;
+
+    use super::WinitPlatformError;
+
+    pub(super) fn raise_window_without_activation(
+        window: &Window,
+    ) -> Result<(), WinitPlatformError> {
+        let handle =
+            window
+                .window_handle()
+                .map_err(|error| WinitPlatformError::WindowOperation {
+                    operation: "access AppKit viewport window handle",
+                    message: error.to_string(),
+                })?;
+        let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
+            return Err(WinitPlatformError::WindowOperation {
+                operation: "access AppKit viewport window handle",
+                message: "Winit returned a non-AppKit window handle on macOS".to_owned(),
+            });
+        };
+
+        // SAFETY: Winit's borrowed AppKit handle keeps this NSView alive for the duration of the
+        // call, and multi-viewport callbacks run inside Winit's main-thread event-loop scope.
+        let view = unsafe { &*handle.ns_view.as_ptr().cast::<NSView>() };
+        let native_window = view
+            .window()
+            .ok_or_else(|| WinitPlatformError::WindowOperation {
+                operation: "show AppKit viewport without activation",
+                message: "Winit's NSView is not attached to an NSWindow".to_owned(),
+            })?;
+        native_window.orderFront(None);
         Ok(())
     }
 }

--- a/backends/dear-imgui-winit/src/multi_viewport/registry.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/registry.rs
@@ -25,6 +25,15 @@ pub(super) struct ViewportEntry {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct FailedViewport {
+    identity: ViewportIdentity,
+    viewport_id: u32,
+    platform_user_data: usize,
+    platform_handle: usize,
+    platform_handle_raw: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct ViewportIdentity {
     context: usize,
     address: usize,
@@ -49,6 +58,42 @@ impl ViewportIdentity {
             )
         };
         (!viewport.is_null()).then_some(viewport)
+    }
+}
+
+impl FailedViewport {
+    unsafe fn capture(
+        context: *mut dear_imgui_rs::sys::ImGuiContext,
+        viewport: *mut dear_imgui_rs::sys::ImGuiViewport,
+    ) -> Self {
+        let viewport_ref = unsafe { &*viewport };
+        Self {
+            identity: ViewportIdentity::capture(context, viewport),
+            viewport_id: viewport_ref.ID,
+            platform_user_data: viewport_ref.PlatformUserData as usize,
+            platform_handle: viewport_ref.PlatformHandle as usize,
+            platform_handle_raw: viewport_ref.PlatformHandleRaw as usize,
+        }
+    }
+
+    fn matches_address(self, viewport: *mut dear_imgui_rs::sys::ImGuiViewport) -> bool {
+        self.identity.address == viewport as usize
+    }
+
+    unsafe fn reassert_close(self) -> bool {
+        let Some(viewport) = (unsafe { self.identity.resolve() }) else {
+            return false;
+        };
+        let viewport_ref = unsafe { &mut *viewport };
+        if viewport_ref.ID != self.viewport_id
+            || viewport_ref.PlatformUserData as usize != self.platform_user_data
+            || viewport_ref.PlatformHandle as usize != self.platform_handle
+            || viewport_ref.PlatformHandleRaw as usize != self.platform_handle_raw
+        {
+            return false;
+        }
+        viewport_ref.PlatformRequestClose = true;
+        true
     }
 }
 
@@ -202,6 +247,39 @@ pub(super) fn insert_viewport_data(
         data,
     });
     Ok(data_ptr)
+}
+
+pub(super) fn record_failed_viewport(
+    control: &RuntimeControl,
+    viewport: *mut dear_imgui_rs::sys::ImGuiViewport,
+) {
+    if viewport.is_null() {
+        return;
+    }
+    let failure = unsafe { FailedViewport::capture(control.context_raw(), viewport) };
+    clear_failed_viewport(control, viewport);
+    control.failed_viewports.borrow_mut().push(failure);
+    unsafe { (*viewport).PlatformRequestClose = true };
+}
+
+pub(super) fn clear_failed_viewport(
+    control: &RuntimeControl,
+    viewport: *mut dear_imgui_rs::sys::ImGuiViewport,
+) {
+    if viewport.is_null() {
+        return;
+    }
+    control
+        .failed_viewports
+        .borrow_mut()
+        .retain(|failure| !failure.matches_address(viewport));
+}
+
+pub(super) fn reassert_failed_viewports(control: &RuntimeControl) {
+    control
+        .failed_viewports
+        .borrow_mut()
+        .retain(|failure| unsafe { failure.reassert_close() });
 }
 
 pub(super) fn owns_viewport_data(

--- a/backends/dear-imgui-winit/src/multi_viewport/runtime.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/runtime.rs
@@ -34,8 +34,9 @@ use super::native_cursor_hittest::query_native_mouse_state;
 #[cfg(target_os = "windows")]
 use super::registry::viewport_id_for_native_window;
 use super::registry::{
-    apply_pending_geometry_refresh, preflight_viewport_ownership, register_runtime,
-    request_geometry_refresh_for_window, secondary_viewport_windows, unregister_runtime,
+    FailedViewport, apply_pending_geometry_refresh, preflight_viewport_ownership,
+    reassert_failed_viewports, register_runtime, request_geometry_refresh_for_window,
+    secondary_viewport_windows, unregister_runtime,
 };
 use super::viewport_data::{init_main_viewport, preflight_main_viewport};
 use crate::cursor::CursorSettings;
@@ -227,6 +228,7 @@ pub(crate) struct RuntimeControl {
     focus: RefCell<ContextFocusState>,
     platform_focus: Cell<PlatformFocusState>,
     pub(super) viewports: RefCell<Vec<super::registry::ViewportEntry>>,
+    pub(super) failed_viewports: RefCell<Vec<FailedViewport>>,
 }
 
 impl RuntimeControl {
@@ -257,6 +259,7 @@ impl RuntimeControl {
             focus: RefCell::new(focus),
             platform_focus: Cell::new(PlatformFocusState::default()),
             viewports: RefCell::new(Vec::new()),
+            failed_viewports: RefCell::new(Vec::new()),
         }
     }
 
@@ -281,6 +284,7 @@ impl RuntimeControl {
             focus: RefCell::new(ContextFocusState::default()),
             platform_focus: Cell::new(PlatformFocusState::default()),
             viewports: RefCell::new(Vec::new()),
+            failed_viewports: RefCell::new(Vec::new()),
         }
     }
 
@@ -674,6 +678,7 @@ impl RuntimeControl {
     }
 
     pub(super) fn drop_all_viewports(&self) {
+        self.failed_viewports.borrow_mut().clear();
         let entries = std::mem::take(&mut *self.viewports.borrow_mut());
         for entry in entries {
             entry.detach_and_drop();
@@ -683,6 +688,7 @@ impl RuntimeControl {
     fn discard_all_viewports_without_touching_native(&self) {
         // Native viewport pointers may have been filtered from the public snapshot or invalidated
         // by core teardown. Dropping the entries releases only Rust-owned windows and sidecars.
+        self.failed_viewports.borrow_mut().clear();
         self.viewports.borrow_mut().clear();
     }
 
@@ -1020,6 +1026,9 @@ struct EventLoopRestore<'a> {
 
 impl Drop for EventLoopRestore<'_> {
     fn drop(&mut self) {
+        // Dear ImGui clears platform request flags after invoking every callback. Reassert failed
+        // viewport closure only after the entire event-loop operation has returned.
+        reassert_failed_viewports(self.control);
         self.control.event_loop.set(self.previous);
     }
 }

--- a/backends/dear-imgui-winit/src/multi_viewport/tests.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/tests.rs
@@ -1014,6 +1014,175 @@ fn unsupported_viewport_policy_fault_requests_close() {
     assert_eq!(runtime.poll_fault(), Err(error));
 }
 
+fn create_headless_secondary_viewport(
+    context: &mut Context,
+) -> *mut dear_imgui_rs::sys::ImGuiViewport {
+    context
+        .font_atlas()
+        .try_claim_legacy_renderer()
+        .expect("the headless viewport test needs a built font atlas")
+        .build();
+
+    unsafe {
+        context
+            .platform_io_mut()
+            .set_monitors(&[valid_test_monitor()]);
+    }
+    let _temporary_callbacks = super::callbacks::claim_platform_callbacks(context);
+    let main_viewport = unsafe { dear_imgui_rs::sys::igGetMainViewport() };
+    assert!(!main_viewport.is_null());
+    assert!(unsafe { (*main_viewport).PlatformUserData.is_null() });
+    assert!(unsafe { (*main_viewport).PlatformHandle.is_null() });
+    let temporary_handle = std::ptr::dangling_mut::<u8>().cast::<c_void>();
+    unsafe { (*main_viewport).PlatformHandle = temporary_handle };
+
+    let mut backend_flags = context.io().backend_flags();
+    backend_flags
+        .insert(BackendFlags::PLATFORM_HAS_VIEWPORTS | BackendFlags::RENDERER_HAS_VIEWPORTS);
+    context.io_mut().set_backend_flags(backend_flags);
+    context.enable_multi_viewport();
+    context.prepare_frame(dear_imgui_rs::FramePrepareOptions::new(
+        [320.0, 240.0],
+        1.0 / 60.0,
+    ));
+    context
+        .frame()
+        .window("Persistent failed viewport")
+        .position([640.0, 480.0], dear_imgui_rs::Condition::Always)
+        .size([160.0, 120.0], dear_imgui_rs::Condition::Always)
+        .build(|| {});
+    drop(context.render_legacy());
+
+    unsafe {
+        context.platform_io_mut().clear_platform_handlers();
+        (*main_viewport).PlatformHandle = std::ptr::null_mut();
+    }
+    backend_flags.remove(BackendFlags::PLATFORM_HAS_VIEWPORTS);
+    context.io_mut().set_backend_flags(backend_flags);
+
+    let platform_io = context.platform_io().as_raw();
+    unsafe {
+        let viewports = &(*platform_io).Viewports;
+        std::slice::from_raw_parts(viewports.Data, viewports.Size as usize)
+            .iter()
+            .copied()
+            .find(|viewport| *viewport != main_viewport)
+            .expect("the off-screen window should own a secondary viewport")
+    }
+}
+
+#[test]
+fn viewport_failure_survives_imgui_clearing_request_flags() {
+    let _guard = lock_context();
+    let mut context = Context::create();
+    let secondary_viewport = create_headless_secondary_viewport(&mut context);
+    let runtime = WinitPlatformRuntime::new_for_test(&mut context).unwrap();
+
+    runtime
+        .control()
+        .enter_event_loop_pointer_for_test(std::ptr::null(), || unsafe {
+            winit_create_window(secondary_viewport);
+            assert!((*secondary_viewport).PlatformRequestClose);
+            (*secondary_viewport).PlatformRequestClose = false;
+        });
+
+    assert!(unsafe { (*secondary_viewport).PlatformRequestClose });
+    assert_eq!(
+        runtime.poll_fault(),
+        Err(WinitPlatformError::EventLoopUnavailable)
+    );
+}
+
+#[test]
+fn destroying_a_viewport_clears_its_persistent_failure() {
+    let _guard = lock_context();
+    let mut context = Context::create();
+    let runtime = WinitPlatformRuntime::new_for_test(&mut context).unwrap();
+    let mut viewport = dear_imgui_rs::sys::ImGuiViewport::default();
+
+    record_viewport_failure(
+        runtime.control(),
+        &mut viewport,
+        WinitPlatformError::EventLoopUnavailable,
+    );
+    assert_eq!(
+        runtime.poll_fault(),
+        Err(WinitPlatformError::EventLoopUnavailable)
+    );
+    unsafe { winit_destroy_window(&mut viewport) };
+    viewport.PlatformRequestClose = false;
+
+    runtime
+        .control()
+        .enter_event_loop_pointer_for_test(std::ptr::null(), || {});
+
+    assert!(!viewport.PlatformRequestClose);
+}
+
+#[test]
+fn persistent_failure_does_not_cross_a_native_ownership_change() {
+    let _guard = lock_context();
+    let mut context = Context::create();
+    let viewport = create_headless_secondary_viewport(&mut context);
+    let runtime = WinitPlatformRuntime::new_for_test(&mut context).unwrap();
+
+    record_viewport_failure(
+        runtime.control(),
+        viewport,
+        WinitPlatformError::EventLoopUnavailable,
+    );
+    assert_eq!(
+        runtime.poll_fault(),
+        Err(WinitPlatformError::EventLoopUnavailable)
+    );
+    unsafe {
+        (*viewport).PlatformRequestClose = false;
+        (*viewport).PlatformUserData = std::ptr::dangling_mut::<u8>().cast();
+    }
+
+    runtime
+        .control()
+        .enter_event_loop_pointer_for_test(std::ptr::null(), || {});
+    unsafe {
+        (*viewport).PlatformUserData = std::ptr::null_mut();
+    }
+    runtime
+        .control()
+        .enter_event_loop_pointer_for_test(std::ptr::null(), || {});
+
+    assert!(!unsafe { (*viewport).PlatformRequestClose });
+}
+
+#[test]
+fn persistent_failure_does_not_cross_a_viewport_id_generation_change() {
+    let _guard = lock_context();
+    let mut context = Context::create();
+    let viewport = create_headless_secondary_viewport(&mut context);
+    let runtime = WinitPlatformRuntime::new_for_test(&mut context).unwrap();
+
+    record_viewport_failure(
+        runtime.control(),
+        viewport,
+        WinitPlatformError::EventLoopUnavailable,
+    );
+    assert_eq!(
+        runtime.poll_fault(),
+        Err(WinitPlatformError::EventLoopUnavailable)
+    );
+    let original_id = unsafe { (*viewport).ID };
+    unsafe {
+        (*viewport).PlatformRequestClose = false;
+        (*viewport).ID = original_id.wrapping_add(1);
+    }
+
+    runtime
+        .control()
+        .enter_event_loop_pointer_for_test(std::ptr::null(), || {});
+
+    assert!(!unsafe { (*viewport).PlatformRequestClose });
+    unsafe { (*viewport).ID = original_id };
+}
+
 #[test]
 fn callback_fault_queue_drains_every_failure_in_observation_order() {
     let _guard = lock_context();

--- a/dear-app/README.md
+++ b/dear-app/README.md
@@ -130,6 +130,13 @@ fn main() -> Result<(), RunError> {
 - `gpu_recreated` runs after a replacement generation is committed.
 - `shutdown` runs once before add-ons and the Dear ImGui context are destroyed.
 
+`InitContext` exposes the complete Dear ImGui `Context` only from `configure_imgui`, before platform
+and renderer attachment, for extension APIs that require it. `initialized` receives
+`InitializedContext`; runtime event, pre-frame, and shutdown hooks likewise expose only narrow IO,
+style, font-atlas, and managed-texture capabilities. The runtime compares the Context identity,
+native frame sequence, and lifecycle state at every callback boundary, so opening and closing a
+frame inside a callback is still reported as `RunError::ImGuiFrameOwnership`.
+
 Every failing hook is wrapped with its typed `ApplicationStage`, while the hook's original
 `RunError` remains in the source chain. The first actual failure remains primary. Shutdown still
 runs exactly once, and a shutdown or backend-release failure is returned only when no earlier

--- a/dear-app/src/application.rs
+++ b/dear-app/src/application.rs
@@ -149,6 +149,16 @@ pub enum RunError {
     DeviceRequest(#[source] wgpu::RequestDeviceError),
     #[error("Dear ImGui context creation failed: {0}")]
     ImGuiContext(#[source] imgui::ImGuiError),
+    #[error("Dear ImGui frame admission failed: {0}")]
+    ImGuiFrame(#[source] imgui::render::RendererConsumerError),
+    #[error(
+        "application callback during {stage} changed Dear ImGui frame ownership from {before:?} to {after:?}"
+    )]
+    ImGuiFrameOwnership {
+        stage: ApplicationStage,
+        before: imgui::FrameLifecycleStamp,
+        after: imgui::FrameLifecycleStamp,
+    },
     #[error("WGPU renderer initialization failed: {0}")]
     RendererInit(#[source] dear_imgui_wgpu::RendererError),
     #[error("WGPU renderer draw failed: {0}")]
@@ -211,7 +221,9 @@ impl RunError {
     #[must_use]
     pub const fn application_stage(&self) -> Option<ApplicationStage> {
         match self {
-            Self::Application { stage, .. } => Some(*stage),
+            Self::Application { stage, .. } | Self::ImGuiFrameOwnership { stage, .. } => {
+                Some(*stage)
+            }
             _ => None,
         }
     }
@@ -222,13 +234,7 @@ impl RunError {
     }
 
     pub(crate) fn during_application_stage(self, stage: ApplicationStage) -> Self {
-        if matches!(
-            &self,
-            Self::Application {
-                stage: existing,
-                ..
-            } if *existing == stage
-        ) {
+        if self.application_stage() == Some(stage) {
             self
         } else {
             Self::application(stage, self)
@@ -250,7 +256,7 @@ pub trait Application {
     /// Runs exactly once after the window, UI state, and first GPU generation are ready.
     fn initialized(
         &mut self,
-        _init: &mut InitContext<'_>,
+        _context: &mut InitializedContext<'_>,
         _gpu: &mut GpuContext<'_>,
     ) -> Result<(), RunError> {
         Ok(())
@@ -302,6 +308,11 @@ pub struct InitContext<'a> {
 }
 
 impl InitContext<'_> {
+    /// Returns the Context before platform and renderer ownership is attached.
+    ///
+    /// This full capability exists for extension crates whose initialization API requires
+    /// `&mut Context`. The runtime validates the Context identity and frame progress when the
+    /// callback returns. Later lifecycle hooks expose only narrow capabilities.
     pub fn imgui(&mut self) -> &mut imgui::Context {
         self.imgui
     }
@@ -317,6 +328,44 @@ impl InitContext<'_> {
     }
 }
 
+/// Post-attachment initialization capabilities without Context or frame ownership.
+///
+/// ```compile_fail
+/// use dear_app::InitializedContext;
+///
+/// fn replace_context(context: &mut InitializedContext<'_>) {
+///     let _ = std::mem::replace(context.imgui(), dear_app::imgui::Context::create());
+/// }
+/// ```
+pub struct InitializedContext<'a> {
+    pub(crate) imgui: &'a mut imgui::Context,
+    pub(crate) window: &'a Window,
+    pub(crate) config: &'a AppConfig,
+}
+
+impl InitializedContext<'_> {
+    #[must_use]
+    pub fn window(&self) -> &Window {
+        self.window
+    }
+
+    #[must_use]
+    pub fn config(&self) -> &AppConfig {
+        self.config
+    }
+}
+
+/// Event-time capabilities that cannot open or render a Dear ImGui frame.
+///
+/// Frame lifecycle APIs are intentionally unavailable at this boundary:
+///
+/// ```compile_fail
+/// use dear_app::EventContext;
+///
+/// fn steal_frame(context: &mut EventContext<'_>) {
+///     context.imgui().begin_frame();
+/// }
+/// ```
 pub struct EventContext<'a> {
     pub(crate) event: &'a WindowEvent,
     pub(crate) imgui: &'a mut imgui::Context,
@@ -330,10 +379,6 @@ impl EventContext<'_> {
         self.event
     }
 
-    pub fn imgui(&mut self) -> &mut imgui::Context {
-        self.imgui
-    }
-
     #[must_use]
     pub fn window(&self) -> &Window {
         self.window
@@ -345,35 +390,130 @@ impl EventContext<'_> {
     }
 }
 
+/// Terminal resource capabilities without Context or frame ownership.
+///
+/// ```compile_fail
+/// use dear_app::ShutdownContext;
+///
+/// fn replace_context(context: &mut ShutdownContext<'_>) {
+///     let _ = std::mem::replace(context.imgui(), dear_app::imgui::Context::create());
+/// }
+/// ```
 pub struct ShutdownContext<'a> {
     pub(crate) imgui: &'a mut imgui::Context,
     pub(crate) window: &'a Window,
     pub(crate) generation: Option<GpuGeneration>,
 }
 
-/// Pre-frame access to Context-owned resources.
+/// Pre-frame access to Context-owned resources without frame lifecycle authority.
+///
+/// Resource mutations are allowed here, but opening or rendering the frame remains owned by the
+/// runtime:
+///
+/// ```compile_fail
+/// use dear_app::PrepareFrameContext;
+///
+/// fn steal_frame(context: &mut PrepareFrameContext<'_>) {
+///     context.imgui().begin_frame();
+/// }
+/// ```
 pub struct PrepareFrameContext<'a> {
     pub(crate) imgui: &'a mut imgui::Context,
     pub(crate) window: &'a Window,
 }
 
 impl PrepareFrameContext<'_> {
-    /// Returns the Context before its Dear ImGui frame is opened.
-    pub fn imgui(&mut self) -> &mut imgui::Context {
-        self.imgui
-    }
-
     #[must_use]
     pub fn window(&self) -> &Window {
         self.window
     }
 }
 
-impl ShutdownContext<'_> {
-    pub fn imgui(&mut self) -> &mut imgui::Context {
-        self.imgui
-    }
+macro_rules! impl_context_resource_access {
+    ($context:ident) => {
+        impl $context<'_> {
+            /// Borrows Dear ImGui IO without exposing frame lifecycle operations.
+            #[must_use]
+            pub fn io(&self) -> &imgui::Io {
+                self.imgui.io()
+            }
 
+            /// Mutates Dear ImGui IO without exposing frame lifecycle operations.
+            pub fn io_mut(&mut self) -> &mut imgui::Io {
+                self.imgui.io_mut()
+            }
+
+            /// Borrows the global Dear ImGui style.
+            #[must_use]
+            pub fn style(&self) -> &imgui::Style {
+                self.imgui.style()
+            }
+
+            /// Mutates the global Dear ImGui style.
+            pub fn style_mut(&mut self) -> &mut imgui::Style {
+                self.imgui.style_mut()
+            }
+
+            /// Borrows the Context-owned font atlas.
+            #[must_use]
+            pub fn font_atlas(&self) -> &imgui::FontAtlas {
+                self.imgui.font_atlas()
+            }
+
+            /// Transfers an owned texture into the Context-managed texture registry.
+            pub fn register_texture(
+                &mut self,
+                texture: imgui::OwnedTextureData,
+            ) -> imgui::ManagedTextureId {
+                self.imgui.register_texture(texture)
+            }
+
+            /// Reads a managed texture through a non-escaping capability.
+            pub fn with_texture<R>(
+                &self,
+                id: imgui::ManagedTextureId,
+                operation: impl for<'texture> FnOnce(imgui::ManagedTextureRef<'texture>) -> R,
+            ) -> Result<R, imgui::ManagedTextureError> {
+                self.imgui.with_texture(id, operation)
+            }
+
+            /// Mutates a managed texture through a non-escaping capability.
+            pub fn with_texture_mut<R>(
+                &mut self,
+                id: imgui::ManagedTextureId,
+                operation: impl for<'texture> FnOnce(imgui::ManagedTextureMut<'texture>) -> R,
+            ) -> Result<R, imgui::ManagedTextureError> {
+                self.imgui.with_texture_mut(id, operation)
+            }
+
+            /// Mutates a managed texture while flattening access and data-validation errors.
+            pub fn try_with_texture_mut<R>(
+                &mut self,
+                id: imgui::ManagedTextureId,
+                operation: impl for<'texture> FnOnce(
+                    imgui::ManagedTextureMut<'texture>,
+                ) -> Result<R, imgui::TextureDataError>,
+            ) -> Result<R, imgui::ManagedTextureMutationError> {
+                self.imgui.try_with_texture_mut(id, operation)
+            }
+
+            /// Retires a managed texture after outstanding renderer work completes.
+            pub fn remove_texture(
+                &mut self,
+                id: imgui::ManagedTextureId,
+            ) -> Result<(), imgui::ManagedTextureError> {
+                self.imgui.remove_texture(id)
+            }
+        }
+    };
+}
+
+impl_context_resource_access!(EventContext);
+impl_context_resource_access!(InitializedContext);
+impl_context_resource_access!(PrepareFrameContext);
+impl_context_resource_access!(ShutdownContext);
+
+impl ShutdownContext<'_> {
     #[must_use]
     pub fn window(&self) -> &Window {
         self.window
@@ -623,6 +763,23 @@ mod tests {
                 .source()
                 .and_then(|source| source.downcast_ref::<UserError>())
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn frame_ownership_error_reports_its_application_stage() {
+        let _guard = crate::runtime::imgui_test_guard();
+        let context = dear_imgui_rs::Context::create();
+        let stamp = context.frame_lifecycle_stamp();
+        let error = RunError::ImGuiFrameOwnership {
+            stage: ApplicationStage::PrepareFrame,
+            before: stamp,
+            after: stamp,
+        };
+
+        assert_eq!(
+            error.application_stage(),
+            Some(ApplicationStage::PrepareFrame)
         );
     }
 

--- a/dear-app/src/lib.rs
+++ b/dear-app/src/lib.rs
@@ -21,7 +21,7 @@ mod runtime;
 pub use application::{
     AddOns, Application, ApplicationStage, DockingApi, EventContext, ExternalTextureError,
     ExternalTextureHandle, FrameContext, GpuApi, GpuContext, GpuGeneration, InitContext,
-    PrepareFrameContext, RunError, ShutdownContext,
+    InitializedContext, PrepareFrameContext, RunError, ShutdownContext,
 };
 pub use config::{
     AddOnsConfig, AppConfig, DockingConfig, RedrawMode, Theme, WgpuConfig, WgpuPreset,

--- a/dear-app/src/runtime/runner.rs
+++ b/dear-app/src/runtime/runner.rs
@@ -24,8 +24,8 @@ use super::{
     surface::render_surface_frame,
 };
 use crate::{
-    AppConfig, Application, ApplicationStage, GpuGeneration, InitContext, RedrawMode, RunError,
-    ShutdownContext,
+    AppConfig, Application, ApplicationStage, GpuGeneration, InitializedContext, RedrawMode,
+    RunError,
 };
 
 pub(crate) fn run<A: Application + 'static>(
@@ -148,15 +148,19 @@ impl Runtime {
             .ok_or_else(|| RunError::Recovery {
                 message: "initialized callback requested without a GPU generation".to_owned(),
             })?;
-        let mut init = InitContext {
-            imgui: &mut ui.context,
-            window: &window.window,
-            config,
-        };
-        let mut gpu = generation.context(window)?;
-        application
-            .initialized(&mut init, &mut gpu)
-            .map_err(|error| error.during_application_stage(ApplicationStage::Initialized))?;
+        super::state::run_application_frame_boundary(
+            &mut ui.context,
+            ApplicationStage::Initialized,
+            |context| {
+                let mut initialized = InitializedContext {
+                    imgui: context,
+                    window: &window.window,
+                    config,
+                };
+                let mut gpu = generation.context(window)?;
+                application.initialized(&mut initialized, &mut gpu)
+            },
+        )?;
         super::state::validate_supported_imgui_config(&ui.context)
     }
 
@@ -180,17 +184,19 @@ impl Runtime {
             .map_err(|error| super::state::platform_error("Winit event handling", error))?;
 
         let mut exit_requested = matches!(event, WindowEvent::CloseRequested);
-        {
-            let mut context = crate::EventContext {
-                event,
-                imgui: &mut ui.context,
-                window: &window.window,
-                exit_requested: &mut exit_requested,
-            };
-            application
-                .event(&mut context)
-                .map_err(|error| error.during_application_stage(ApplicationStage::Event))?;
-        }
+        super::state::run_application_frame_boundary(
+            &mut ui.context,
+            ApplicationStage::Event,
+            |imgui| {
+                let mut context = crate::EventContext {
+                    event,
+                    imgui,
+                    window: &window.window,
+                    exit_requested: &mut exit_requested,
+                };
+                application.event(&mut context)
+            },
+        )?;
         super::state::validate_supported_imgui_config(&ui.context)?;
 
         let Some(generation) = generations.current() else {
@@ -268,15 +274,13 @@ impl Runtime {
             generations,
         } = self.ownership.get_mut();
         let generation = generations.current_generation();
-        let mut context = ShutdownContext {
-            imgui: &mut ui.context,
-            window: &window.window,
+        super::state::run_application_shutdown(
+            application,
+            &mut ui.context,
+            &window.window,
             generation,
-        };
-        application
-            .shutdown(&mut context)
-            .map_err(|error| error.during_application_stage(ApplicationStage::Shutdown))
-            .err()
+        )
+        .err()
     }
 
     fn fail(&mut self, error: RunError) {

--- a/dear-app/src/runtime/shutdown.rs
+++ b/dear-app/src/runtime/shutdown.rs
@@ -1,7 +1,7 @@
 //! Runtime initialization rollback and exactly-once shutdown coordination.
 
 use super::state::{UiState, WindowState};
-use crate::{Application, ApplicationStage, RunError, ShutdownContext};
+use crate::{Application, RunError};
 
 pub(super) fn abort_runtime_initialization<A: Application>(
     application: &mut A,
@@ -10,16 +10,12 @@ pub(super) fn abort_runtime_initialization<A: Application>(
     primary_error: RunError,
 ) -> RunError {
     super::state::preserve_initialization_error(primary_error, move || {
-        let application_result = {
-            let mut shutdown = ShutdownContext {
-                imgui: &mut ui.context,
-                window: &window.window,
-                generation: None,
-            };
-            application
-                .shutdown(&mut shutdown)
-                .map_err(|error| error.during_application_stage(ApplicationStage::Shutdown))
-        };
+        let application_result = super::state::run_application_shutdown(
+            application,
+            &mut ui.context,
+            &window.window,
+            None,
+        );
         let platform_result = ui.release_platform_then_teardown_or_quarantine();
         drop(window);
         application_result.and(platform_result)

--- a/dear-app/src/runtime/state.rs
+++ b/dear-app/src/runtime/state.rs
@@ -27,6 +27,56 @@ pub(crate) fn platform_error(
     }
 }
 
+pub(crate) fn run_application_frame_boundary<T>(
+    context: &mut imgui::Context,
+    stage: ApplicationStage,
+    callback: impl FnOnce(&mut imgui::Context) -> Result<T, RunError>,
+) -> Result<T, RunError> {
+    let before = context.frame_lifecycle_stamp();
+    let result = callback(context);
+    let result = result.map_err(|error| error.during_application_stage(stage));
+    let after = context.frame_lifecycle_stamp();
+    if after == before {
+        return result;
+    }
+
+    if after.state() == imgui::FrameLifecycleState::InFrame {
+        context.end_frame();
+    }
+    let ownership_error = RunError::ImGuiFrameOwnership {
+        stage,
+        before,
+        after,
+    };
+    match result {
+        Ok(_) => Err(ownership_error),
+        Err(primary) => {
+            tracing::warn!(
+                %primary,
+                secondary = %ownership_error,
+                "application callback failed after changing Dear ImGui frame ownership"
+            );
+            Err(primary)
+        }
+    }
+}
+
+pub(crate) fn run_application_shutdown<A: Application>(
+    application: &mut A,
+    context: &mut imgui::Context,
+    window: &Window,
+    generation: Option<GpuGeneration>,
+) -> Result<(), RunError> {
+    run_application_frame_boundary(context, ApplicationStage::Shutdown, |imgui| {
+        let mut shutdown = ShutdownContext {
+            imgui,
+            window,
+            generation,
+        };
+        application.shutdown(&mut shutdown)
+    })
+}
+
 pub(crate) fn preserve_initialization_error(
     primary_error: RunError,
     cleanup: impl FnOnce() -> Result<(), RunError>,
@@ -46,14 +96,7 @@ fn shutdown_after_initialization_failure<A: Application>(
     context: &mut imgui::Context,
     window: &Window,
 ) -> Result<(), RunError> {
-    let mut shutdown = ShutdownContext {
-        imgui: context,
-        window,
-        generation: None,
-    };
-    application
-        .shutdown(&mut shutdown)
-        .map_err(|error| error.during_application_stage(ApplicationStage::Shutdown))
+    run_application_shutdown(application, context, window, None)
 }
 
 fn abort_context_initialization<A: Application>(
@@ -312,14 +355,18 @@ impl UiState {
             context,
             |application, context| {
                 configure_context(context, config);
-                let mut init = InitContext {
-                    imgui: context,
-                    window: &window.window,
-                    config,
-                };
-                application.configure_imgui(&mut init).map_err(|error| {
-                    error.during_application_stage(ApplicationStage::ConfigureImgui)
-                })?;
+                run_application_frame_boundary(
+                    context,
+                    ApplicationStage::ConfigureImgui,
+                    |context| {
+                        let mut init = InitContext {
+                            imgui: context,
+                            window: &window.window,
+                            config,
+                        };
+                        application.configure_imgui(&mut init)
+                    },
+                )?;
                 validate_supported_imgui_config(context)
             },
             |_, context| {
@@ -591,7 +638,12 @@ fn configure_context(context: &mut imgui::Context, config: &AppConfig) {
 mod tests {
     use std::{cell::Cell, rc::Rc};
 
-    use super::{initialize_configured_ui, platform_error, preserve_initialization_error};
+    use dear_imgui_rs::{FrameLifecycleState, FramePrepareOptions};
+
+    use super::{
+        initialize_configured_ui, platform_error, preserve_initialization_error,
+        run_application_frame_boundary,
+    };
     use crate::{ApplicationStage, RunError};
 
     #[derive(Debug)]
@@ -607,6 +659,104 @@ mod tests {
     struct InitializationProbe {
         configured: usize,
         shutdown_calls: usize,
+    }
+
+    fn prepared_context() -> (
+        dear_imgui_rs::Context,
+        dear_imgui_rs::render::SynchronousRendererConsumer,
+    ) {
+        let mut context = dear_imgui_rs::Context::create();
+        context.prepare_frame(
+            FramePrepareOptions::new([640.0, 480.0], 1.0 / 60.0).renderer_has_textures(),
+        );
+        let consumer = context
+            .create_synchronous_renderer_consumer()
+            .expect("the test renderer consumer must attach");
+        (context, consumer)
+    }
+
+    fn leak_open_frame(context: &mut dear_imgui_rs::Context) {
+        let frame = context.begin_frame();
+        std::mem::forget(frame);
+    }
+
+    #[test]
+    fn application_boundary_rejects_and_closes_a_leaked_frame() {
+        let _guard = crate::runtime::imgui_test_guard();
+        let (mut context, _consumer) = prepared_context();
+        let error = run_application_frame_boundary(
+            &mut context,
+            ApplicationStage::PrepareFrame,
+            |context| {
+                leak_open_frame(context);
+                Ok(())
+            },
+        )
+        .expect_err("frame ownership changes must be rejected");
+
+        assert!(matches!(
+            error,
+            RunError::ImGuiFrameOwnership {
+                stage: ApplicationStage::PrepareFrame,
+                before,
+                after,
+            } if before.state() == FrameLifecycleState::Idle
+                && after.state() == FrameLifecycleState::InFrame
+        ));
+        assert_eq!(context.frame_lifecycle_state(), FrameLifecycleState::Idle);
+    }
+
+    #[test]
+    fn application_boundary_rejects_an_idle_to_idle_frame_round_trip() {
+        let _guard = crate::runtime::imgui_test_guard();
+        let (mut context, _consumer) = prepared_context();
+        let error = run_application_frame_boundary(
+            &mut context,
+            ApplicationStage::ConfigureImgui,
+            |context| {
+                drop(context.begin_frame());
+                Ok(())
+            },
+        )
+        .expect_err("opening and ending a frame inside a callback must remain observable");
+
+        assert!(matches!(
+            error,
+            RunError::ImGuiFrameOwnership { before, after, .. }
+                if before.state() == FrameLifecycleState::Idle
+                    && after.state() == FrameLifecycleState::Idle
+                    && before.context_id() == after.context_id()
+                    && before != after
+        ));
+        assert_eq!(context.frame_lifecycle_state(), FrameLifecycleState::Idle);
+    }
+
+    #[test]
+    fn application_boundary_preserves_the_callback_error_and_closes_a_leaked_frame() {
+        let _guard = crate::runtime::imgui_test_guard();
+        let (mut context, _consumer) = prepared_context();
+        let error = run_application_frame_boundary(
+            &mut context,
+            ApplicationStage::ConfigureImgui,
+            |context| {
+                leak_open_frame(context);
+                Err::<(), _>(RunError::application_message(
+                    ApplicationStage::ConfigureImgui,
+                    "primary failure",
+                ))
+            },
+        )
+        .expect_err("the original callback failure must remain primary");
+
+        assert_eq!(
+            error.application_stage(),
+            Some(ApplicationStage::ConfigureImgui)
+        );
+        assert_eq!(
+            error.to_string(),
+            "application callback failed during configure_imgui: primary failure"
+        );
+        assert_eq!(context.frame_lifecycle_state(), FrameLifecycleState::Idle);
     }
 
     #[test]

--- a/dear-app/src/runtime/surface.rs
+++ b/dear-app/src/runtime/surface.rs
@@ -288,13 +288,17 @@ pub(super) fn render_surface_frame<A: Application>(
                 docking,
             } = ui;
 
-            let mut prepare_frame = PrepareFrameContext {
-                imgui: context,
-                window: &window.window,
-            };
-            application
-                .prepare_frame(&mut prepare_frame)
-                .map_err(|error| error.during_application_stage(ApplicationStage::PrepareFrame))?;
+            super::state::run_application_frame_boundary(
+                context,
+                ApplicationStage::PrepareFrame,
+                |context| {
+                    let mut prepare_frame = PrepareFrameContext {
+                        imgui: context,
+                        window: &window.window,
+                    };
+                    application.prepare_frame(&mut prepare_frame)
+                },
+            )?;
             super::state::validate_supported_imgui_config(context)?;
             platform
                 .prepare_frame(context, &window.window)
@@ -360,7 +364,7 @@ pub(super) fn build_frame<'ctx>(
     context: &'ctx mut dear_imgui_rs::Context,
     build: impl FnOnce(&dear_imgui_rs::Ui) -> Result<(), RunError>,
 ) -> Result<FrameToken<'ctx>, RunError> {
-    let frame = context.begin_frame();
+    let frame = context.try_begin_frame().map_err(RunError::ImGuiFrame)?;
     build(frame.ui())?;
     Ok(frame)
 }

--- a/dear-imgui/src/context.rs
+++ b/dear-imgui/src/context.rs
@@ -35,7 +35,9 @@ pub use self::error::{
     ContextActivationError, ContextActivationReason, ContextScopeError, ContextSuspensionError,
     ContextSuspensionReason, ScopedActivationError,
 };
-pub use self::frame::{FrameLifecycleState, FramePrepareOptions, FrameResult, FrameToken};
+pub use self::frame::{
+    FrameLifecycleStamp, FrameLifecycleState, FramePrepareOptions, FrameResult, FrameToken,
+};
 pub use self::snapshot_hub::RendererTextureReset;
 pub use self::suspended::SuspendedContext;
 pub(crate) use self::texture_registry::SharedTextureRegistry;

--- a/dear-imgui/src/context/binding.rs
+++ b/dear-imgui/src/context/binding.rs
@@ -25,6 +25,11 @@ thread_local! {
     // old Context generation and cannot restore the reused address by mistake.
     static MANAGED_CONTEXTS: RefCell<HashMap<usize, ManagedContextEntry>> =
         RefCell::new(HashMap::new());
+    // Main viewport addresses are stable for the lifetime of their native Context. Keeping a
+    // generation-bound reverse index makes Viewport::is_main independent from GImGui and avoids
+    // scanning historical Context tombstones on every platform snapshot.
+    static LIVE_MAIN_VIEWPORTS: RefCell<HashMap<usize, ContextId>> =
+        RefCell::new(HashMap::new());
     static BOUND_CONTEXT_DEPTH: Cell<usize> = const { Cell::new(0) };
 }
 
@@ -82,6 +87,45 @@ pub(super) fn bound_context_scope_active() -> bool {
     BOUND_CONTEXT_DEPTH.with(|depth| depth.get() != 0)
 }
 
+/// Returns whether `viewport` is the main viewport of one of this thread's live managed Contexts.
+///
+/// The viewport wrapper does not carry an owner field, while Context binding deliberately restores
+/// the previous native Context when a safe closure returns. Keep the ownership lookup here so
+/// viewport predicates do not silently change meaning when another managed Context is current.
+pub(crate) fn viewport_is_main_viewport(viewport: *const sys::ImGuiViewport) -> bool {
+    if viewport.is_null() {
+        return false;
+    }
+
+    if LIVE_MAIN_VIEWPORTS.with(|viewports| viewports.borrow().contains_key(&(viewport as usize))) {
+        return true;
+    }
+
+    // Raw FFI users may construct a Viewport for an unmanaged Context. Preserve that unsafe
+    // escape hatch without making managed secondary viewports call into native state.
+    let _lock = CTX_MUTEX.lock();
+    let current = unsafe { sys::igGetCurrentContext() };
+    if current.is_null() {
+        return false;
+    }
+    let current_is_managed = MANAGED_CONTEXTS.with(|contexts| {
+        matches!(
+            contexts.borrow().get(&(current as usize)),
+            Some(ManagedContextEntry::Live { state, .. })
+                if state.upgrade().is_some_and(|state| {
+                    state.lifecycle() != ContextLifecycle::NativeDestroyed
+                        && state.raw_during_teardown() == current
+                })
+        )
+    });
+    if current_is_managed {
+        return false;
+    }
+
+    let main = unsafe { sys::igGetMainViewport() };
+    !main.is_null() && std::ptr::eq(viewport, main.cast_const())
+}
+
 #[derive(Clone)]
 enum ManagedContextEntry {
     Live {
@@ -128,6 +172,7 @@ pub enum ContextLifecycle {
 pub(crate) struct ContextState {
     id: ContextId,
     address: usize,
+    main_viewport_address: usize,
     raw: Cell<*mut sys::ImGuiContext>,
     lifecycle: Cell<ContextLifecycle>,
     dockspace_submissions: RefCell<FrameIdClaims>,
@@ -168,9 +213,16 @@ impl fmt::Debug for ContextState {
 
 impl ContextState {
     pub(crate) fn new(id: ContextId, raw: *mut sys::ImGuiContext) -> Rc<Self> {
+        let main_viewport = with_bound_context(raw, || unsafe { sys::igGetMainViewport() });
+        assert!(
+            !main_viewport.is_null(),
+            "new ImGui context returned a null main viewport"
+        );
+        let main_viewport_address = main_viewport as usize;
         let state = Rc::new(Self {
             id,
             address: raw as usize,
+            main_viewport_address,
             raw: Cell::new(raw),
             lifecycle: Cell::new(ContextLifecycle::Alive),
             dockspace_submissions: RefCell::new(FrameIdClaims::default()),
@@ -184,6 +236,14 @@ impl ContextState {
                     state: Rc::downgrade(&state),
                 },
             );
+        });
+        LIVE_MAIN_VIEWPORTS.with(|viewports| {
+            let mut viewports = viewports.borrow_mut();
+            debug_assert!(
+                !viewports.contains_key(&main_viewport_address),
+                "two live ImGui contexts exposed the same main viewport address"
+            );
+            viewports.insert(main_viewport_address, id);
         });
         state
     }
@@ -206,13 +266,24 @@ impl ContextState {
     }
 
     pub(crate) fn mark_native_destroyed(&self) {
+        self.unregister_main_viewport();
         self.raw.set(ptr::null_mut());
         self.lifecycle.set(ContextLifecycle::NativeDestroyed);
+    }
+
+    fn unregister_main_viewport(&self) {
+        let _ = LIVE_MAIN_VIEWPORTS.try_with(|viewports| {
+            let mut viewports = viewports.borrow_mut();
+            if viewports.get(&self.main_viewport_address) == Some(&self.id) {
+                viewports.remove(&self.main_viewport_address);
+            }
+        });
     }
 }
 
 impl Drop for ContextState {
     fn drop(&mut self) {
+        self.unregister_main_viewport();
         let _ = MANAGED_CONTEXTS.try_with(|contexts| {
             let mut contexts = contexts.borrow_mut();
             let Some(entry) = contexts.get_mut(&self.address) else {

--- a/dear-imgui/src/context/frame.rs
+++ b/dear-imgui/src/context/frame.rs
@@ -26,6 +26,32 @@ pub enum FrameLifecycleState {
     Rendered,
 }
 
+/// Comparable identity and native progress marker for a Context frame boundary.
+///
+/// Integrations can retain a stamp before invoking application code and require the same stamp
+/// afterward. Equality covers the Context generation, native frame sequence, and current lifecycle
+/// state, so an `Idle -> Idle` frame round trip is still observable.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct FrameLifecycleStamp {
+    context: super::ContextId,
+    native_frame: i32,
+    state: FrameLifecycleState,
+}
+
+impl FrameLifecycleStamp {
+    /// Return the Context generation captured by this stamp.
+    #[must_use]
+    pub const fn context_id(self) -> super::ContextId {
+        self.context
+    }
+
+    /// Return the frame lifecycle state captured by this stamp.
+    #[must_use]
+    pub const fn state(self) -> FrameLifecycleState {
+        self.state
+    }
+}
+
 /// Options used by [`Context::prepare_frame`].
 #[derive(Copy, Clone, Debug)]
 pub struct FramePrepareOptions {
@@ -119,9 +145,17 @@ impl Context {
 
     /// Return the current frame lifecycle state for this context.
     pub fn frame_lifecycle_state(&self) -> FrameLifecycleState {
+        self.frame_lifecycle_stamp().state()
+    }
+
+    /// Capture this Context's identity and native frame progress as one comparable value.
+    ///
+    /// This is intended for engine callback boundaries that must reject both an open frame and a
+    /// frame that was opened and closed entirely inside the callback.
+    pub fn frame_lifecycle_stamp(&self) -> FrameLifecycleStamp {
         let _guard = CTX_MUTEX.lock();
-        self.assert_current_context("Context::frame_lifecycle_state()");
-        self.frame_lifecycle_state_unlocked()
+        self.assert_current_context("Context::frame_lifecycle_stamp()");
+        self.frame_lifecycle_stamp_unlocked()
     }
 
     /// End an open frame without producing render data.
@@ -406,14 +440,23 @@ dear-imgui-winit::WinitPlatform::prepare_frame().",
     }
 
     pub(super) fn frame_lifecycle_state_unlocked(&self) -> FrameLifecycleState {
+        self.frame_lifecycle_stamp_unlocked().state()
+    }
+
+    fn frame_lifecycle_stamp_unlocked(&self) -> FrameLifecycleStamp {
         unsafe {
             let raw = &*self.raw;
-            if raw.WithinFrameScope {
+            let state = if raw.WithinFrameScope {
                 FrameLifecycleState::InFrame
             } else if raw.FrameCountRendered == raw.FrameCount && raw.FrameCount > 0 {
                 FrameLifecycleState::Rendered
             } else {
                 FrameLifecycleState::Idle
+            };
+            FrameLifecycleStamp {
+                context: self.id(),
+                native_frame: raw.FrameCount,
+                state,
             }
         }
     }

--- a/dear-imgui/src/context/tests.rs
+++ b/dear-imgui/src/context/tests.rs
@@ -931,6 +931,26 @@ fn end_frame_is_idempotent_and_allows_a_new_frame() {
     );
 }
 
+#[test]
+fn frame_lifecycle_stamp_observes_an_idle_round_trip() {
+    let _guard = crate::test_support::imgui_context_guard();
+    let mut ctx = Context::create();
+    ctx.font_atlas()
+        .try_claim_legacy_renderer()
+        .expect("legacy renderer font atlas should be available")
+        .build();
+    ctx.prepare_frame(super::FramePrepareOptions::new([128.0, 128.0], 1.0 / 60.0));
+
+    let before = ctx.frame_lifecycle_stamp();
+    drop(ctx.begin_frame());
+    let after = ctx.frame_lifecycle_stamp();
+
+    assert_eq!(before.context_id(), after.context_id());
+    assert_eq!(before.state(), super::FrameLifecycleState::Idle);
+    assert_eq!(after.state(), super::FrameLifecycleState::Idle);
+    assert_ne!(before, after);
+}
+
 #[cfg(feature = "multi-viewport")]
 #[test]
 fn set_monitors_replaces_and_clears_imgui_owned_storage() {

--- a/dear-imgui/src/platform_io/viewport.rs
+++ b/dear-imgui/src/platform_io/viewport.rs
@@ -177,18 +177,14 @@ impl Viewport {
         }
     }
 
-    /// Check whether this is the currently bound Context's application-owned main viewport.
+    /// Check whether this is an application-owned main viewport.
     ///
-    /// Viewport IDs are not used for this decision because the same numeric ID may appear in
-    /// different Contexts. Returns `false` when no Context is current.
+    /// The owning managed Context is used for this decision, so the result remains stable while
+    /// another managed Context is temporarily bound by a nested safe operation. Viewport IDs are
+    /// not used because the same numeric ID may appear in different Contexts. A viewport created
+    /// through an unmanaged raw FFI path is resolved against the currently bound native Context.
     pub fn is_main(&self) -> bool {
-        unsafe {
-            if sys::igGetCurrentContext().is_null() {
-                return false;
-            }
-            let main = sys::igGetMainViewport();
-            !main.is_null() && std::ptr::eq(self.as_raw(), main.cast_const())
-        }
+        crate::context::binding::viewport_is_main_viewport(self.as_raw())
     }
 
     /// Check whether this is a secondary platform window managed for Dear ImGui.
@@ -453,25 +449,31 @@ mod tests {
     }
 
     #[test]
-    fn main_viewport_identity_is_scoped_to_the_current_context() {
+    fn main_viewport_identity_is_scoped_to_its_managed_context() {
         let _guard = crate::test_support::imgui_context_guard();
         let context_a = Context::create();
         let binding_a = context_a.binding();
         let main_a = unsafe { sys::igGetMainViewport() };
         unsafe { sys::igSetCurrentContext(std::ptr::null_mut()) };
-        let _context_b = Context::create();
+        let context_b = Context::create();
         let main_b = unsafe { sys::igGetMainViewport() };
+        unsafe { sys::igSetCurrentContext(std::ptr::null_mut()) };
 
         unsafe {
             assert_eq!((*main_a).ID, (*main_b).ID);
-            assert!(!Viewport::from_raw(main_a).is_main());
+            assert!(Viewport::from_raw(main_a).is_main());
             assert!(Viewport::from_raw(main_b).is_main());
         }
 
         binding_a.with_bound_context(|| unsafe {
             assert!(Viewport::from_raw(main_a).is_main());
-            assert!(!Viewport::from_raw(main_b).is_main());
+            assert!(Viewport::from_raw(main_b).is_main());
         });
+
+        drop(context_a);
+        assert!(!crate::context::binding::viewport_is_main_viewport(main_a));
+        assert!(crate::context::binding::viewport_is_main_viewport(main_b));
+        drop(context_b);
     }
 
     #[test]

--- a/examples/00-quickstart/application_lifecycle.rs
+++ b/examples/00-quickstart/application_lifecycle.rs
@@ -2,7 +2,7 @@
 
 use dear_app::{
     AppConfig, Application, EventContext, FrameContext, GpuContext, InitContext,
-    PrepareFrameContext, RunError, ShutdownContext, imgui::Condition, run,
+    InitializedContext, PrepareFrameContext, RunError, ShutdownContext, imgui::Condition, run,
 };
 
 /// Long-lived state owned by `Application`; it is not recreated with GPU resources.
@@ -49,7 +49,7 @@ impl Application for LifecycleApp {
 
     fn initialized(
         &mut self,
-        _init: &mut InitContext<'_>,
+        _context: &mut InitializedContext<'_>,
         gpu: &mut GpuContext<'_>,
     ) -> Result<(), RunError> {
         self.initialized_calls += 1;

--- a/examples/01-renderers/dear_app_external_texture.rs
+++ b/examples/01-renderers/dear_app_external_texture.rs
@@ -6,7 +6,7 @@
 
 use dear_app::{
     AppConfig, Application, ApplicationStage, ExternalTextureHandle, FrameContext, GpuApi,
-    GpuContext, InitContext, RedrawMode, RunError, Theme, WgpuConfig, WgpuPreset, run,
+    GpuContext, InitializedContext, RedrawMode, RunError, Theme, WgpuConfig, WgpuPreset, run,
 };
 use dear_imgui_rs::Condition;
 use wgpu as wgpu_rs;
@@ -161,7 +161,7 @@ impl ExternalTextureApp {
 impl Application for ExternalTextureApp {
     fn initialized(
         &mut self,
-        _init: &mut InitContext<'_>,
+        _context: &mut InitializedContext<'_>,
         context: &mut GpuContext<'_>,
     ) -> Result<(), RunError> {
         self.register(context.gpu(), ApplicationStage::Initialized)

--- a/examples/01-renderers/sdl3_sdlrenderer3.rs
+++ b/examples/01-renderers/sdl3_sdlrenderer3.rs
@@ -82,7 +82,10 @@ impl SdlRendererApp {
     }
 
     fn iterate(&self) -> Result<AppResult, Box<dyn Error>> {
-        let mut events = self.events.try_drain()?;
+        let mut events = self.events.drain();
+        if let Some(error) = events.first_fault() {
+            return Err(error.into());
+        }
         let mut main_guard = self.main.assert_get().borrow_mut();
         let main = &mut *main_guard;
         while let Some(event) = events.pop() {

--- a/examples/01-renderers/sdl3_wgpu.rs
+++ b/examples/01-renderers/sdl3_wgpu.rs
@@ -156,13 +156,11 @@ impl WgpuApp {
     }
 
     fn process_events(&self) -> AppResult {
-        let mut events = match self.events.try_drain() {
-            Ok(events) => events,
-            Err(error) => {
-                eprintln!("SDL3 callback event handoff failed: {error}");
-                return AppResult::Failure;
-            }
-        };
+        let mut events = self.events.drain();
+        if let Some(error) = events.first_fault() {
+            eprintln!("SDL3 callback event handoff failed: {error}");
+            return AppResult::Failure;
+        }
         let mut main_guard = self.main.assert_get().borrow_mut();
         let main = &mut *main_guard;
         while let Some(event) = events.pop() {

--- a/examples/02-docking/sdl3_ash_multi_viewport.rs
+++ b/examples/02-docking/sdl3_ash_multi_viewport.rs
@@ -2234,13 +2234,11 @@ impl Sdl3AshApp {
     }
 
     fn app_iterate(&self) -> AppResult {
-        let mut events = match self.events.try_drain() {
-            Ok(events) => events,
-            Err(error) => {
-                eprintln!("SDL3 callback event handoff failed: {error}");
-                return AppResult::Failure;
-            }
-        };
+        let mut events = self.events.drain();
+        if let Some(error) = events.first_fault() {
+            eprintln!("SDL3 callback event handoff failed: {error}");
+            return AppResult::Failure;
+        }
         let mut main_guard = self.main.assert_get().borrow_mut();
         let main = &mut main_guard.app;
         while let Some(event) = events.pop() {

--- a/examples/02-docking/sdl3_opengl_multi_viewport.rs
+++ b/examples/02-docking/sdl3_opengl_multi_viewport.rs
@@ -258,13 +258,11 @@ impl OpenGlApp {
     }
 
     fn process_events(&self) -> AppResult {
-        let mut events = match self.events.try_drain() {
-            Ok(events) => events,
-            Err(error) => {
-                eprintln!("SDL3 callback event handoff failed: {error}");
-                return AppResult::Failure;
-            }
-        };
+        let mut events = self.events.drain();
+        if let Some(error) = events.first_fault() {
+            eprintln!("SDL3 callback event handoff failed: {error}");
+            return AppResult::Failure;
+        }
         let mut main_guard = self.main.assert_get().borrow_mut();
         let main = &mut *main_guard;
         while let Some(event) = events.pop() {

--- a/examples/02-docking/sdl3_sdlgpu_multi_viewport.rs
+++ b/examples/02-docking/sdl3_sdlgpu_multi_viewport.rs
@@ -122,7 +122,10 @@ impl SdlGpuApp {
     }
 
     fn iterate(&self) -> Result<AppResult, Box<dyn Error>> {
-        let mut events = self.events.try_drain()?;
+        let mut events = self.events.drain();
+        if let Some(error) = events.first_fault() {
+            return Err(error.into());
+        }
         let mut main_guard = self.main.assert_get().borrow_mut();
         let main = &mut *main_guard;
         while let Some(event) = events.pop() {

--- a/examples/02-docking/sdl3_wgpu_multi_viewport.rs
+++ b/examples/02-docking/sdl3_wgpu_multi_viewport.rs
@@ -176,13 +176,11 @@ impl WgpuMultiViewportApp {
     }
 
     fn process_events(&self) -> AppResult {
-        let mut events = match self.events.try_drain() {
-            Ok(events) => events,
-            Err(error) => {
-                eprintln!("SDL3 callback event handoff failed: {error}");
-                return AppResult::Failure;
-            }
-        };
+        let mut events = self.events.drain();
+        if let Some(error) = events.first_fault() {
+            eprintln!("SDL3 callback event handoff failed: {error}");
+            return AppResult::Failure;
+        }
         let mut main_guard = self.main.assert_get().borrow_mut();
         let main = &mut *main_guard;
         while let Some(event) = events.pop() {

--- a/examples/03-features/managed_texture_minimal.rs
+++ b/examples/03-features/managed_texture_minimal.rs
@@ -55,21 +55,17 @@ impl ManagedTextureApp {
         pixels
     }
 
-    fn register(
-        &mut self,
-        context: &mut dear_imgui_rs::Context,
-        revision: u32,
-    ) -> Result<(), TextureDataError> {
-        self.texture = Some(context.register_texture(Self::texture_data(revision)?));
+    fn record_registration(&mut self, texture: ManagedTextureId, revision: u32) {
+        self.texture = Some(texture);
         self.revision = revision;
-        Ok(())
     }
 }
 
 impl Application for ManagedTextureApp {
     fn configure_imgui(&mut self, context: &mut InitContext<'_>) -> Result<(), RunError> {
-        self.register(context.imgui(), self.revision)
+        let texture = Self::texture_data(self.revision)
             .map_err(|error| RunError::application(ApplicationStage::ConfigureImgui, error))?;
+        self.record_registration(context.imgui().register_texture(texture), self.revision);
         Ok(())
     }
 
@@ -86,7 +82,6 @@ impl Application for ManagedTextureApp {
                 let revision = self.revision.wrapping_add(1);
                 let pixels = Self::pixels(revision);
                 context
-                    .imgui()
                     .try_with_texture_mut(texture, |mut texture| texture.replace_pixels(&pixels))
                     .map_err(|error| {
                         RunError::application(ApplicationStage::PrepareFrame, error)
@@ -113,7 +108,6 @@ impl Application for ManagedTextureApp {
                     }
                 }
                 context
-                    .imgui()
                     .try_with_texture_mut(texture, |mut texture| {
                         texture
                             .update_subresource(TextureSubresource::new(region, row_pitch, &pixels))
@@ -127,17 +121,18 @@ impl Application for ManagedTextureApp {
                 let Some(texture) = self.texture else {
                     return Ok(());
                 };
-                context.imgui().remove_texture(texture).map_err(|error| {
+                context.remove_texture(texture).map_err(|error| {
                     RunError::application(ApplicationStage::PrepareFrame, error)
                 })?;
                 self.texture = None;
             }
             TextureAction::Recreate => {
                 if self.texture.is_none() {
-                    self.register(context.imgui(), self.revision.wrapping_add(1))
-                        .map_err(|error| {
-                            RunError::application(ApplicationStage::PrepareFrame, error)
-                        })?;
+                    let revision = self.revision.wrapping_add(1);
+                    let texture = Self::texture_data(revision).map_err(|error| {
+                        RunError::application(ApplicationStage::PrepareFrame, error)
+                    })?;
+                    self.record_registration(context.register_texture(texture), revision);
                 }
             }
         }

--- a/examples/03-features/style_and_fonts.rs
+++ b/examples/03-features/style_and_fonts.rs
@@ -200,12 +200,12 @@ impl StyleAndFontsApp {
         context: &mut PrepareFrameContext<'_>,
     ) -> Result<(), RunError> {
         if let Some(theme) = self.pending_theme.take() {
-            theme.theme().apply_to_context(context.imgui());
+            theme.theme().apply_to_style(context.style_mut());
             self.status = format!("Applied {} before opening this frame.", theme.label());
         }
 
         if let Some(scale) = self.pending_global_font_scale.take() {
-            context.imgui().style_mut().set_font_scale_main(scale);
+            context.style_mut().set_font_scale_main(scale);
             self.status = format!("Global font scale is now {scale:.2}x.");
         }
 
@@ -217,7 +217,7 @@ impl StyleAndFontsApp {
                 .ok_or_else(|| Self::missing_fonts(ApplicationStage::PrepareFrame))?;
 
             if fonts.compact.is_none() {
-                let atlas = context.imgui().font_atlas();
+                let atlas = context.font_atlas();
                 let compact = atlas.add_font(&[FontSource::default_bitmap_with_size(13.0)
                     .with_config(FontConfig::new().name("Compact bitmap UI"))]);
 

--- a/examples/support/sdl3_glow_multi_viewport_runtime.rs
+++ b/examples/support/sdl3_glow_multi_viewport_runtime.rs
@@ -562,7 +562,10 @@ impl<S: ViewportScenario> GlowApp<S> {
     }
 
     fn process_events(&self) -> Result<AppResult, Box<dyn Error>> {
-        let mut events = self.events.try_drain()?;
+        let mut events = self.events.drain();
+        if let Some(error) = events.first_fault() {
+            return Err(error.into());
+        }
         let mut main = self.main.assert_get().borrow_mut();
         let main = main
             .as_mut()


### PR DESCRIPTION
- What
  - Make native viewport identity, callback delivery, Bevy frame input, and `dear-app` callback access obey explicit ownership boundaries.
  - Stale viewport generations can no longer affect reused windows, callback faults and events are observed atomically, and engine integrations cannot split or replace a live Dear ImGui frame transaction.

- Why
  - The previous APIs exposed phase controls and full `Context` access after backend attachment. Safe application code could therefore retain stale native identity, suspend part of an input transaction, or complete an entire frame inside a callback without the integration detecting it.
  - This change makes those invalid states unrepresentable or explicitly fallible instead of relying on application call order.

- Affected crates
  - [x] dear-imgui-rs
  - [ ] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [x] backends/dear-imgui-winit
  - [x] backends/dear-imgui-sdl3
  - [x] backends/dear-imgui-bevy
  - [x] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [x] CI / tooling / docs

- Behavior
  - [x] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [ ] No behavior change (refactor/cleanup)
  - Native prebuilt artifacts and their selection contract are unchanged.

- Breaking changes
  - [ ] None
  - [x] Yes:
    - SDL3 callback applications replace `try_drain` and `Sdl3CallbackEventQueue` with one atomic `drain` batch.
    - Bevy Context queries and pass registration are fallible; application input producers use `add_imgui_input_producers`; `ImguiInputSystems` is removed.
    - `dear-app::Application::initialized` receives `InitializedContext`, shutdown no longer exposes the full `Context`, and frame ownership errors report lifecycle stamps.

- Testing / validation
  - `cargo nextest run -j 1 -p dear-imgui-rs --features multi-viewport` - 413 passed.
  - `cargo nextest run -j 1 -p dear-imgui-winit --lib --features multi-viewport` - 114 passed.
  - `cargo nextest run -j 1 -p dear-imgui-sdl3 --lib --no-default-features` - 59 passed.
  - `cargo nextest run -j 1 -p dear-imgui-bevy --lib --features multi-viewport` - 283 passed, 3 skipped.
  - `cargo nextest run -j 1 -p dear-app --all-features` - 66 passed.
  - Core, SDL3, Bevy, and `dear-app` doctests passed, including deletion-boundary compile-fail coverage.
  - Every SDL3 renderer/platform example route compiled individually on Windows x86_64 MSVC.

- Docs
  - [ ] N/A
  - [x] Updated README / crate docs
  - Updated root and crate changelogs with migration guidance.

- Links
  - N/A
