### PR TITLE
docs(release): finalize 0.16.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ## [Unreleased]
 
-The alpha.3 candidate continues the ownership-first 0.16 migration with stricter host-runtime transactions and a focused regression fix for accidental fallback-window rendering. [PR #70](https://github.com/Latias94/dear-imgui-rs/pull/70)
+## [0.16.0-alpha.3] - 2026-08-11
+
+This source-breaking prerelease continues the ownership-first 0.16 migration with stricter host-runtime transactions and a focused regression fix for accidental fallback-window rendering. [PR #70](https://github.com/Latias94/dear-imgui-rs/pull/70)
 
 ### Breaking Changes and Migration
 

--- a/README.md
+++ b/README.md
@@ -168,25 +168,25 @@ under `examples/ci/` are release evidence and are intentionally excluded from th
 
 ## Installation
 
-The source tree is preparing the unified `0.16.0-alpha.3` release. The latest crates.io prerelease is `0.16.0-alpha.2`, while the latest stable train remains `0.15.1`. Until alpha.3 is published, use Git dependencies on the repository's `main` branch; the published alpha.2 API can be selected with the exact `=0.16.0-alpha.2` requirement. After publication, pin the exact prerelease `=0.16.0-alpha.3`; a broad `"0.16"` requirement does not select a prerelease. Applications staying on `0.15.1` can use the [v0.15.1 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.15.1/README.md) for its API and installation snippets.
+The latest crates.io prerelease is `0.16.0-alpha.3`, while the latest stable train remains `0.15.1`. Pin the exact prerelease `=0.16.0-alpha.3`; a broad `"0.16"` requirement does not select a prerelease. Applications staying on `0.15.1` can use the [v0.15.1 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.15.1/README.md) for its API and installation snippets.
 
 ### Core + Backends
 
 ```toml
 [dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
+dear-imgui-rs = "=0.16.0-alpha.3"
 # Choose a backend + platform integration
-dear-imgui-wgpu = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }  # or dear-imgui-glow / dear-imgui-ash
-dear-imgui-winit = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" } # or dear-imgui-sdl3
+dear-imgui-wgpu = "=0.16.0-alpha.3"  # or dear-imgui-glow / dear-imgui-ash
+dear-imgui-winit = "=0.16.0-alpha.3" # or dear-imgui-sdl3
 ```
 
 `dear-imgui-wgpu` 0.16 defaults to WGPU 30. WGPU 29, 28, and 27 remain available as separate, mutually exclusive compatibility features:
 
 ```toml
 [dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-imgui-wgpu = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", default-features = false, features = ["wgpu-29"] }
-dear-imgui-winit = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-29"] }
+dear-imgui-winit = "=0.16.0-alpha.3"
 ```
 
 Replace `wgpu-29` with `wgpu-28` or `wgpu-27` when integrating an older WGPU application.
@@ -195,7 +195,7 @@ Replace `wgpu-29` with `wgpu-28` or `wgpu-27` when integrating an older WGPU app
 
 ```toml
 [dependencies]
-dear-app = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" } # State-owning Winit + WGPU runtime with docking support
+dear-app = "=0.16.0-alpha.3" # State-owning Winit + WGPU runtime with docking support
 ```
 
 ### Apple Platform Examples
@@ -237,8 +237,8 @@ Example: low-level Android route without a dedicated Android convenience crate:
 
 ```toml
 [dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-imgui-sys = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["backend-shim-android", "backend-shim-opengl3"] }
+dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["backend-shim-android", "backend-shim-opengl3"] }
 ```
 
 Recommended ownership split:
@@ -268,25 +268,25 @@ assembly.
 ```toml
 [dependencies]
 # Plotting
-dear-implot = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }   # 2D plotting
-dear-implot3d = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" } # 3D plotting
+dear-implot = "=0.16.0-alpha.3"   # 2D plotting
+dear-implot3d = "=0.16.0-alpha.3" # 3D plotting
 
 # 3D Gizmos
-dear-imguizmo = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }      # Standard 3D gizmo + GraphEditor
-dear-imguizmo-quat = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" } # Quaternion-based gizmo
+dear-imguizmo = "=0.16.0-alpha.3"      # Standard 3D gizmo + GraphEditor
+dear-imguizmo-quat = "=0.16.0-alpha.3" # Quaternion-based gizmo
 
 # Node Editor
-dear-imnodes = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-node-editor = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" } # native-only; add feature "blueprints" for stack layout
+dear-imnodes = "=0.16.0-alpha.3"
+dear-node-editor = "=0.16.0-alpha.3" # native-only; add feature "blueprints" for stack layout
 
 # Test automation
-dear-imgui-test-engine = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
+dear-imgui-test-engine = "=0.16.0-alpha.3"
 
 # File Browser
-dear-file-browser = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" } # Native dialogs + ImGui file browser
+dear-file-browser = "=0.16.0-alpha.3" # Native dialogs + ImGui file browser
 
 # Reflection-based UI helpers
-dear-imgui-reflect = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
+dear-imgui-reflect = "=0.16.0-alpha.3"
 ```
 
 ### Reflection-based UI (dear-imgui-reflect)
@@ -357,9 +357,9 @@ Quick examples (enable auto prebuilt download):
 - Env (Unix): `IMGUI_SYS_USE_PREBUILT=1 cargo build -p dear-imgui-rs --features prebuilt`
 - Env (Windows PowerShell): `$env:IMGUI_SYS_USE_PREBUILT='1'; cargo build -p dear-imgui-rs --features prebuilt`
 
-## Compatibility Candidate (0.16.0-alpha.3)
+## Compatibility (0.16.0-alpha.3)
 
-The workspace follows a release-train model. The table below lists the combinations validated for the 0.16.0-alpha.3 candidate. See [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for version history and compatibility policy.
+The workspace follows a release-train model. The table below lists the combinations validated for the 0.16.0-alpha.3 release. See [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for version history and compatibility policy.
 
 Core
 

--- a/backends/dear-imgui-bevy/README.md
+++ b/backends/dear-imgui-bevy/README.md
@@ -10,28 +10,27 @@ The backend owns Dear ImGui Contexts on Bevy's main thread, routes Bevy window i
 | --- | --- |
 | Rust | `1.95.0` or newer |
 | Bevy | exactly `0.19.0` |
-| dear-imgui-rs | `main` (`0.16.0-alpha.3` candidate) |
+| dear-imgui-rs | exactly `0.16.0-alpha.3` |
 
 `dear-imgui-bevy` defaults to the renderer plus deterministic Bevy UI ordering. Native multi-viewport is supported through an explicit feature and runtime opt-in. WASM supports the normal and headless feature sets but cannot create native platform windows.
 
 ## Installation
 
-This README documents the source-breaking `0.16.0-alpha.3` candidate on `main`. Use matching Git dependencies:
+Use matching exact prerelease dependencies:
 
 ```toml
 [dependencies]
 bevy = "=0.19.0"
-dear-imgui-bevy = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
+dear-imgui-bevy = "=0.16.0-alpha.3"
+dear-imgui-rs = "=0.16.0-alpha.3"
 ```
 
-For the published `0.16.0-alpha.2` API and crates.io dependencies, use the
-[tagged alpha.2 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.16.0-alpha.2/backends/dear-imgui-bevy/README.md).
+Users upgrading from alpha.2 must apply the Bevy migration steps in the root changelog.
 
 For a headless integration that drives private UI passes without installing the Bevy renderer:
 
 ```toml
-dear-imgui-bevy = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", default-features = false }
+dear-imgui-bevy = { version = "=0.16.0-alpha.3", default-features = false }
 ```
 
 ## Quick Start

--- a/backends/dear-imgui-sdl3/README.md
+++ b/backends/dear-imgui-sdl3/README.md
@@ -41,13 +41,11 @@ Typical use cases:
 - `sdlgpu3-renderer`: enables this crate's official SDLGPU3 renderer shim.
 - `multi-viewport`: enables multi-viewport helpers (requires `dear-imgui-rs/multi-viewport`).
 
-Until `0.16.0-alpha.3` is published, test any feature combination from `main`:
+Use the exact prerelease requirement for the desired feature combination:
 
 ```toml
-dear-imgui-sdl3 = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["opengl3-renderer"] }
+dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["opengl3-renderer"] }
 ```
-
-After publication, use the exact prerelease requirement in the combinations below.
 
 Platform-only usage (SDL3 + WGPU/Glow, no official OpenGL3 renderer):
 

--- a/backends/dear-imgui-wgpu/README.md
+++ b/backends/dear-imgui-wgpu/README.md
@@ -220,16 +220,12 @@ replacements are preserved rather than overwritten.
 
 ## Selecting wgpu version
 
-The `0.16.0-alpha.3` candidate defaults to WGPU 30. Until it is published, test
-the candidate from `main`:
+The `0.16.0-alpha.3` release defaults to WGPU 30:
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
+dear-imgui-wgpu = "=0.16.0-alpha.3"
 ```
-
-After publication, use the exact prerelease requirement for the compatibility
-routes below.
 
 If your ecosystem is pinned to `wgpu` v29, v28, or v27, select it explicitly:
 
@@ -264,7 +260,7 @@ dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, featu
 
 | Track | wgpu support |
 |-------|--------------|
-| `main` (unpublished 0.16.0-alpha.3) | 30 (default), 29 (`wgpu-29`), 28 (`wgpu-28`), 27 (`wgpu-27`) |
+| `0.16.0-alpha.3` | 30 (default), 29 (`wgpu-29`), 28 (`wgpu-28`), 27 (`wgpu-27`) |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 

--- a/dear-app/README.md
+++ b/dear-app/README.md
@@ -7,14 +7,12 @@
 
 ## Quick Start
 
-Create a binary crate and add the unreleased `0.16.0-alpha.3` candidate from `main`:
+Create a binary crate and add the exact prerelease:
 
 ```toml
 [dependencies]
-dear-app = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", package = "dear-app" }
+dear-app = "=0.16.0-alpha.3"
 ```
-
-After publication, replace that dependency with `dear-app = "=0.16.0-alpha.3"`.
 
 Then use `dear_app::run_ui` for applications that only need persistent UI state:
 

--- a/dear-imgui-sys/README.md
+++ b/dear-imgui-sys/README.md
@@ -25,8 +25,7 @@ This crate supports multiple build strategies to fit different development workf
 ### 1. Prebuilt Static Libraries (Recommended)
 
 The fastest way to get started is to use prebuilt static libraries instead of compiling from source.
-`0.16.0-alpha.2` archives are currently published. Until `0.16.0-alpha.3` is published, use a
-repository checkout or build the alpha.3 candidate from source.
+`0.16.0-alpha.3` archives are published for the supported release targets and profiles.
 
 ```bash
 # Option A: Point to the library directory inside an extracted core artifact.
@@ -168,14 +167,7 @@ For a complete, up-to-date guide (including required tools, commands, and troubl
 
 This is a low-level sys crate providing unsafe FFI bindings. Most users should use the higher-level [`dear-imgui-rs`](https://crates.io/crates/dear-imgui-rs) crate instead, which provides safe Rust wrappers.
 
-Until `0.16.0-alpha.3` is published, test this candidate from `main`:
-
-```toml
-[dependencies]
-dear-imgui-sys = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-```
-
-After publication, use the exact prerelease requirement:
+Use the exact prerelease requirement:
 
 ```toml
 [dependencies]

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,8 +8,8 @@ paths, see `docs/workstreams/apple-platform-support.md`.
 ## Versioning Policy
 
 - Unified release train: all published `dear-*` crates in this workspace are versioned and released together under the same semver, so consumers can depend on a single minor across the board.
-- Upcoming train: unified `v0.16.0-alpha.3`. Until it is published, test the candidate with a Git dependency on `main`; after publication, use an exact `=0.16.0-alpha.3` requirement rather than a broad crates.io `0.16` requirement.
-- Current published prerelease: unified `v0.16.0-alpha.2` (use exact requirements such as `version = "=0.16.0-alpha.2"`).
+- Current published prerelease: unified `v0.16.0-alpha.3` (use exact requirements such as `version = "=0.16.0-alpha.3"`).
+- Previous prerelease: unified `v0.16.0-alpha.2`.
 - Current stable train: unified `v0.15.1` (use `version = "0.15"`).
 - Previous train: unified `v0.14.1` (use `version = "0.14"`).
 - Previous train: unified `v0.13.0` (use `version = "0.13"`).
@@ -20,7 +20,7 @@ paths, see `docs/workstreams/apple-platform-support.md`.
 - Previous train: unified `v0.8.0` (use `version = "0.8"`).
 - Internal dependency constraints in this repo pin to the exact current prerelease (for example, `=0.16.0-alpha.3`). Mixing different release trains across our crates is unsupported.
 
-## Release Candidate (0.16.0-alpha.3)
+## Current Prerelease (0.16.0-alpha.3)
 
 Core
 
@@ -68,7 +68,7 @@ Extensions
 
 ## 0.16 Architecture Contracts
 
-The 0.16 train is not source-compatible with 0.15.x, and alpha.2 deliberately removes provisional alpha.1 APIs whose contracts were not sound enough to stabilize. The baseline is Dear ImGui v1.92.9b docking via cimgui, Rust 1.92 for the workspace, Rust 1.95 for the Bevy backend, WGPU 30 by default with explicit 29/28/27 routes, and Bevy 0.19. Alpha.2 migrations live in the `0.16.0-alpha.2` section of `CHANGELOG.md`; applications coming from 0.15.x must also apply the alpha.1 migrations. The alpha.3 candidate migrations are tracked in `Unreleased`.
+The 0.16 train is not source-compatible with 0.15.x, and alpha.2 deliberately removes provisional alpha.1 APIs whose contracts were not sound enough to stabilize. The baseline is Dear ImGui v1.92.9b docking via cimgui, Rust 1.92 for the workspace, Rust 1.95 for the Bevy backend, WGPU 30 by default with explicit 29/28/27 routes, and Bevy 0.19. Alpha.3 migrations live in the `0.16.0-alpha.3` section of `CHANGELOG.md`; applications coming from 0.15.x must also apply the alpha.2 and alpha.1 migrations.
 
 The safe Rust layer intentionally breaks APIs that expose C++ lifecycle
 protocols, wrong-context state, stale GPU handles, or platform-specific ABI
@@ -286,7 +286,7 @@ import-style binding artifact. `xtask verify-bindings` regenerates and compares
 all supported profiles; arbitrary bindgen clang-argument overrides are rejected
 for canonical artifacts.
 
-The binding generator contract, formatter, allow/block lists, enum normalization, header shims, opaque types, provider name, and exact compatibility target facts all participate in the deterministic binding-spec hash. `dear-imgui-build-support` will ship on the same 0.16.0-alpha.3 train as every other publishable crate.
+The binding generator contract, formatter, allow/block lists, enum normalization, header shims, opaque types, provider name, and exact compatibility target facts all participate in the deterministic binding-spec hash. `dear-imgui-build-support` ships on the same 0.16.0-alpha.3 train as every other publishable crate.
 
 Source identity is package data rather than repository state. The exact 40-hex
 cimgui and nested Dear ImGui revisions live in

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -17,26 +17,21 @@ revision instead of renaming its files or remapping it under the v1 module name.
 
 WASM support is explicit and target-specific. The only supported Rust target is
 `wasm32-unknown-unknown`, and every dependency path to the core crate must
-enable the `wasm` feature. Until `0.16.0-alpha.3` is published, use the candidate
-from `main`:
+enable the `wasm` feature. Use the exact prerelease requirement:
 
 ```toml
 [dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["wasm"] }
+dear-imgui-rs = { version = "=0.16.0-alpha.3", features = ["wasm"] }
 ```
 
 For Bevy, enable `wasm` alongside the features needed by the application and
-take both packages from the same candidate source:
+take both packages from the same release train:
 
 ```toml
 [dependencies]
-dear-imgui-bevy = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["render", "wasm"] }
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["wasm"] }
+dear-imgui-bevy = { version = "=0.16.0-alpha.3", features = ["render", "wasm"] }
+dear-imgui-rs = { version = "=0.16.0-alpha.3", features = ["wasm"] }
 ```
-
-After publication, replace those Git dependencies with the exact prerelease
-requirements `dear-imgui-rs = { version = "=0.16.0-alpha.3", features = ["wasm"] }`
-and `dear-imgui-bevy = { version = "=0.16.0-alpha.3", features = ["render", "wasm"] }`.
 
 Five safe native extensions expose the same `wasm` feature and forward it to
 both `dear-imgui-rs` and their matching sys crate:

--- a/extensions/BEST_PRACTICES.md
+++ b/extensions/BEST_PRACTICES.md
@@ -120,13 +120,7 @@ Use C bindings (cimgui family) + bindgen when available:
 Centralize all prebuilt download/extract/naming logic via the shared helper crate:
 
 - Depend on `dear-imgui-build-support` in your `-sys` crate as a build-dependency.
-  Until `0.16.0-alpha.3` is published, use the candidate source:
-  ```toml
-  [build-dependencies]
-  build-support = { package = "dear-imgui-build-support", git = "https://github.com/Latias94/dear-imgui-rs", branch = "main", features = ["binding-spec"] }
-  ```
-
-  After publication, use the exact prerelease requirement:
+  Use the exact prerelease requirement:
   ```toml
   [build-dependencies]
   build-support = { package = "dear-imgui-build-support", version = "=0.16.0-alpha.3", features = ["binding-spec"] }

--- a/extensions/dear-imgui-reflect/README.md
+++ b/extensions/dear-imgui-reflect/README.md
@@ -19,15 +19,7 @@ Dear ImGui context or panel whose settings and drafts it should retain.
 
 ## Cargo Integration
 
-`0.16.0-alpha.3` is not published yet. Test the candidate from `main`:
-
-```toml
-[dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-imgui-reflect = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-```
-
-After publication, use the exact prerelease requirements:
+Use the exact prerelease requirements:
 
 ```toml
 [dependencies]

--- a/extensions/dear-imgui-test-engine/README.md
+++ b/extensions/dear-imgui-test-engine/README.md
@@ -33,15 +33,7 @@ See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob
 
 ## Quick Start
 
-Until `0.16.0-alpha.3` is published, use matching Git dependencies from `main`:
-
-```toml
-[dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-imgui-test-engine = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-```
-
-After publication, use the exact prerelease requirements:
+Use the exact prerelease requirements:
 
 ```toml
 [dependencies]

--- a/extensions/dear-imguizmo-quat/README.md
+++ b/extensions/dear-imguizmo-quat/README.md
@@ -93,15 +93,7 @@ use one saved value rather than a stack, so avoid nesting `set_*`/`restore_*` or
 
 ## Quick Start
 
-Until `0.16.0-alpha.3` is published, take both crates from `main`:
-
-```toml
-[dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-imguizmo-quat = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-```
-
-After publication, use the exact prerelease requirements:
+Use the exact prerelease requirements:
 
 ```toml
 [dependencies]

--- a/extensions/dear-imguizmo/README.md
+++ b/extensions/dear-imguizmo/README.md
@@ -74,15 +74,7 @@ All matrix arguments in the API are generic over a `Mat4Like` trait, implemented
 
 ## Quick Start
 
-Until `0.16.0-alpha.3` is published, take both crates from `main`:
-
-```toml
-[dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-imguizmo = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-```
-
-After publication, use the exact prerelease requirements:
+Use the exact prerelease requirements:
 
 ```toml
 [dependencies]

--- a/extensions/dear-implot/README.md
+++ b/extensions/dear-implot/README.md
@@ -64,15 +64,7 @@ See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob
 
 This crate integrates with `dear-imgui-rs` directly — add both crates, then build plots inside an ImGui window using a `PlotContext` bound to the current ImGui context.
 
-Until `0.16.0-alpha.3` is published, take both crates from `main`:
-
-```toml
-[dependencies]
-dear-imgui-rs = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-dear-implot = { git = "https://github.com/Latias94/dear-imgui-rs", branch = "main" }
-```
-
-After publication, use the exact prerelease requirements:
+Use the exact prerelease requirements:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
- What
  - Finalize the dated `0.16.0-alpha.3` changelog section and switch user-facing installation and compatibility documentation from the temporary Git candidate to exact crates.io prerelease requirements.

- Why
  - The protected release workflow requires extractable versioned notes, and the published crate documentation must describe the release that users can install.

- Affected crates
  - [x] dear-imgui-rs
  - [x] dear-imgui-sys
  - [x] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [ ] backends/dear-imgui-winit
  - [x] backends/dear-imgui-sdl3
  - [x] dear-app
  - [x] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [x] extensions/dear-imguizmo(-sys)
  - [x] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [x] extensions/dear-imgui-reflect
  - [x] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [x] No behavior change (refactor/cleanup)

- Breaking changes
  - [x] None
  - [ ] Yes (describe):

- Testing / validation
  - `python -B tools/changelog.py check-unreleased`
  - `python -B tools/changelog.py check-soft-wrap --version 0.16.0-alpha.3`
  - `RELEASE_TAG=v0.16.0-alpha.3 python -B tools/ci/run_contract.py release-notes --output <temp>`
  - `cargo metadata --locked --format-version 1` for the workspace and all three standalone Android/iOS manifests
  - `cargo run --locked -j 1 -p xtask -- release-version 0.16.0-alpha.3 --dry-run`
  - 67 focused changelog, release metadata, publication, workflow, and policy unit tests
  - Windows host; Android and iOS manifests validated through locked Cargo metadata

- Docs
  - [ ] N/A
  - [x] Updated README / crate docs

- Links
  - N/A
