### PR TITLE
chore(release): prepare 0.16.0-alpha.3 development train

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ## [Unreleased]
 
+The alpha.3 candidate continues the ownership-first 0.16 migration with stricter host-runtime transactions and a focused regression fix for accidental fallback-window rendering. [PR #70](https://github.com/Latias94/dear-imgui-rs/pull/70)
+
 ### Breaking Changes and Migration
 
 - SDL3 callback-mode applications must replace `Sdl3CallbackEventHandoff::try_drain` and `Sdl3CallbackEventQueue` with `drain`, inspect the returned batch through `faults()`, and then consume its retained events. The atomic batch preserves every distinct deferred fault and keeps ordered input available after overflow or lock-poison recovery.
@@ -21,9 +23,11 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ### Fixed
 
+- `ScopeSnapshot` now reads Dear ImGui's current window without marking the implicit fallback window as written, so ending an empty top-level window no longer creates an unintended debug window. Thanks to [@jamsterwes](https://github.com/jamsterwes) for the report, fix, and regression test. [PR #69](https://github.com/Latias94/dear-imgui-rs/pull/69)
 - `Viewport::is_main` now identifies main viewports across all live managed Contexts without depending on whichever native Context is temporarily current.
 - `dear-app` now reports and closes frames leaked by application callbacks while preserving the callback's original error as the primary failure.
 - SDL3 callback coalescing now uses a bounded indexed queue, keeping high-frequency mouse, window, and display state updates O(1) without changing FIFO, reserve, or overflow behavior.
+- Release automation now keeps generated release notes outside the checkout, so clean-worktree publication checks remain authoritative. [PR #68](https://github.com/Latias94/dear-imgui-rs/pull/68)
 
 ## [0.16.0-alpha.2] - 2026-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dear-app"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "dear-imgui-rs",
  "dear-imgui-test-engine",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "dear-file-browser"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "chrono",
  "dear-imgui-rs",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-ash"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "ash",
  "ash-window",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-bevy"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "flate2",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-glow"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "dear-imgui-rs",
  "dear-imgui-winit",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-reflect"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "dear-imgui-reflect-derive",
  "dear-imgui-rs",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-reflect-derive"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "approx",
  "bitflags 2.13.0",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sdl3"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-test-engine"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags 2.13.0",
  "dear-imgui-rs",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-test-engine-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-wgpu"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bytemuck",
  "dear-imgui-rs",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-winit"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "dear-imgui-rs",
  "objc2-app-kit 0.3.2",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags 2.13.0",
  "dear-imgui-rs",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo-quat"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags 2.13.0",
  "dear-imgui-rs",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo-quat-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imnodes"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags 2.13.0",
  "dear-imgui-rs",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imnodes-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "approx",
  "bitflags 2.13.0",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot3d"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags 2.13.0",
  "dear-imgui-rs",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot3d-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "dear-node-editor"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags 2.13.0",
  "dear-imgui-rs",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "dear-node-editor-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Mingzhen Zhuang <superfrankie621@gmail.com>"]
@@ -61,33 +61,33 @@ xtask = { path = "xtask", version = "0.1.0" }
 [workspace.dependencies]
 # Workspace release catalog. Keep every publishable package here so member
 # manifests inherit one path and one registry requirement for internal edges.
-build-support = { package = "dear-imgui-build-support", version = "=0.16.0-alpha.2", path = "tools/build-support" }
-dear-app = { version = "=0.16.0-alpha.2", path = "dear-app" }
-dear-file-browser = { version = "=0.16.0-alpha.2", path = "extensions/dear-file-browser" }
-dear-imgui-ash = { version = "=0.16.0-alpha.2", path = "backends/dear-imgui-ash" }
-dear-imgui-bevy = { version = "=0.16.0-alpha.2", path = "backends/dear-imgui-bevy" }
-dear-imgui-glow = { version = "=0.16.0-alpha.2", path = "backends/dear-imgui-glow" }
-dear-imgui-reflect = { version = "=0.16.0-alpha.2", path = "extensions/dear-imgui-reflect" }
-dear-imgui-reflect-derive = { version = "=0.16.0-alpha.2", path = "extensions/dear-imgui-reflect-derive" }
-dear-imgui-rs = { version = "=0.16.0-alpha.2", path = "dear-imgui", default-features = false }
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.2", path = "backends/dear-imgui-sdl3" }
-dear-imgui-sys = { version = "=0.16.0-alpha.2", path = "dear-imgui-sys", default-features = false }
-dear-imgui-test-engine = { version = "=0.16.0-alpha.2", path = "extensions/dear-imgui-test-engine" }
-dear-imgui-test-engine-sys = { version = "=0.16.0-alpha.2", path = "extensions/dear-imgui-test-engine-sys", default-features = false }
-dear-imgui-wgpu = { version = "=0.16.0-alpha.2", path = "backends/dear-imgui-wgpu" }
-dear-imgui-winit = { version = "=0.16.0-alpha.2", path = "backends/dear-imgui-winit" }
-dear-imguizmo = { version = "=0.16.0-alpha.2", path = "extensions/dear-imguizmo" }
-dear-imguizmo-quat = { version = "=0.16.0-alpha.2", path = "extensions/dear-imguizmo-quat" }
-dear-imguizmo-quat-sys = { version = "=0.16.0-alpha.2", path = "extensions/dear-imguizmo-quat-sys", default-features = false }
-dear-imguizmo-sys = { version = "=0.16.0-alpha.2", path = "extensions/dear-imguizmo-sys", default-features = false }
-dear-imnodes = { version = "=0.16.0-alpha.2", path = "extensions/dear-imnodes" }
-dear-imnodes-sys = { version = "=0.16.0-alpha.2", path = "extensions/dear-imnodes-sys", default-features = false }
-dear-implot = { version = "=0.16.0-alpha.2", path = "extensions/dear-implot" }
-dear-implot-sys = { version = "=0.16.0-alpha.2", path = "extensions/dear-implot-sys", default-features = false }
-dear-implot3d = { version = "=0.16.0-alpha.2", path = "extensions/dear-implot3d" }
-dear-implot3d-sys = { version = "=0.16.0-alpha.2", path = "extensions/dear-implot3d-sys", default-features = false }
-dear-node-editor = { version = "=0.16.0-alpha.2", path = "extensions/dear-node-editor" }
-dear-node-editor-sys = { version = "=0.16.0-alpha.2", path = "extensions/dear-node-editor-sys", default-features = false }
+build-support = { package = "dear-imgui-build-support", version = "=0.16.0-alpha.3", path = "tools/build-support" }
+dear-app = { version = "=0.16.0-alpha.3", path = "dear-app" }
+dear-file-browser = { version = "=0.16.0-alpha.3", path = "extensions/dear-file-browser" }
+dear-imgui-ash = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-ash" }
+dear-imgui-bevy = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-bevy" }
+dear-imgui-glow = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-glow" }
+dear-imgui-reflect = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-reflect" }
+dear-imgui-reflect-derive = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-reflect-derive" }
+dear-imgui-rs = { version = "=0.16.0-alpha.3", path = "dear-imgui", default-features = false }
+dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-sdl3" }
+dear-imgui-sys = { version = "=0.16.0-alpha.3", path = "dear-imgui-sys", default-features = false }
+dear-imgui-test-engine = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-test-engine" }
+dear-imgui-test-engine-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-test-engine-sys", default-features = false }
+dear-imgui-wgpu = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-wgpu" }
+dear-imgui-winit = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-winit" }
+dear-imguizmo = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo" }
+dear-imguizmo-quat = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo-quat" }
+dear-imguizmo-quat-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo-quat-sys", default-features = false }
+dear-imguizmo-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo-sys", default-features = false }
+dear-imnodes = { version = "=0.16.0-alpha.3", path = "extensions/dear-imnodes" }
+dear-imnodes-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imnodes-sys", default-features = false }
+dear-implot = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot" }
+dear-implot-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot-sys", default-features = false }
+dear-implot3d = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot3d" }
+dear-implot3d-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot3d-sys", default-features = false }
+dear-node-editor = { version = "=0.16.0-alpha.3", path = "extensions/dear-node-editor" }
+dear-node-editor-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-node-editor-sys", default-features = false }
 
 # Core dependencies
 bitflags = "2.11"

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ under `examples/ci/` are release evidence and are intentionally excluded from th
 
 ## Installation
 
-The source tree is preparing the unified `0.16.0-alpha.2` release. The latest crates.io prerelease is `0.16.0-alpha.1`, while the latest stable train remains `0.15.1`. Before alpha.2 is published, use Git dependencies on the repository's `main` branch. After publication, pin the exact prerelease `=0.16.0-alpha.2`; a broad `"0.16"` requirement does not select a prerelease. Applications staying on `0.15.1` can use the [v0.15.1 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.15.1/README.md) for its API and installation snippets.
+The source tree is preparing the unified `0.16.0-alpha.3` release. The latest crates.io prerelease is `0.16.0-alpha.2`, while the latest stable train remains `0.15.1`. Until alpha.3 is published, use Git dependencies on the repository's `main` branch; the published alpha.2 API can be selected with the exact `=0.16.0-alpha.2` requirement. After publication, pin the exact prerelease `=0.16.0-alpha.3`; a broad `"0.16"` requirement does not select a prerelease. Applications staying on `0.15.1` can use the [v0.15.1 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.15.1/README.md) for its API and installation snippets.
 
 ### Core + Backends
 
@@ -357,47 +357,47 @@ Quick examples (enable auto prebuilt download):
 - Env (Unix): `IMGUI_SYS_USE_PREBUILT=1 cargo build -p dear-imgui-rs --features prebuilt`
 - Env (Windows PowerShell): `$env:IMGUI_SYS_USE_PREBUILT='1'; cargo build -p dear-imgui-rs --features prebuilt`
 
-## Compatibility Candidate (0.16.0-alpha.2)
+## Compatibility Candidate (0.16.0-alpha.3)
 
-The workspace follows a release-train model. The table below lists the combinations validated for the 0.16.0-alpha.2 candidate. See [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for version history and compatibility policy.
+The workspace follows a release-train model. The table below lists the combinations validated for the 0.16.0-alpha.3 candidate. See [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for version history and compatibility policy.
 
 Core
 
 | Crate           | Version | Notes                                     |
 |-----------------|---------|-------------------------------------------|
-| dear-imgui-rs   | 0.16.0-alpha.2 | Safe Rust API over dear-imgui-sys     |
-| dear-imgui-sys  | 0.16.0-alpha.2 | Dear ImGui v1.92.9b docking via cimgui |
+| dear-imgui-rs   | 0.16.0-alpha.3 | Safe Rust API over dear-imgui-sys     |
+| dear-imgui-sys  | 0.16.0-alpha.3 | Dear ImGui v1.92.9b docking via cimgui |
 
 Backends
 
 | Crate            | Version | External deps     | Notes                          |
 |------------------|---------|-------------------|--------------------------------|
-| dear-imgui-wgpu  | 0.16.0-alpha.2 | wgpu = 30/29/28/27 | WebGPU renderer; WGPU 30 default, native Winit/SDL3 multi-viewport, browser single-window |
-| dear-imgui-glow  | 0.16.0-alpha.2 | glow = 0.17       | OpenGL renderer (winit/glutin) |
-| dear-imgui-ash   | 0.16.0-alpha.2 | ash = 0.38        | Native Vulkan renderer with Winit/SDL3 multi-viewport adapters |
-| dear-imgui-winit | 0.16.0-alpha.2 | winit = 0.30.13   | Winit platform backend         |
-| dear-imgui-sdl3  | 0.16.0-alpha.2 | sdl3 = 0.18.4     | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
-| dear-imgui-bevy  | 0.16.0-alpha.2 | Bevy = 0.19.0     | Experimental Bevy-native backend with docking, texture interop, and native multi-viewport |
+| dear-imgui-wgpu  | 0.16.0-alpha.3 | wgpu = 30/29/28/27 | WebGPU renderer; WGPU 30 default, native Winit/SDL3 multi-viewport, browser single-window |
+| dear-imgui-glow  | 0.16.0-alpha.3 | glow = 0.17       | OpenGL renderer (winit/glutin) |
+| dear-imgui-ash   | 0.16.0-alpha.3 | ash = 0.38        | Native Vulkan renderer with Winit/SDL3 multi-viewport adapters |
+| dear-imgui-winit | 0.16.0-alpha.3 | winit = 0.30.13   | Winit platform backend         |
+| dear-imgui-sdl3  | 0.16.0-alpha.3 | sdl3 = 0.18.4     | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
+| dear-imgui-bevy  | 0.16.0-alpha.3 | Bevy = 0.19.0     | Experimental Bevy-native backend with docking, texture interop, and native multi-viewport |
 
 Application Runtime
 
 | Crate     | Version | Requires dear-imgui-rs | Notes                                            |
 |-----------|---------|------------------------|--------------------------------------------------|
-| dear-app  | 0.16.0-alpha.2 | 0.16.0-alpha.2       | Generation-aware Winit + WGPU application runtime |
+| dear-app  | 0.16.0-alpha.3 | 0.16.0-alpha.3       | Generation-aware Winit + WGPU application runtime |
 
 Extensions
 
 | Crate               | Version | Requires dear-imgui-rs | Sys crate                   | Notes                                  |
 |---------------------|---------|------------------------|-----------------------------|----------------------------------------|
-| dear-implot         | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-implot-sys 0.16.0-alpha.2 | 2D plotting                         |
-| dear-imnodes        | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imnodes-sys 0.16.0-alpha.2 | WASM-capable node editor            |
-| dear-node-editor    | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-node-editor-sys 0.16.0-alpha.2 | Native imgui-node-editor; optional blueprints profile |
-| dear-imguizmo       | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imguizmo-sys 0.16.0-alpha.2 | 3D gizmo + GraphEditor              |
-| dear-file-browser   | 0.16.0-alpha.2 | 0.16.0-alpha.2 | —                              | State-owned ImGui UI + native dialog backends |
-| dear-implot3d       | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-implot3d-sys 0.16.0-alpha.2 | 3D plotting                       |
-| dear-imguizmo-quat  | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imguizmo-quat-sys 0.16.0-alpha.2 | Quaternion gizmo              |
-| dear-imgui-test-engine | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imgui-test-engine-sys 0.16.0-alpha.2 | UI automation and test runner |
-| dear-imgui-reflect  | 0.16.0-alpha.2 | 0.16.0-alpha.2 | —                              | Session-owned reflection UI              |
+| dear-implot         | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot-sys 0.16.0-alpha.3 | 2D plotting                         |
+| dear-imnodes        | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imnodes-sys 0.16.0-alpha.3 | WASM-capable node editor            |
+| dear-node-editor    | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-node-editor-sys 0.16.0-alpha.3 | Native imgui-node-editor; optional blueprints profile |
+| dear-imguizmo       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-sys 0.16.0-alpha.3 | 3D gizmo + GraphEditor              |
+| dear-file-browser   | 0.16.0-alpha.3 | 0.16.0-alpha.3 | —                              | State-owned ImGui UI + native dialog backends |
+| dear-implot3d       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot3d-sys 0.16.0-alpha.3 | 3D plotting                       |
+| dear-imguizmo-quat  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-quat-sys 0.16.0-alpha.3 | Quaternion gizmo              |
+| dear-imgui-test-engine | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imgui-test-engine-sys 0.16.0-alpha.3 | UI automation and test runner |
+| dear-imgui-reflect  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | —                              | Session-owned reflection UI              |
 
 The workspace MSRV is Rust 1.92. The experimental Bevy backend requires Rust 1.95 because Bevy 0.19 does. Select exactly one WGPU major; `dear-app` follows the WGPU 30 default.
 

--- a/backends/dear-imgui-ash/README.md
+++ b/backends/dear-imgui-ash/README.md
@@ -419,8 +419,8 @@ the shader gamma path will not match (you'll effectively decode twice).
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.2  |
-| dear-imgui-rs | 0.16.0-alpha.2  |
+| Crate         | 0.16.0-alpha.3  |
+| dear-imgui-rs | 0.16.0-alpha.3  |
 | ash           | 0.38    |
 | ash-window    | 0.13 (`multi-viewport-winit`) |
 

--- a/backends/dear-imgui-bevy/README.md
+++ b/backends/dear-imgui-bevy/README.md
@@ -10,13 +10,13 @@ The backend owns Dear ImGui Contexts on Bevy's main thread, routes Bevy window i
 | --- | --- |
 | Rust | `1.95.0` or newer |
 | Bevy | exactly `0.19.0` |
-| dear-imgui-rs | `main` (next prerelease) |
+| dear-imgui-rs | `main` (`0.16.0-alpha.3` candidate) |
 
 `dear-imgui-bevy` defaults to the renderer plus deterministic Bevy UI ordering. Native multi-viewport is supported through an explicit feature and runtime opt-in. WASM supports the normal and headless feature sets but cannot create native platform windows.
 
 ## Installation
 
-This README documents the source-breaking API on `main`. Use matching Git dependencies:
+This README documents the source-breaking `0.16.0-alpha.3` candidate on `main`. Use matching Git dependencies:
 
 ```toml
 [dependencies]

--- a/backends/dear-imgui-glow/README.md
+++ b/backends/dear-imgui-glow/README.md
@@ -227,8 +227,8 @@ renderer and runtime retain the exact same `Rc<glow::Context>` from initializati
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.2  |
-| dear-imgui-rs | 0.16.0-alpha.2  |
+| Crate         | 0.16.0-alpha.3  |
+| dear-imgui-rs | 0.16.0-alpha.3  |
 | glow          | 0.17    |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.

--- a/backends/dear-imgui-sdl3/README.md
+++ b/backends/dear-imgui-sdl3/README.md
@@ -41,7 +41,7 @@ Typical use cases:
 - `sdlgpu3-renderer`: enables this crate's official SDLGPU3 renderer shim.
 - `multi-viewport`: enables multi-viewport helpers (requires `dear-imgui-rs/multi-viewport`).
 
-Until `0.16.0-alpha.2` is published, test any feature combination from `main`:
+Until `0.16.0-alpha.3` is published, test any feature combination from `main`:
 
 ```toml
 dear-imgui-sdl3 = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["opengl3-renderer"] }
@@ -52,33 +52,33 @@ After publication, use the exact prerelease requirement in the combinations belo
 Platform-only usage (SDL3 + WGPU/Glow, no official OpenGL3 renderer):
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.2", default-features = false }
+dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", default-features = false }
 ```
 
 Enable the official OpenGL3 renderer:
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.2", features = ["opengl3-renderer"] }
+dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["opengl3-renderer"] }
 ```
 
 Enable the official SDLRenderer3 renderer:
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.2", features = ["sdlrenderer3-renderer"] }
+dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["sdlrenderer3-renderer"] }
 ```
 
 Enable the official SDLGPU3 renderer:
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.2", features = ["sdlgpu3-renderer"] }
+dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["sdlgpu3-renderer"] }
 ```
 
 ## Compatibility
 
 | Item          | Version  |
 |---------------|----------|
-| Crate         | 0.16.0-alpha.2  |
-| dear-imgui-rs | 0.16.0-alpha.2  |
+| Crate         | 0.16.0-alpha.3  |
+| dear-imgui-rs | 0.16.0-alpha.3  |
 | SDL3 crate    | 0.18.4   |
 | sdl3-sys      | 0.6      |
 
@@ -423,7 +423,7 @@ Example:
 
 ```toml
 [dependencies]
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.2", features = ["opengl3-renderer"] }
+dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["opengl3-renderer"] }
 sdl3 = { version = "0.18", features = ["build-from-source"] }
 ```
 

--- a/backends/dear-imgui-wgpu/README.md
+++ b/backends/dear-imgui-wgpu/README.md
@@ -220,7 +220,7 @@ replacements are preserved rather than overwritten.
 
 ## Selecting wgpu version
 
-The `0.16.0-alpha.2` candidate defaults to WGPU 30. Until it is published, test
+The `0.16.0-alpha.3` candidate defaults to WGPU 30. Until it is published, test
 the candidate from `main`:
 
 ```toml
@@ -235,17 +235,17 @@ If your ecosystem is pinned to `wgpu` v29, v28, or v27, select it explicitly:
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = { version = "=0.16.0-alpha.2", default-features = false, features = ["wgpu-29"] }
+dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-29"] }
 ```
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = { version = "=0.16.0-alpha.2", default-features = false, features = ["wgpu-28"] }
+dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-28"] }
 ```
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = { version = "=0.16.0-alpha.2", default-features = false, features = ["wgpu-27"] }
+dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-27"] }
 ```
 
 ## What You Get
@@ -264,7 +264,7 @@ dear-imgui-wgpu = { version = "=0.16.0-alpha.2", default-features = false, featu
 
 | Track | wgpu support |
 |-------|--------------|
-| `main` (unpublished 0.16.0-alpha.2) | 30 (default), 29 (`wgpu-29`), 28 (`wgpu-28`), 27 (`wgpu-27`) |
+| `main` (unpublished 0.16.0-alpha.3) | 30 (default), 29 (`wgpu-29`), 28 (`wgpu-28`), 27 (`wgpu-27`) |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 

--- a/backends/dear-imgui-winit/README.md
+++ b/backends/dear-imgui-winit/README.md
@@ -8,8 +8,8 @@ cursor handling and DPI awareness into Dear ImGui. Inspired by
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.2  |
-| dear-imgui-rs | 0.16.0-alpha.2  |
+| Crate         | 0.16.0-alpha.3  |
+| dear-imgui-rs | 0.16.0-alpha.3  |
 | winit         | 0.30.13 |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.

--- a/dear-app/README.md
+++ b/dear-app/README.md
@@ -7,14 +7,14 @@
 
 ## Quick Start
 
-Create a binary crate and add the unreleased `0.16.0-alpha.2` candidate from `main`:
+Create a binary crate and add the unreleased `0.16.0-alpha.3` candidate from `main`:
 
 ```toml
 [dependencies]
 dear-app = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", package = "dear-app" }
 ```
 
-After publication, replace that dependency with `dear-app = "=0.16.0-alpha.2"`.
+After publication, replace that dependency with `dear-app = "=0.16.0-alpha.3"`.
 
 Then use `dear_app::run_ui` for applications that only need persistent UI state:
 

--- a/dear-imgui-sys/README.md
+++ b/dear-imgui-sys/README.md
@@ -25,8 +25,8 @@ This crate supports multiple build strategies to fit different development workf
 ### 1. Prebuilt Static Libraries (Recommended)
 
 The fastest way to get started is to use prebuilt static libraries instead of compiling from source.
-`0.16.0-alpha.1` archives are currently published. Until `0.16.0-alpha.2` is published, use a
-repository checkout or build the alpha.2 candidate from source.
+`0.16.0-alpha.2` archives are currently published. Until `0.16.0-alpha.3` is published, use a
+repository checkout or build the alpha.3 candidate from source.
 
 ```bash
 # Option A: Point to the library directory inside an extracted core artifact.
@@ -34,7 +34,7 @@ repository checkout or build the alpha.2 candidate from source.
 export IMGUI_SYS_LIB_DIR=/path/to/extracted/dear-imgui-artifact/lib
 
 # Option B: Use a package-tool-generated local archive or HTTP(S) URL.
-export IMGUI_SYS_PREBUILT_URL=/path/to/dear-imgui-prebuilt-0.16.0-alpha.2-<target>-static.tar.gz
+export IMGUI_SYS_PREBUILT_URL=/path/to/dear-imgui-prebuilt-0.16.0-alpha.3-<target>-static.tar.gz
 cargo build -p dear-imgui-sys --features prebuilt
 
 # Option C: Enable HTTP(S) downloads / auto-download from GitHub releases
@@ -168,7 +168,7 @@ For a complete, up-to-date guide (including required tools, commands, and troubl
 
 This is a low-level sys crate providing unsafe FFI bindings. Most users should use the higher-level [`dear-imgui-rs`](https://crates.io/crates/dear-imgui-rs) crate instead, which provides safe Rust wrappers.
 
-Until `0.16.0-alpha.2` is published, test this candidate from `main`:
+Until `0.16.0-alpha.3` is published, test this candidate from `main`:
 
 ```toml
 [dependencies]
@@ -179,10 +179,10 @@ After publication, use the exact prerelease requirement:
 
 ```toml
 [dependencies]
-dear-imgui-sys = "=0.16.0-alpha.2"
+dear-imgui-sys = "=0.16.0-alpha.3"
 
 # Enable features as needed
-dear-imgui-sys = { version = "=0.16.0-alpha.2", features = ["freetype", "wasm"] }
+dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["freetype", "wasm"] }
 ```
 
 ### Direct FFI Usage (Advanced)
@@ -215,7 +215,7 @@ can expose optional backend shim modules behind `backend-shim-*` features:
 
 ```toml
 [dependencies]
-dear-imgui-sys = { version = "=0.16.0-alpha.2", features = ["backend-shim-opengl3"] }
+dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["backend-shim-opengl3"] }
 ```
 
 These features expose self-contained modules such as:
@@ -348,8 +348,8 @@ There are two first-class Android directions.
 
    ```toml
    [dependencies]
-   dear-imgui-rs = "=0.16.0-alpha.2"
-   dear-imgui-sys = { version = "=0.16.0-alpha.2", features = ["backend-shim-android", "backend-shim-opengl3"] }
+   dear-imgui-rs = "=0.16.0-alpha.3"
+   dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["backend-shim-android", "backend-shim-opengl3"] }
    ```
 
    Use `dear-imgui-rs` for the safe core (`Context`, IO, frame lifecycle,

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,8 +8,8 @@ paths, see `docs/workstreams/apple-platform-support.md`.
 ## Versioning Policy
 
 - Unified release train: all published `dear-*` crates in this workspace are versioned and released together under the same semver, so consumers can depend on a single minor across the board.
-- Upcoming train: unified `v0.16.0-alpha.2`. Until it is published, test the candidate with a Git dependency on `main`; after publication, use an exact `=0.16.0-alpha.2` requirement rather than a broad crates.io `0.16` requirement.
-- Current published prerelease: unified `v0.16.0-alpha.1` (use exact requirements such as `version = "=0.16.0-alpha.1"`).
+- Upcoming train: unified `v0.16.0-alpha.3`. Until it is published, test the candidate with a Git dependency on `main`; after publication, use an exact `=0.16.0-alpha.3` requirement rather than a broad crates.io `0.16` requirement.
+- Current published prerelease: unified `v0.16.0-alpha.2` (use exact requirements such as `version = "=0.16.0-alpha.2"`).
 - Current stable train: unified `v0.15.1` (use `version = "0.15"`).
 - Previous train: unified `v0.14.1` (use `version = "0.14"`).
 - Previous train: unified `v0.13.0` (use `version = "0.13"`).
@@ -18,57 +18,57 @@ paths, see `docs/workstreams/apple-platform-support.md`.
 - Previous train: unified `v0.10.4` (use `version = "0.10"`).
 - Previous train: unified `v0.9.0` (use `version = "0.9"`).
 - Previous train: unified `v0.8.0` (use `version = "0.8"`).
-- Internal dependency constraints in this repo pin to the exact current prerelease (for example, `=0.16.0-alpha.2`). Mixing different release trains across our crates is unsupported.
+- Internal dependency constraints in this repo pin to the exact current prerelease (for example, `=0.16.0-alpha.3`). Mixing different release trains across our crates is unsupported.
 
-## Release Candidate (0.16.0-alpha.2)
+## Release Candidate (0.16.0-alpha.3)
 
 Core
 
 | Crate           | Version | Upstream        | Notes                                     |
 |-----------------|---------|-----------------|-------------------------------------------|
-| dear-imgui-rs   | 0.16.0-alpha.2  | —               | Safe Rust API over dear-imgui-sys         |
-| dear-imgui-sys  | 0.16.0-alpha.2  | ImGui v1.92.9b  | Docking branch via cimgui; three binding profiles |
+| dear-imgui-rs   | 0.16.0-alpha.3  | —               | Safe Rust API over dear-imgui-sys         |
+| dear-imgui-sys  | 0.16.0-alpha.3  | ImGui v1.92.9b  | Docking branch via cimgui; three binding profiles |
 
 Backends
 
 | Crate             | Version | External deps           | Notes |
 |-------------------|---------|-------------------------|-------|
-| dear-imgui-wgpu   | 0.16.0-alpha.2  | wgpu = 30/29/28/27     | WGPU 30 default; native Winit/SDL3 multi-viewport; browser single-window |
-| dear-imgui-glow   | 0.16.0-alpha.2  | glow = 0.17            | OpenGL 3.0+/ES 3.0+/WebGL 2 renderer; live sampler capability with restorative fallback |
-| dear-imgui-ash    | 0.16.0-alpha.2  | ash = 0.38             | Native Vulkan renderer; shared Winit/SDL3 multi-viewport runtime |
-| dear-imgui-winit  | 0.16.0-alpha.2  | winit = 0.30.13        | Winit platform backend |
-| dear-imgui-sdl3   | 0.16.0-alpha.2  | sdl3 = 0.18.4, sdl3-sys 0.6 | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
-| dear-imgui-bevy   | 0.16.0-alpha.2  | Bevy = 0.19.0          | Bevy-native backend; default renderer and Bevy UI ordering, explicit advanced routes, Rust 1.95 minimum |
+| dear-imgui-wgpu   | 0.16.0-alpha.3  | wgpu = 30/29/28/27     | WGPU 30 default; native Winit/SDL3 multi-viewport; browser single-window |
+| dear-imgui-glow   | 0.16.0-alpha.3  | glow = 0.17            | OpenGL 3.0+/ES 3.0+/WebGL 2 renderer; live sampler capability with restorative fallback |
+| dear-imgui-ash    | 0.16.0-alpha.3  | ash = 0.38             | Native Vulkan renderer; shared Winit/SDL3 multi-viewport runtime |
+| dear-imgui-winit  | 0.16.0-alpha.3  | winit = 0.30.13        | Winit platform backend |
+| dear-imgui-sdl3   | 0.16.0-alpha.3  | sdl3 = 0.18.4, sdl3-sys 0.6 | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
+| dear-imgui-bevy   | 0.16.0-alpha.3  | Bevy = 0.19.0          | Bevy-native backend; default renderer and Bevy UI ordering, explicit advanced routes, Rust 1.95 minimum |
 
 Utilities
 
 | Crate     | Version | External deps | Notes |
 |-----------|---------|---------------|-------|
-| dear-app  | 0.16.0-alpha.2  | winit, wgpu 30 | Generation-aware application runtime |
+| dear-app  | 0.16.0-alpha.3  | winit, wgpu 30 | Generation-aware application runtime |
 
 Tooling
 
 | Crate                    | Version | External deps | Notes |
 |--------------------------|---------|---------------|-------|
-| dear-imgui-build-support | 0.16.0-alpha.2  | ureq = 3.3    | Binding specification, build, package, and prebuilt helpers |
+| dear-imgui-build-support | 0.16.0-alpha.3  | ureq = 3.3    | Binding specification, build, package, and prebuilt helpers |
 
 Extensions
 
 | Crate               | Version | Requires dear-imgui-rs | Sys crate                    | Notes                                  |
 |---------------------|---------|------------------------|------------------------------|----------------------------------------|
-| dear-implot         | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-implot-sys 0.16.0-alpha.2 | 2D plotting |
-| dear-imnodes        | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imnodes-sys 0.16.0-alpha.2 | WASM-capable node editor |
-| dear-node-editor    | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-node-editor-sys 0.16.0-alpha.2 | Native-only; opt-in blueprints profile |
-| dear-imguizmo       | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imguizmo-sys 0.16.0-alpha.2 | 3D gizmo |
-| dear-file-browser   | 0.16.0-alpha.2 | 0.16.0-alpha.2 | — | State-owned ImGui UI + native dialogs |
-| dear-implot3d       | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-implot3d-sys 0.16.0-alpha.2 | 3D plotting |
-| dear-imguizmo-quat  | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imguizmo-quat-sys 0.16.0-alpha.2 | Quaternion gizmo |
-| dear-imgui-test-engine | 0.16.0-alpha.2 | 0.16.0-alpha.2 | dear-imgui-test-engine-sys 0.16.0-alpha.2 | UI automation and test runner |
-| dear-imgui-reflect  | 0.16.0-alpha.2 | 0.16.0-alpha.2 | — | Session-owned reflection UI |
+| dear-implot         | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot-sys 0.16.0-alpha.3 | 2D plotting |
+| dear-imnodes        | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imnodes-sys 0.16.0-alpha.3 | WASM-capable node editor |
+| dear-node-editor    | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-node-editor-sys 0.16.0-alpha.3 | Native-only; opt-in blueprints profile |
+| dear-imguizmo       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-sys 0.16.0-alpha.3 | 3D gizmo |
+| dear-file-browser   | 0.16.0-alpha.3 | 0.16.0-alpha.3 | — | State-owned ImGui UI + native dialogs |
+| dear-implot3d       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot3d-sys 0.16.0-alpha.3 | 3D plotting |
+| dear-imguizmo-quat  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-quat-sys 0.16.0-alpha.3 | Quaternion gizmo |
+| dear-imgui-test-engine | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imgui-test-engine-sys 0.16.0-alpha.3 | UI automation and test runner |
+| dear-imgui-reflect  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | — | Session-owned reflection UI |
 
 ## 0.16 Architecture Contracts
 
-The 0.16 train is not source-compatible with 0.15.x, and alpha.2 deliberately removes provisional alpha.1 APIs whose contracts were not sound enough to stabilize. The baseline is Dear ImGui v1.92.9b docking via cimgui, Rust 1.92 for the workspace, Rust 1.95 for the Bevy backend, WGPU 30 by default with explicit 29/28/27 routes, and Bevy 0.19. Alpha.2 migrations live in the `0.16.0-alpha.2` section of `CHANGELOG.md`; applications coming from 0.15.x must also apply the alpha.1 migrations.
+The 0.16 train is not source-compatible with 0.15.x, and alpha.2 deliberately removes provisional alpha.1 APIs whose contracts were not sound enough to stabilize. The baseline is Dear ImGui v1.92.9b docking via cimgui, Rust 1.92 for the workspace, Rust 1.95 for the Bevy backend, WGPU 30 by default with explicit 29/28/27 routes, and Bevy 0.19. Alpha.2 migrations live in the `0.16.0-alpha.2` section of `CHANGELOG.md`; applications coming from 0.15.x must also apply the alpha.1 migrations. The alpha.3 candidate migrations are tracked in `Unreleased`.
 
 The safe Rust layer intentionally breaks APIs that expose C++ lifecycle
 protocols, wrong-context state, stale GPU handles, or platform-specific ABI
@@ -286,7 +286,7 @@ import-style binding artifact. `xtask verify-bindings` regenerates and compares
 all supported profiles; arbitrary bindgen clang-argument overrides are rejected
 for canonical artifacts.
 
-The binding generator contract, formatter, allow/block lists, enum normalization, header shims, opaque types, provider name, and exact compatibility target facts all participate in the deterministic binding-spec hash. `dear-imgui-build-support` will ship on the same 0.16.0-alpha.2 train as every other publishable crate.
+The binding generator contract, formatter, allow/block lists, enum normalization, header shims, opaque types, provider name, and exact compatibility target facts all participate in the deterministic binding-spec hash. `dear-imgui-build-support` will ship on the same 0.16.0-alpha.3 train as every other publishable crate.
 
 Source identity is package data rather than repository state. The exact 40-hex
 cimgui and nested Dear ImGui revisions live in

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -17,12 +17,12 @@ The repository workflow token defaults to read-only. The protected crates.io job
 Preparation intentionally changes the worktree; validation requires the resulting commit to be clean.
 
 ```bash
-python3 tools/tasks.py release-prepare 0.16.0-alpha.2
+python3 tools/tasks.py release-prepare 0.16.0-alpha.3
 
 # Review generated bindings, source metadata, Cargo.lock, CHANGELOG.md, and docs.
 git diff
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.2"
+git commit -m "chore: prepare release v0.16.0-alpha.3"
 
 python3 tools/tasks.py release-check
 ```
@@ -34,7 +34,7 @@ Before merging, require normal CI to pass on Linux, Windows, and macOS. The root
 Merge the candidate to `main`, then dispatch the release workflow with the matching tag:
 
 ```bash
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.2
+gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
 ```
 
 The workflow binds the tag to the workspace version and the exact `main` commit before doing any irreversible work. It then:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -159,17 +159,17 @@ These checks generate/use bindings only and won’t build/link native code.
 Preparation and validation remain separate because preparation intentionally changes the worktree:
 
 ```bash
-python3 tools/tasks.py release-prepare 0.16.0-alpha.2
+python3 tools/tasks.py release-prepare 0.16.0-alpha.3
 git diff
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.2"
+git commit -m "chore: prepare release v0.16.0-alpha.3"
 python3 tools/tasks.py release-check
 ```
 
 After the candidate is merged to `main` and normal CI is green, run the single release entry point:
 
 ```bash
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.2
+gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
 ```
 
 `release.yml` binds the tag, workspace version, `main` ref, and exact candidate;

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -17,7 +17,7 @@ revision instead of renaming its files or remapping it under the v1 module name.
 
 WASM support is explicit and target-specific. The only supported Rust target is
 `wasm32-unknown-unknown`, and every dependency path to the core crate must
-enable the `wasm` feature. Until `0.16.0-alpha.2` is published, use the candidate
+enable the `wasm` feature. Until `0.16.0-alpha.3` is published, use the candidate
 from `main`:
 
 ```toml
@@ -35,8 +35,8 @@ dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "m
 ```
 
 After publication, replace those Git dependencies with the exact prerelease
-requirements `dear-imgui-rs = { version = "=0.16.0-alpha.2", features = ["wasm"] }`
-and `dear-imgui-bevy = { version = "=0.16.0-alpha.2", features = ["render", "wasm"] }`.
+requirements `dear-imgui-rs = { version = "=0.16.0-alpha.3", features = ["wasm"] }`
+and `dear-imgui-bevy = { version = "=0.16.0-alpha.3", features = ["render", "wasm"] }`.
 
 Five safe native extensions expose the same `wasm` feature and forward it to
 both `dear-imgui-rs` and their matching sys crate:

--- a/examples-android/dear-imgui-android-smoke/Cargo.lock
+++ b/examples-android/dear-imgui-android-smoke/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "serde",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags",
  "dear-imgui-sys",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "dear-imgui-build-support",

--- a/examples-ios/dear-imgui-ios-sdl3-smoke/Cargo.lock
+++ b/examples-ios/dear-imgui-ios-sdl3-smoke/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "pkg-config",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags",
  "dear-imgui-sys",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sdl3"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-wgpu"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bytemuck",
  "dear-imgui-rs",

--- a/examples-ios/dear-imgui-ios-smoke/Cargo.lock
+++ b/examples-ios/dear-imgui-ios-smoke/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "serde",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bitflags 2.11.1",
  "dear-imgui-sys",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-wgpu"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "bytemuck",
  "dear-imgui-rs",
@@ -376,9 +376,10 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-winit"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "dear-imgui-rs",
+ "objc2-app-kit 0.3.2",
  "thiserror 2.0.18",
  "web-sys",
  "web-time",
@@ -960,6 +961,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,7 +1103,7 @@ checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -2447,7 +2459,7 @@ dependencies = [
  "memmap2",
  "ndk",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",

--- a/extensions/BEST_PRACTICES.md
+++ b/extensions/BEST_PRACTICES.md
@@ -120,7 +120,7 @@ Use C bindings (cimgui family) + bindgen when available:
 Centralize all prebuilt download/extract/naming logic via the shared helper crate:
 
 - Depend on `dear-imgui-build-support` in your `-sys` crate as a build-dependency.
-  Until `0.16.0-alpha.2` is published, use the candidate source:
+  Until `0.16.0-alpha.3` is published, use the candidate source:
   ```toml
   [build-dependencies]
   build-support = { package = "dear-imgui-build-support", git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["binding-spec"] }
@@ -129,7 +129,7 @@ Centralize all prebuilt download/extract/naming logic via the shared helper crat
   After publication, use the exact prerelease requirement:
   ```toml
   [build-dependencies]
-  build-support = { package = "dear-imgui-build-support", version = "=0.16.0-alpha.2", features = ["binding-spec"] }
+  build-support = { package = "dear-imgui-build-support", version = "=0.16.0-alpha.3", features = ["binding-spec"] }
   ```
 
   Workspace members should inherit the repository catalog instead:

--- a/extensions/dear-file-browser/README.md
+++ b/extensions/dear-file-browser/README.md
@@ -33,8 +33,8 @@ File dialogs and in-UI file browser for `dear-imgui-rs` with two backends:
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.2  |
-| dear-imgui-rs | 0.16.0-alpha.2  |
+| Crate         | 0.16.0-alpha.3  |
+| dear-imgui-rs | 0.16.0-alpha.3  |
 
 ## Features
 

--- a/extensions/dear-imgui-reflect/README.md
+++ b/extensions/dear-imgui-reflect/README.md
@@ -19,7 +19,7 @@ Dear ImGui context or panel whose settings and drafts it should retain.
 
 ## Cargo Integration
 
-`0.16.0-alpha.2` is not published yet. Test the candidate from `main`:
+`0.16.0-alpha.3` is not published yet. Test the candidate from `main`:
 
 ```toml
 [dependencies]
@@ -31,14 +31,14 @@ After publication, use the exact prerelease requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.2"
-dear-imgui-reflect = "=0.16.0-alpha.2"
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imgui-reflect = "=0.16.0-alpha.3"
 ```
 
 Optional math support:
 
 ```toml
-dear-imgui-reflect = { version = "=0.16.0-alpha.2", features = ["glam", "mint"] }
+dear-imgui-reflect = { version = "=0.16.0-alpha.3", features = ["glam", "mint"] }
 glam = "0.32"
 mint = "0.5"
 ```
@@ -207,8 +207,8 @@ See `examples/03-features/reflect_demo.rs` for a complete inspector and
 
 | Item | Version |
 |---|---|
-| Crate | 0.16.0-alpha.2 |
-| dear-imgui-rs | 0.16.0-alpha.2 |
+| Crate | 0.16.0-alpha.3 |
+| dear-imgui-rs | 0.16.0-alpha.3 |
 
 ## License
 

--- a/extensions/dear-imgui-test-engine/README.md
+++ b/extensions/dear-imgui-test-engine/README.md
@@ -25,15 +25,15 @@ For native build/link options, see `extensions/dear-imgui-test-engine-sys/README
 
 | Item                        | Version |
 |-----------------------------|---------|
-| Crate                       | 0.16.0-alpha.2  |
-| dear-imgui-rs               | 0.16.0-alpha.2  |
-| dear-imgui-test-engine-sys  | 0.16.0-alpha.2  |
+| Crate                       | 0.16.0-alpha.3  |
+| dear-imgui-rs               | 0.16.0-alpha.3  |
+| dear-imgui-test-engine-sys  | 0.16.0-alpha.3  |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md).
 
 ## Quick Start
 
-Until `0.16.0-alpha.2` is published, use matching Git dependencies from `main`:
+Until `0.16.0-alpha.3` is published, use matching Git dependencies from `main`:
 
 ```toml
 [dependencies]
@@ -45,8 +45,8 @@ After publication, use the exact prerelease requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.2"
-dear-imgui-test-engine = "=0.16.0-alpha.2"
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imgui-test-engine = "=0.16.0-alpha.3"
 ```
 
 ```rust

--- a/extensions/dear-imguizmo-quat/README.md
+++ b/extensions/dear-imguizmo-quat/README.md
@@ -19,9 +19,9 @@ Safe, idiomatic Rust bindings for ImGuIZMO.quat (quaternion + 3D gizmo helpers) 
 
 | Item                   | Version |
 |------------------------|---------|
-| Crate                  | 0.16.0-alpha.2  |
-| dear-imgui-rs          | 0.16.0-alpha.2  |
-| dear-imguizmo-quat-sys | 0.16.0-alpha.2  |
+| Crate                  | 0.16.0-alpha.3  |
+| dear-imgui-rs          | 0.16.0-alpha.3  |
+| dear-imguizmo-quat-sys | 0.16.0-alpha.3  |
 
 See also: docs/COMPATIBILITY.md in the workspace for the full matrix.
 
@@ -93,7 +93,7 @@ use one saved value rather than a stack, so avoid nesting `set_*`/`restore_*` or
 
 ## Quick Start
 
-Until `0.16.0-alpha.2` is published, take both crates from `main`:
+Until `0.16.0-alpha.3` is published, take both crates from `main`:
 
 ```toml
 [dependencies]
@@ -105,8 +105,8 @@ After publication, use the exact prerelease requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.2"
-dear-imguizmo-quat = "=0.16.0-alpha.2"
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imguizmo-quat = "=0.16.0-alpha.3"
 ```
 
 Minimal usage with the Ui extension and builder API:

--- a/extensions/dear-imguizmo/README.md
+++ b/extensions/dear-imguizmo/README.md
@@ -26,9 +26,9 @@ This project is a Rust wrapper around the C shim (cimguizmo), not a direct C++ b
 
 | Item              | Version |
 |-------------------|---------|
-| Crate             | 0.16.0-alpha.2  |
-| dear-imgui-rs     | 0.16.0-alpha.2  |
-| dear-imguizmo-sys | 0.16.0-alpha.2  |
+| Crate             | 0.16.0-alpha.3  |
+| dear-imgui-rs     | 0.16.0-alpha.3  |
+| dear-imguizmo-sys | 0.16.0-alpha.3  |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 
@@ -74,7 +74,7 @@ All matrix arguments in the API are generic over a `Mat4Like` trait, implemented
 
 ## Quick Start
 
-Until `0.16.0-alpha.2` is published, take both crates from `main`:
+Until `0.16.0-alpha.3` is published, take both crates from `main`:
 
 ```toml
 [dependencies]
@@ -86,8 +86,8 @@ After publication, use the exact prerelease requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.2"
-dear-imguizmo = "=0.16.0-alpha.2"
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imguizmo = "=0.16.0-alpha.3"
 ```
 
 Minimal usage (dear-imgui-style API):

--- a/extensions/dear-imnodes/README.md
+++ b/extensions/dear-imnodes/README.md
@@ -27,9 +27,9 @@ Safe, idiomatic Rust bindings for [ImNodes](https://github.com/Nelarius/imnodes)
 
 | Item              | Version |
 |-------------------|---------|
-| Crate             | 0.16.0-alpha.2  |
-| dear-imgui-rs     | 0.16.0-alpha.2  |
-| dear-imnodes-sys  | 0.16.0-alpha.2  |
+| Crate             | 0.16.0-alpha.3  |
+| dear-imgui-rs     | 0.16.0-alpha.3  |
+| dear-imnodes-sys  | 0.16.0-alpha.3  |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 

--- a/extensions/dear-implot/README.md
+++ b/extensions/dear-implot/README.md
@@ -21,9 +21,9 @@ For native build/link options (source, system/prebuilt, remote prebuilt), see `e
 
 | Item              | Version |
 |-------------------|---------|
-| Crate             | 0.16.0-alpha.2  |
-| dear-imgui-rs     | 0.16.0-alpha.2  |
-| dear-implot-sys   | 0.16.0-alpha.2  |
+| Crate             | 0.16.0-alpha.3  |
+| dear-imgui-rs     | 0.16.0-alpha.3  |
+| dear-implot-sys   | 0.16.0-alpha.3  |
 
 ### WASM (WebAssembly) support
 
@@ -64,7 +64,7 @@ See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob
 
 This crate integrates with `dear-imgui-rs` directly — add both crates, then build plots inside an ImGui window using a `PlotContext` bound to the current ImGui context.
 
-Until `0.16.0-alpha.2` is published, take both crates from `main`:
+Until `0.16.0-alpha.3` is published, take both crates from `main`:
 
 ```toml
 [dependencies]
@@ -76,8 +76,8 @@ After publication, use the exact prerelease requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.2"
-dear-implot = "=0.16.0-alpha.2"
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-implot = "=0.16.0-alpha.3"
 ```
 
 ```rust
@@ -142,8 +142,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.2"
-dear-implot = "=0.16.0-alpha.2"
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-implot = "=0.16.0-alpha.3"
 ```
 
 Basic usage:

--- a/extensions/dear-implot3d/README.md
+++ b/extensions/dear-implot3d/README.md
@@ -22,9 +22,9 @@ the ergonomics of `dear-implot`.
 
 | Item               | Version |
 |--------------------|---------|
-| Crate              | 0.16.0-alpha.2  |
-| dear-imgui-rs      | 0.16.0-alpha.2  |
-| dear-implot3d-sys  | 0.16.0-alpha.2  |
+| Crate              | 0.16.0-alpha.3  |
+| dear-imgui-rs      | 0.16.0-alpha.3  |
+| dear-implot3d-sys  | 0.16.0-alpha.3  |
 
 See also: docs/COMPATIBILITY.md in the workspace for the full matrix.
 

--- a/extensions/dear-node-editor/README.md
+++ b/extensions/dear-node-editor/README.md
@@ -46,9 +46,9 @@ layout compatibility notice.
 
 | Item                 | Version |
 |----------------------|---------|
-| Crate                | 0.16.0-alpha.2  |
-| dear-imgui-rs        | 0.16.0-alpha.2  |
-| dear-node-editor-sys | 0.16.0-alpha.2  |
+| Crate                | 0.16.0-alpha.3  |
+| dear-imgui-rs        | 0.16.0-alpha.3  |
+| dear-node-editor-sys | 0.16.0-alpha.3  |
 
 ## Quick Start
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,18 +12,18 @@ The workspace uses a **unified release train** model. All 27 publishable package
 
 ```bash
 # Generate the complete release diff.
-python3 tools/tasks.py release-prepare 0.16.0-alpha.2
+python3 tools/tasks.py release-prepare 0.16.0-alpha.3
 
 # Review and commit versions, bindings, lockfile, changelog, and docs.
 git diff
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.2"
+git commit -m "chore: prepare release v0.16.0-alpha.3"
 
 # Validate the committed clean release candidate.
 python3 tools/tasks.py release-check
 
 # After merging to main and normal CI passes, run the complete release.
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.2
+gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
 ```
 
 `release-prepare` intentionally leaves changes in the working tree. `release-check` runs the strict clean-tree, changelog, locked dependency graph, reproducible binding, package/offline, documentation, and test gates. Keeping these phases separate prevents release preparation from failing its own clean-tree check.
@@ -59,7 +59,7 @@ python3 tools/tasks.py doc
 python3 tools/tasks.py clean
 
 # Create a release diff, then validate it after commit
-python3 tools/tasks.py release-prepare 0.16.0-alpha.2
+python3 tools/tasks.py release-prepare 0.16.0-alpha.3
 python3 tools/tasks.py release-check
 ```
 
@@ -68,7 +68,7 @@ python3 tools/tasks.py release-check
 The workspace root is the single version source. Publishable manifests use `version.workspace = true`, and internal dependencies inherit their root workspace declarations. `[workspace.metadata.dear-imgui-release]` is the shared policy for the core package and private package paths/versions; Rust and Python release validators derive package counts from the actual workspace members. Update the release train with:
 
 ```bash
-cargo run -p xtask -- release-version 0.16.0-alpha.2 --allow-prerelease-relabel
+cargo run -p xtask -- release-version 0.16.0-alpha.3 --allow-prerelease-relabel
 ```
 
 The command updates the root release version and inherited internal dependency requirements as one validated workspace operation. It never offers partial crate selection. Documentation remains an explicit review step.
@@ -219,18 +219,18 @@ job, prebuilt build, or consumer directly fails the release.
 
 ```bash
 # 1. Generate versions, bindings, provenance, and lockfile changes.
-python3 tools/tasks.py release-prepare 0.16.0-alpha.2
+python3 tools/tasks.py release-prepare 0.16.0-alpha.3
 
 # 2. Review CHANGELOG.md, compatibility docs, generated files, and Cargo.lock.
 git diff
 
 # 3. Commit and validate the exact candidate.
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.2"
+git commit -m "chore: prepare release v0.16.0-alpha.3"
 python3 tools/tasks.py release-check
 
 # 4. Merge to main, require normal CI to pass, then run the complete release.
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.2
+gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
 ```
 
 The release workflow acquires a short-lived crates.io token only after all


### PR DESCRIPTION
## Summary

Prepare the unified workspace for `0.16.0-alpha.3`, so the ownership and runtime fixes merged after alpha.2 can be developed and validated on one exact release train.

- Bump all 27 publishable crates and 89 internal dependency edges, including root and standalone mobile lockfiles.
- Update installation, compatibility, backend, extension, and release documentation while retaining alpha.2 as the current crates.io prerelease.
- Carry the merged PR #68-#70 changes into `Unreleased` and credit @jamsterwes for the fallback-window fix in PR #69.

## Validation

- `cargo metadata --locked --format-version 1`
- `cargo run --locked -p xtask -- release-version 0.16.0-alpha.3 --dry-run`
- Locked metadata validation for the Android, iOS Winit, and iOS SDL3 smoke crates
- 67 focused release-tool contract tests
- `tools/changelog.py check-unreleased`
- `tools/changelog.py check-soft-wrap --version Unreleased`
