### PR TITLE
fix(winit): preserve detached viewport client geometry

### DIFF
--- a/backends/dear-imgui-winit/CHANGELOG.md
+++ b/backends/dear-imgui-winit/CHANGELOG.md
@@ -13,6 +13,10 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 - Make `WinitPlatform` the sole public multi-viewport owner. `with_event_loop` now returns `WinitViewportAttempt`, which preserves the callback output and every deferred platform fault as parallel values instead of dropping one side through nested `Result` precedence.
 - Replace one-at-a-time `poll_viewport_fault` with the advanced `drain_viewport_faults` escape hatch. First-party renderer routes retain an exact-generation platform adapter and aggregate the complete ordered fault batch automatically.
 
+### Fixed
+
+- Preserve secondary viewport client geometry when positioning undecorated Windows windows, changing native decorations, crossing physical-coordinate DPI boundaries without viewport scaling, or creating decorated X11 windows before their frame extents settle. This fixes detached title-bar dragging and prevents native/ImGui geometry and initial X11 DPI drift.
+
 ## [0.16.0-alpha.1]
 
 ### Breaking Changes

--- a/backends/dear-imgui-winit/CHANGELOG.md
+++ b/backends/dear-imgui-winit/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ### Fixed
 
-- Preserve secondary viewport client geometry when positioning undecorated Windows windows, changing native decorations, crossing physical-coordinate DPI boundaries without viewport scaling, or creating decorated X11 windows before their frame extents settle. This fixes detached title-bar dragging and prevents native/ImGui geometry and initial X11 DPI drift.
+- Preserve secondary viewport client geometry when positioning undecorated Windows windows, changing native decorations, crossing physical-coordinate DPI boundaries without viewport scaling, or creating decorated X11 windows before their frame extents settle. Geometry and visibility events now wake the main window and retain unfinished reconciliation under `ControlFlow::Wait`. This fixes detached title-bar dragging and prevents native/ImGui geometry and initial X11 DPI drift.
 
 ## [0.16.0-alpha.1]
 

--- a/backends/dear-imgui-winit/src/multi_viewport.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport.rs
@@ -42,8 +42,8 @@ use crate::native_support::{MonitorCollectionError, MonitorSnapshot};
 
 pub(crate) use self::coordinates::{
     client_physical_to_screen_pos, desktop_size_for_window, framebuffer_scale_for_window,
-    ime_cursor_area_for_viewport, single_window_display_metrics, window_position_from_desktop,
-    window_size_from_desktop,
+    ime_cursor_area_for_viewport, scale_factor_inner_size_override, single_window_display_metrics,
+    window_position_from_desktop, window_size_from_desktop,
 };
 pub(crate) use self::runtime::RuntimeControl;
 pub use self::runtime::{EventLoopScope, WinitViewportAttempt, WinitViewportRendererAdapter};

--- a/backends/dear-imgui-winit/src/multi_viewport/callbacks.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/callbacks.rs
@@ -1,4 +1,8 @@
-use super::coordinates::{desktop_position_from_physical, outer_position_from_client};
+use super::coordinates::{
+    decoration_offset, desktop_position_from_physical, framebuffer_scale_for_dpi_scale,
+    outer_position_from_client, request_client_geometry, validate_viewport_position,
+    validate_viewport_size, viewport_target_dpi_scale,
+};
 use super::native_cursor_hittest::{
     MouseCaptureTransfer, focus_and_raise_window, raise_window_without_activation,
     show_window_without_activation, transfer_mouse_capture,
@@ -122,6 +126,36 @@ fn should_focus_on_show(policy: ViewportWindowPolicy) -> bool {
     !policy.no_focus_on_appearing
 }
 
+fn requires_client_geometry_reconciliation(
+    current: ViewportWindowPolicy,
+    next: ViewportWindowPolicy,
+) -> bool {
+    current.decorations != next.decorations
+}
+
+fn requires_async_client_geometry_reconciliation() -> bool {
+    cfg!(target_os = "linux")
+}
+
+fn viewport_client_geometry(
+    viewport: *mut dear_imgui_rs::sys::ImGuiViewport,
+) -> Result<([f32; 2], [f32; 2]), WinitPlatformError> {
+    let viewport = unsafe { viewport.as_ref() }.ok_or(WinitPlatformError::ContextMismatch)?;
+    let position = validate_viewport_position([viewport.Pos.x, viewport.Pos.y]).ok_or(
+        WinitPlatformError::InvalidViewportGeometry {
+            operation: "client geometry reconciliation",
+            reason: "position must be finite and representable by a native window",
+        },
+    )?;
+    let size = validate_viewport_size([viewport.Size.x, viewport.Size.y]).ok_or(
+        WinitPlatformError::InvalidViewportGeometry {
+            operation: "client geometry reconciliation",
+            reason: "size must be finite, positive, and representable by a native window",
+        },
+    )?;
+    Ok((position, size))
+}
+
 fn request_platform_window_focus(
     control: &RuntimeControl,
     window: &winit::window::Window,
@@ -200,12 +234,19 @@ pub(super) fn record_viewport_failure(
 fn sync_window_policy(
     data: &ViewportData,
     next: ViewportWindowPolicy,
+    viewport: *mut dear_imgui_rs::sys::ImGuiViewport,
 ) -> Result<(), WinitPlatformError> {
     let current = data.window_policy.get();
     let taskbar_capability = skip_taskbar_capability();
     validate_policy_transition(current, next, taskbar_capability)?;
+    let client_geometry = requires_client_geometry_reconciliation(current, next)
+        .then(|| viewport_client_geometry(viewport))
+        .transpose()?;
 
     let window = data.window();
+    let decoration_offset_before_policy_change = client_geometry
+        .filter(|_| requires_async_client_geometry_reconciliation())
+        .and_then(|_| decoration_offset(window));
     if current.cursor_hittest != next.cursor_hittest {
         if !next.cursor_hittest {
             // A moving viewport becomes hit-test transparent so the backend can identify the
@@ -218,8 +259,21 @@ fn sync_window_policy(
     if current.no_focus_on_click != next.no_focus_on_click {
         data.set_no_focus_on_click(next.no_focus_on_click)?;
     }
-    if current.decorations != next.decorations {
+    if let Some((position, size)) = client_geometry {
         window.set_decorations(next.decorations);
+        let dpi_scale = unsafe { viewport_target_dpi_scale(viewport) };
+        request_client_geometry(window, position, size, dpi_scale);
+        if requires_async_client_geometry_reconciliation() {
+            data.request_client_geometry_reconciliation(
+                position,
+                size,
+                decoration_offset_before_policy_change,
+            );
+        } else {
+            // ImGui clears request flags at the end of the current platform update pass. Queue
+            // the refresh so the next frame observes the settled native client geometry.
+            data.request_geometry_refresh(true, true);
+        }
     }
     if current.top_most != next.top_most {
         window.set_window_level(if next.top_most {

--- a/backends/dear-imgui-winit/src/multi_viewport/callbacks.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/callbacks.rs
@@ -232,6 +232,7 @@ pub(super) fn record_viewport_failure(
 }
 
 fn sync_window_policy(
+    control: &RuntimeControl,
     data: &ViewportData,
     next: ViewportWindowPolicy,
     viewport: *mut dear_imgui_rs::sys::ImGuiViewport,
@@ -273,6 +274,7 @@ fn sync_window_policy(
             // ImGui clears request flags at the end of the current platform update pass. Queue
             // the refresh so the next frame observes the settled native client geometry.
             data.request_geometry_refresh(true, true);
+            control.request_main_window_redraw();
         }
     }
     if current.top_most != next.top_most {

--- a/backends/dear-imgui-winit/src/multi_viewport/callbacks/window.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/callbacks/window.rs
@@ -155,7 +155,7 @@ pub(in super::super) unsafe extern "C" fn winit_create_window(
                     //
                     // ImGui platform coordinates are relative to the *client* origin, while winit only lets us
                     // position by outer window coordinates. Adjust by decoration offset when available.
-                    let dpi_scale = unsafe { viewport_target_dpi_scale(vp, position) };
+                    let dpi_scale = unsafe { viewport_target_dpi_scale(vp) };
                     let outer_target = outer_position_from_client(&window, position, dpi_scale);
                     window.set_outer_position(window_position_from_desktop(outer_target));
 
@@ -192,9 +192,9 @@ pub(in super::super) unsafe extern "C" fn winit_create_window(
 
                     // DPI controls UI scaling while framebuffer scale converts this backend's
                     // desktop coordinate unit into render-target pixels.
-                    let scale = sanitize::positive_finite_f32_or(window.scale_factor() as f32, 1.0);
+                    let scale = sanitize::positive_finite_f32_or(dpi_scale, 1.0);
                     vp_ref.DpiScale = scale;
-                    let framebuffer_scale = framebuffer_scale_for_window(&window);
+                    let framebuffer_scale = framebuffer_scale_for_dpi_scale(f64::from(scale));
                     vp_ref.FramebufferScale.x = framebuffer_scale[0];
                     vp_ref.FramebufferScale.y = framebuffer_scale[1];
 
@@ -265,10 +265,23 @@ pub(in super::super) unsafe extern "C" fn winit_show_window(
         }
         let policy = ViewportWindowPolicy::from_flags(unsafe { (*vp).Flags });
         with_viewport_data(control, vp, |data| {
-            if let Err(error) = sync_window_policy(data, policy) {
+            if let Err(error) = sync_window_policy(data, policy, vp) {
                 record_viewport_failure(control, vp, error);
                 return;
             }
+            let reconciliation =
+                if requires_async_client_geometry_reconciliation() && policy.decorations {
+                    let geometry = match viewport_client_geometry(vp) {
+                        Ok(geometry) => geometry,
+                        Err(error) => {
+                            record_viewport_failure(control, vp, error);
+                            return;
+                        }
+                    };
+                    Some((geometry, decoration_offset(data.window())))
+                } else {
+                    None
+                };
             if should_focus_on_show(policy) {
                 data.window().set_visible(true);
                 if let Err(error) = request_platform_window_focus(control, data.window()) {
@@ -284,6 +297,13 @@ pub(in super::super) unsafe extern "C" fn winit_show_window(
                 {
                     record_viewport_failure(control, vp, error);
                 }
+            }
+            if let Some(((position, size), decoration_offset_before_show)) = reconciliation {
+                data.request_client_geometry_reconciliation(
+                    position,
+                    size,
+                    decoration_offset_before_show,
+                );
             }
         });
     });
@@ -315,112 +335,6 @@ pub(in super::super) unsafe extern "C" fn winit_get_window_pos_out(
     });
 }
 
-fn validate_viewport_position(position: [f32; 2]) -> Option<[f32; 2]> {
-    let position = sanitize::finite_vec2_f32(position)?;
-    let minimum = f64::from(i32::MIN);
-    let maximum = f64::from(i32::MAX);
-    position
-        .into_iter()
-        .map(f64::from)
-        .all(|value| value >= minimum && value <= maximum)
-        .then_some(position)
-}
-
-fn validate_viewport_size(size: [f32; 2]) -> Option<[f32; 2]> {
-    let size = sanitize::finite_vec2_f32(size)?;
-    let maximum = f64::from(i32::MAX);
-    size.into_iter()
-        .map(f64::from)
-        .all(|value| value > 0.0 && value <= maximum)
-        .then_some(size)
-}
-
-fn target_monitor_dpi_scale(
-    viewport_dpi_scale: f32,
-    position: [f32; 2],
-    size: [f32; 2],
-    monitors: &[dear_imgui_rs::sys::ImGuiPlatformMonitor],
-) -> f32 {
-    let fallback = sanitize::positive_finite_f32_or(viewport_dpi_scale, 1.0);
-    if monitors.is_empty() {
-        return fallback;
-    }
-
-    let viewport_min = position;
-    let viewport_max = [
-        position[0] + size[0].max(0.0),
-        position[1] + size[1].max(0.0),
-    ];
-    let surface_threshold = (size[0].max(0.0) * size[1].max(0.0) * 0.5).max(1.0);
-    let mut best_index = 0;
-    let mut best_surface = 0.001;
-
-    for (index, monitor) in monitors.iter().enumerate() {
-        let monitor_min = [monitor.MainPos.x, monitor.MainPos.y];
-        let monitor_max = [
-            monitor.MainPos.x + monitor.MainSize.x,
-            monitor.MainPos.y + monitor.MainSize.y,
-        ];
-        let contains = viewport_min[0] >= monitor_min[0]
-            && viewport_min[1] >= monitor_min[1]
-            && viewport_max[0] <= monitor_max[0]
-            && viewport_max[1] <= monitor_max[1];
-        if contains {
-            best_index = index;
-            break;
-        }
-
-        let overlap_width =
-            (viewport_max[0].min(monitor_max[0]) - viewport_min[0].max(monitor_min[0])).max(0.0);
-        let overlap_height =
-            (viewport_max[1].min(monitor_max[1]) - viewport_min[1].max(monitor_min[1])).max(0.0);
-        let overlap_surface = overlap_width * overlap_height;
-        if overlap_surface >= best_surface {
-            best_surface = overlap_surface;
-            best_index = index;
-        }
-        if best_surface >= surface_threshold {
-            break;
-        }
-    }
-
-    sanitize::positive_finite_f32_or(monitors[best_index].DpiScale, fallback)
-}
-
-unsafe fn viewport_target_dpi_scale(
-    vp: *mut dear_imgui_rs::sys::ImGuiViewport,
-    position: [f32; 2],
-) -> f32 {
-    let Some(viewport) = (unsafe { vp.as_ref() }) else {
-        return 1.0;
-    };
-    let fallback = sanitize::positive_finite_f32_or(viewport.DpiScale, 1.0);
-    let platform_io = unsafe { dear_imgui_rs::sys::igGetPlatformIO_Nil() };
-    let Some(platform_io) = (unsafe { platform_io.as_ref() }) else {
-        return fallback;
-    };
-    let native_monitors = &platform_io.Monitors;
-    let Ok(count) = usize::try_from(native_monitors.Size) else {
-        return fallback;
-    };
-    if native_monitors.Capacity < native_monitors.Size
-        || count > 0 && native_monitors.Data.is_null()
-    {
-        return fallback;
-    }
-    let monitors = if count == 0 {
-        &[][..]
-    } else {
-        unsafe { std::slice::from_raw_parts(native_monitors.Data, count) }
-    };
-    target_monitor_dpi_scale(
-        viewport.DpiScale,
-        position,
-        [viewport.Size.x, viewport.Size.y],
-        monitors,
-    )
-}
-
 /// Set window position
 pub(in super::super) unsafe extern "C" fn winit_set_window_pos(
     vp: *mut dear_imgui_rs::sys::ImGuiViewport,
@@ -445,11 +359,30 @@ pub(in super::super) unsafe extern "C" fn winit_set_window_pos(
 
         with_viewport_data(control, vp, |data| {
             let [x, y] = requested_position;
-            let dpi_scale = unsafe { viewport_target_dpi_scale(vp, [x, y]) };
+            let dpi_scale = unsafe { viewport_target_dpi_scale(vp) };
             let window = data.window();
             let desired_client = [x, y];
+            let requires_reconciliation =
+                requires_async_client_geometry_reconciliation() && window.is_decorated();
+            let decoration_offset_before_move = requires_reconciliation
+                .then(|| decoration_offset(window))
+                .flatten();
             let outer_target = outer_position_from_client(window, desired_client, dpi_scale);
             window.set_outer_position(window_position_from_desktop(outer_target));
+            if requires_reconciliation {
+                let size = unsafe { &*vp }.Size;
+                if let Some(size) = validate_viewport_size([size.x, size.y]) {
+                    data.request_client_geometry_reconciliation(
+                        desired_client,
+                        size,
+                        decoration_offset_before_move,
+                    );
+                } else {
+                    data.update_reconciling_client_position(desired_client);
+                }
+            } else {
+                data.update_reconciling_client_position(desired_client);
+            }
         });
     });
 }
@@ -499,6 +432,7 @@ pub(in super::super) unsafe extern "C" fn winit_set_window_size(
 
         with_viewport_data(control, vp, |data| {
             let window = data.window();
+            data.update_reconciling_client_size(size);
             if window
                 .request_inner_size(window_size_from_desktop(size))
                 .is_some()
@@ -672,7 +606,7 @@ pub(in super::super) unsafe extern "C" fn winit_update_window(
         }
         let policy = ViewportWindowPolicy::from_flags(unsafe { (*vp).Flags });
         with_viewport_data(control, vp, |data| {
-            if let Err(error) = sync_window_policy(data, policy) {
+            if let Err(error) = sync_window_policy(data, policy, vp) {
                 record_viewport_failure(control, vp, error);
             }
         });
@@ -744,6 +678,28 @@ mod policy_tests {
     }
 
     #[test]
+    fn changing_decorations_requires_client_geometry_reconciliation() {
+        let current = ViewportWindowPolicy::default();
+        let decorations_changed = ViewportWindowPolicy {
+            decorations: false,
+            ..current
+        };
+        let top_most_changed = ViewportWindowPolicy {
+            top_most: true,
+            ..current
+        };
+
+        assert!(requires_client_geometry_reconciliation(
+            current,
+            decorations_changed
+        ));
+        assert!(!requires_client_geometry_reconciliation(
+            current,
+            top_most_changed
+        ));
+    }
+
+    #[test]
     fn late_focus_and_unsupported_taskbar_changes_fail_closed() {
         let current = ViewportWindowPolicy::default();
         let late_no_focus = ViewportWindowPolicy {
@@ -769,37 +725,6 @@ mod policy_tests {
         assert!(
             validate_policy_transition(current, taskbar_change, SkipTaskbarCapability::Inherent)
                 .is_ok()
-        );
-    }
-
-    #[test]
-    fn window_positioning_uses_the_destination_monitor_dpi() {
-        fn monitor(dpi_scale: f32) -> dear_imgui_rs::sys::ImGuiPlatformMonitor {
-            dear_imgui_rs::sys::ImGuiPlatformMonitor {
-                MainPos: dear_imgui_rs::sys::ImVec2 { x: 0.0, y: 0.0 },
-                MainSize: dear_imgui_rs::sys::ImVec2 { x: 1.0, y: 1.0 },
-                WorkPos: dear_imgui_rs::sys::ImVec2 { x: 0.0, y: 0.0 },
-                WorkSize: dear_imgui_rs::sys::ImVec2 { x: 1.0, y: 1.0 },
-                DpiScale: dpi_scale,
-                PlatformHandle: std::ptr::null_mut(),
-            }
-        }
-        let mut monitors = [monitor(1.0), monitor(1.5)];
-        monitors[0].MainSize = dear_imgui_rs::sys::ImVec2 { x: 100.0, y: 100.0 };
-        monitors[1].MainPos.x = 100.0;
-        monitors[1].MainSize = dear_imgui_rs::sys::ImVec2 { x: 100.0, y: 100.0 };
-
-        assert_eq!(
-            target_monitor_dpi_scale(1.0, [20.0, 20.0], [20.0, 20.0], &monitors),
-            1.0
-        );
-        assert_eq!(
-            target_monitor_dpi_scale(1.0, [120.0, 20.0], [20.0, 20.0], &monitors),
-            1.5
-        );
-        assert_eq!(
-            target_monitor_dpi_scale(1.25, [0.0, 0.0], [10.0, 10.0], &[]),
-            1.25
         );
     }
 }

--- a/backends/dear-imgui-winit/src/multi_viewport/callbacks/window.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/callbacks/window.rs
@@ -265,7 +265,7 @@ pub(in super::super) unsafe extern "C" fn winit_show_window(
         }
         let policy = ViewportWindowPolicy::from_flags(unsafe { (*vp).Flags });
         with_viewport_data(control, vp, |data| {
-            if let Err(error) = sync_window_policy(data, policy, vp) {
+            if let Err(error) = sync_window_policy(control, data, policy, vp) {
                 record_viewport_failure(control, vp, error);
                 return;
             }
@@ -438,6 +438,7 @@ pub(in super::super) unsafe extern "C" fn winit_set_window_size(
                 .is_some()
             {
                 data.request_geometry_refresh(false, true);
+                control.request_main_window_redraw();
             }
         });
     });
@@ -606,7 +607,7 @@ pub(in super::super) unsafe extern "C" fn winit_update_window(
         }
         let policy = ViewportWindowPolicy::from_flags(unsafe { (*vp).Flags });
         with_viewport_data(control, vp, |data| {
-            if let Err(error) = sync_window_policy(data, policy, vp) {
+            if let Err(error) = sync_window_policy(control, data, policy, vp) {
                 record_viewport_failure(control, vp, error);
             }
         });

--- a/backends/dear-imgui-winit/src/multi_viewport/coordinates.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/coordinates.rs
@@ -29,6 +29,26 @@ fn sanitized_scale(scale: f64) -> f64 {
     sanitize::positive_finite_or(scale, 1.0)
 }
 
+pub(super) fn validate_viewport_position(position: [f32; 2]) -> Option<[f32; 2]> {
+    let position = sanitize::finite_vec2_f32(position)?;
+    let minimum = f64::from(i32::MIN);
+    let maximum = f64::from(i32::MAX);
+    position
+        .into_iter()
+        .map(f64::from)
+        .all(|value| value >= minimum && value <= maximum)
+        .then_some(position)
+}
+
+pub(super) fn validate_viewport_size(size: [f32; 2]) -> Option<[f32; 2]> {
+    let size = sanitize::finite_vec2_f32(size)?;
+    let maximum = f64::from(i32::MAX);
+    size.into_iter()
+        .map(f64::from)
+        .all(|value| value > 0.0 && value <= maximum)
+        .then_some(size)
+}
+
 fn desktop_position_from_physical_values(
     space: DesktopCoordinateSpace,
     position: [f64; 2],
@@ -102,10 +122,6 @@ pub(super) fn desktop_position_from_physical(
     .and_then(sanitize::finite_vec2_f64_to_f32)
 }
 
-fn desktop_input_position_from_physical(position: [f64; 2], scale: f64) -> Option<[f64; 2]> {
-    desktop_position_from_physical_values(native_desktop_coordinate_space(), position, scale)
-}
-
 /// Converts detached native monitor facts into the coordinate model used by Winit viewports.
 ///
 /// Main and work rectangles are converted independently. The conversion is fallible so native
@@ -162,6 +178,19 @@ pub(super) fn monitor_from_snapshot(
     })
 }
 
+pub(super) unsafe fn viewport_target_dpi_scale(
+    viewport: *mut dear_imgui_rs::sys::ImGuiViewport,
+) -> f32 {
+    let Some(viewport_ref) = (unsafe { viewport.as_ref() }) else {
+        return 1.0;
+    };
+    let fallback = sanitize::positive_finite_f32_or(viewport_ref.DpiScale, 1.0);
+    let monitor = unsafe { dear_imgui_rs::sys::igGetViewportPlatformMonitor(viewport) };
+    unsafe { monitor.as_ref() }
+        .map(|monitor| sanitize::positive_finite_f32_or(monitor.DpiScale, fallback))
+        .unwrap_or(fallback)
+}
+
 pub(crate) fn desktop_size_for_window(window: &Window) -> [f32; 2] {
     desktop_size_from_physical(window.inner_size(), window.scale_factor())
 }
@@ -194,6 +223,25 @@ pub(crate) fn framebuffer_scale_for_window(window: &Window) -> [f32; 2] {
     framebuffer_scale_for_space(native_desktop_coordinate_space(), window.scale_factor())
 }
 
+pub(crate) fn scale_factor_inner_size_override(
+    scale_viewports: bool,
+    current_size: PhysicalSize<u32>,
+) -> Option<PhysicalSize<u32>> {
+    scale_factor_inner_size_override_for_space(
+        native_desktop_coordinate_space(),
+        scale_viewports,
+        current_size,
+    )
+}
+
+fn scale_factor_inner_size_override_for_space(
+    space: DesktopCoordinateSpace,
+    scale_viewports: bool,
+    current_size: PhysicalSize<u32>,
+) -> Option<PhysicalSize<u32>> {
+    (matches!(space, DesktopCoordinateSpace::Physical) && !scale_viewports).then_some(current_size)
+}
+
 fn framebuffer_scale_for_space(space: DesktopCoordinateSpace, scale: f64) -> [f32; 2] {
     match space {
         // The ImGui coordinate unit already is a framebuffer pixel on Windows and X11.
@@ -203,6 +251,10 @@ fn framebuffer_scale_for_space(space: DesktopCoordinateSpace, scale: f64) -> [f3
             [scale, scale]
         }
     }
+}
+
+pub(super) fn framebuffer_scale_for_dpi_scale(scale: f64) -> [f32; 2] {
+    framebuffer_scale_for_space(native_desktop_coordinate_space(), scale)
 }
 
 pub(crate) fn window_position_from_desktop(position: [f32; 2]) -> Position {
@@ -228,12 +280,27 @@ pub(crate) fn window_size_from_desktop(size: [f32; 2]) -> Size {
     }
 }
 
+pub(super) fn request_client_geometry(
+    window: &Window,
+    position: [f32; 2],
+    size: [f32; 2],
+    dpi_scale: f32,
+) {
+    let _ = window.request_inner_size(window_size_from_desktop(size));
+    let outer_position = outer_position_from_client(window, position, dpi_scale);
+    window.set_outer_position(window_position_from_desktop(outer_position));
+}
+
 pub(crate) fn client_physical_to_screen_pos(
     window: &Window,
     client_position: [f64; 2],
 ) -> Option<[f32; 2]> {
     let scale = window.scale_factor();
-    let client = desktop_input_position_from_physical(client_position, scale)?;
+    let client = desktop_position_from_physical_values(
+        native_desktop_coordinate_space(),
+        client_position,
+        scale,
+    )?;
     let origin = window.inner_position().ok()?;
     let origin = desktop_position_from_physical_values(
         native_desktop_coordinate_space(),
@@ -243,10 +310,41 @@ pub(crate) fn client_physical_to_screen_pos(
     sanitize::finite_vec2_f64_to_f32([origin[0] + client[0], origin[1] + client[1]])
 }
 
-pub(super) fn decoration_offset(window: &Window) -> Option<(f64, f64)> {
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ObservedClientGeometry {
+    pub(super) position: [f32; 2],
+    pub(super) size: [f32; 2],
+    pub(super) decoration_offset: Option<[f32; 2]>,
+}
+
+pub(super) fn observe_client_geometry(window: &Window) -> Option<ObservedClientGeometry> {
+    let scale = window.scale_factor();
+    let inner = window.inner_position().ok()?;
+    let position = desktop_position_from_physical(inner, scale)?;
+    let size = desktop_size_from_physical(window.inner_size(), scale);
+    let decoration_offset = window
+        .outer_position()
+        .ok()
+        .and_then(|outer| decoration_offset_from_positions(inner, outer, scale));
+    Some(ObservedClientGeometry {
+        position,
+        size,
+        decoration_offset,
+    })
+}
+
+pub(super) fn decoration_offset(window: &Window) -> Option<[f32; 2]> {
     let scale = window.scale_factor();
     let inner = window.inner_position().ok()?;
     let outer = window.outer_position().ok()?;
+    decoration_offset_from_positions(inner, outer, scale)
+}
+
+fn decoration_offset_from_positions(
+    inner: PhysicalPosition<i32>,
+    outer: PhysicalPosition<i32>,
+    scale: f64,
+) -> Option<[f32; 2]> {
     let inner = desktop_position_from_physical_values(
         native_desktop_coordinate_space(),
         [f64::from(inner.x), f64::from(inner.y)],
@@ -257,9 +355,7 @@ pub(super) fn decoration_offset(window: &Window) -> Option<(f64, f64)> {
         [f64::from(outer.x), f64::from(outer.y)],
         scale,
     )?;
-    let offset = [inner[0] - outer[0], inner[1] - outer[1]];
-    sanitize::finite_vec2_f64_to_f32(offset)?;
-    Some((offset[0], offset[1]))
+    sanitize::finite_vec2_f64_to_f32([inner[0] - outer[0], inner[1] - outer[1]])
 }
 
 pub(super) fn outer_position_from_client(
@@ -268,20 +364,37 @@ pub(super) fn outer_position_from_client(
     dpi_scale: f32,
 ) -> [f32; 2] {
     #[cfg(target_os = "windows")]
-    if let Some(position) = windows::outer_position_from_client(window, client_position, dpi_scale)
+    if !window.is_decorated() {
+        // Undecorated Winit windows retain resize-capable Win32 style bits while WM_NCCALCSIZE
+        // makes the client area cover the window. Inferring decorations from those styles would
+        // invent a title-bar offset and desynchronize ImGui hit testing from the native client
+        // origin.
+        return client_position;
+    }
+
+    // Decorated Windows windows need the destination monitor DPI, which is not necessarily the
+    // current live decoration offset. Other platforms use Winit's observed client/outer geometry.
+    #[cfg(target_os = "windows")]
+    if let Some(position) =
+        windows::outer_position_from_client_style(window, client_position, dpi_scale)
     {
         return position;
     }
 
     let _ = dpi_scale;
     decoration_offset(window)
-        .and_then(|(dx, dy)| {
-            sanitize::finite_vec2_f32([
-                client_position[0] - dx as f32,
-                client_position[1] - dy as f32,
-            ])
-        })
+        .and_then(|offset| outer_position_from_decoration_offset(client_position, offset))
         .unwrap_or(client_position)
+}
+
+fn outer_position_from_decoration_offset(
+    client_position: [f32; 2],
+    decoration_offset: [f32; 2],
+) -> Option<[f32; 2]> {
+    sanitize::finite_vec2_f32([
+        client_position[0] - decoration_offset[0],
+        client_position[1] - decoration_offset[1],
+    ])
 }
 
 pub(crate) fn ime_cursor_area_for_viewport(
@@ -330,7 +443,7 @@ mod windows {
 
     use crate::sanitize;
 
-    pub(super) fn outer_position_from_client(
+    pub(super) fn outer_position_from_client_style(
         window: &Window,
         client_position: [f32; 2],
         dpi_scale: f32,
@@ -518,6 +631,51 @@ mod tests {
 
         assert_eq!(position, LogicalPosition::new(200.0, 240.0));
         assert_eq!(size, LogicalSize::new(20.0, 20.0));
+    }
+
+    #[test]
+    fn undecorated_client_origin_needs_no_outer_position_offset() {
+        assert_eq!(
+            outer_position_from_decoration_offset([2447.0, 802.0], [0.0, 0.0]),
+            Some([2447.0, 802.0])
+        );
+    }
+
+    #[test]
+    fn observed_decoration_offset_positions_the_client_origin() {
+        assert_eq!(
+            outer_position_from_decoration_offset([2447.0, 802.0], [11.0, 45.0]),
+            Some([2436.0, 757.0])
+        );
+    }
+
+    #[test]
+    fn scale_factor_change_preserves_the_backends_desktop_size_unit() {
+        let current = PhysicalSize::new(800, 600);
+        assert_eq!(
+            scale_factor_inner_size_override_for_space(
+                DesktopCoordinateSpace::Physical,
+                false,
+                current,
+            ),
+            Some(current)
+        );
+        assert_eq!(
+            scale_factor_inner_size_override_for_space(
+                DesktopCoordinateSpace::Physical,
+                true,
+                current,
+            ),
+            None
+        );
+        assert_eq!(
+            scale_factor_inner_size_override_for_space(
+                DesktopCoordinateSpace::Logical,
+                false,
+                current,
+            ),
+            None
+        );
     }
 
     fn client_to_screen_for_space(

--- a/backends/dear-imgui-winit/src/multi_viewport/events.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/events.rs
@@ -33,19 +33,27 @@ pub(crate) fn route_secondary_window_event(
             // machine. The event only invalidates geometry so the registered callbacks query
             // the new values at the next update boundary.
             match event {
-                WindowEvent::Moved(_) => unsafe {
+                WindowEvent::Moved(_) => {
+                    data.note_geometry_event();
                     data.request_geometry_refresh(true, false);
-                    (*viewport).PlatformRequestMove = true;
-                },
-                WindowEvent::Resized(_) => unsafe {
+                }
+                WindowEvent::Resized(_) => {
+                    data.note_geometry_event();
                     data.request_geometry_refresh(false, true);
-                    (*viewport).PlatformRequestResize = true;
-                },
-                WindowEvent::ScaleFactorChanged { .. } => unsafe {
+                }
+                WindowEvent::ScaleFactorChanged {
+                    inner_size_writer, ..
+                } => {
+                    if let Some(size) = super::scale_factor_inner_size_override(
+                        context.io().config_dpi_scale_viewports(),
+                        window.inner_size(),
+                    ) {
+                        let mut inner_size_writer = inner_size_writer.clone();
+                        let _ = inner_size_writer.request_inner_size(size);
+                    }
+                    data.note_geometry_event();
                     data.request_geometry_refresh(true, true);
-                    (*viewport).PlatformRequestMove = true;
-                    (*viewport).PlatformRequestResize = true;
-                },
+                }
                 WindowEvent::CloseRequested => unsafe {
                     (*viewport).PlatformRequestClose = true;
                 },

--- a/backends/dear-imgui-winit/src/multi_viewport/events.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/events.rs
@@ -18,6 +18,30 @@ fn validate_runtime(
     control.platform_control()?.validate_operational_contract()
 }
 
+fn secondary_event_requests_main_redraw(
+    event: &WindowEvent,
+    has_client_geometry_reconciliation: bool,
+) -> bool {
+    matches!(
+        event,
+        WindowEvent::Moved(_)
+            | WindowEvent::Resized(_)
+            | WindowEvent::ScaleFactorChanged { .. }
+            | WindowEvent::CloseRequested
+            | WindowEvent::RedrawRequested
+            | WindowEvent::KeyboardInput { .. }
+            | WindowEvent::ModifiersChanged(_)
+            | WindowEvent::Ime(_)
+            | WindowEvent::CursorMoved { .. }
+            | WindowEvent::CursorLeft { .. }
+            | WindowEvent::CursorEntered { .. }
+            | WindowEvent::Focused(_)
+            | WindowEvent::MouseWheel { .. }
+            | WindowEvent::MouseInput { .. }
+            | WindowEvent::Touch(_)
+    ) || has_client_geometry_reconciliation && matches!(event, WindowEvent::Occluded(_))
+}
+
 pub(crate) fn route_secondary_window_event(
     control: &RuntimeControl,
     context: &mut Context,
@@ -26,9 +50,13 @@ pub(crate) fn route_secondary_window_event(
 ) -> Result<bool, super::WinitPlatformError> {
     control.ensure_context(context)?;
     let binding = context.binding();
-    Ok(binding.with_bound_context(|| {
+    let mut request_main_redraw = false;
+    let consumed = binding.with_bound_context(|| {
         with_viewport_data_for_window(control, window_id, |viewport, data| {
             let window = data.window();
+            let has_client_geometry_reconciliation = data.has_client_geometry_reconciliation();
+            request_main_redraw |=
+                secondary_event_requests_main_redraw(event, has_client_geometry_reconciliation);
             // Keep DPI and framebuffer values owned by Dear ImGui's platform update state
             // machine. The event only invalidates geometry so the registered callbacks query
             // the new values at the next update boundary.
@@ -52,6 +80,13 @@ pub(crate) fn route_secondary_window_event(
                         let _ = inner_size_writer.request_inner_size(size);
                     }
                     data.note_geometry_event();
+                    data.request_geometry_refresh(true, true);
+                }
+                WindowEvent::Occluded(_) if has_client_geometry_reconciliation => {
+                    // X11 reports its first visibility state after the map request, including
+                    // fully obscured windows. Winit updates its internal visibility after this
+                    // callback returns, so schedule another observation without treating the
+                    // visibility notification as authoritative geometry.
                     data.request_geometry_refresh(true, true);
                 }
                 WindowEvent::CloseRequested => unsafe {
@@ -141,7 +176,11 @@ pub(crate) fn route_secondary_window_event(
             }
         })
         .unwrap_or(false)
-    }))
+    });
+    if request_main_redraw {
+        control.request_main_window_redraw();
+    }
+    Ok(consumed)
 }
 
 pub(super) fn route_secondary_event<T>(
@@ -182,4 +221,36 @@ pub(crate) fn handle_event<T>(
     let consumed = route_secondary_event(control, context, event)? || consumed;
     control.poll_fault()?;
     Ok(consumed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::secondary_event_requests_main_redraw;
+    use winit::event::WindowEvent;
+
+    #[test]
+    fn secondary_close_and_redraw_wake_the_main_window() {
+        assert!(secondary_event_requests_main_redraw(
+            &WindowEvent::CloseRequested,
+            false,
+        ));
+        assert!(secondary_event_requests_main_redraw(
+            &WindowEvent::RedrawRequested,
+            false,
+        ));
+    }
+
+    #[test]
+    fn either_x11_occlusion_state_wakes_pending_reconciliation() {
+        for occluded in [false, true] {
+            assert!(secondary_event_requests_main_redraw(
+                &WindowEvent::Occluded(occluded),
+                true,
+            ));
+            assert!(!secondary_event_requests_main_redraw(
+                &WindowEvent::Occluded(occluded),
+                false,
+            ));
+        }
+    }
 }

--- a/backends/dear-imgui-winit/src/multi_viewport/registry.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/registry.rs
@@ -360,7 +360,7 @@ pub(super) fn request_geometry_refresh_for_window(
     window_id: WindowId,
     position: bool,
     size: bool,
-) {
+) -> bool {
     if let Some(entry) = control
         .viewports
         .borrow()
@@ -368,6 +368,9 @@ pub(super) fn request_geometry_refresh_for_window(
         .find(|entry| entry.data.window().id() == window_id)
     {
         entry.data.request_geometry_refresh(position, size);
+        true
+    } else {
+        false
     }
 }
 
@@ -404,7 +407,15 @@ pub(super) fn apply_pending_geometry_refresh(control: &RuntimeControl) {
                 continue;
             };
             match decision.action {
-                ClientGeometryReconciliationAction::Wait => continue,
+                ClientGeometryReconciliationAction::Wait => {
+                    // Waiting for a native geometry or visibility event must not consume the
+                    // transaction's only refresh. The event that makes progress requests the
+                    // main-window redraw, so retaining this state does not create a busy loop.
+                    entry
+                        .data
+                        .request_geometry_refresh(refresh.position, refresh.size);
+                    continue;
+                }
                 ClientGeometryReconciliationAction::ApplyTarget => {
                     let dpi_scale = unsafe { viewport_target_dpi_scale(viewport) };
                     request_client_geometry(window, decision.position, decision.size, dpi_scale);

--- a/backends/dear-imgui-winit/src/multi_viewport/registry.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/registry.rs
@@ -6,8 +6,11 @@ use dear_imgui_rs::{ContextId, ContextLifecycle};
 use winit::window::{Window, WindowId};
 
 use super::WinitPlatformError;
+use super::coordinates::{
+    observe_client_geometry, request_client_geometry, viewport_target_dpi_scale,
+};
 use super::runtime::RuntimeControl;
-use super::viewport_data::ViewportData;
+use super::viewport_data::{ClientGeometryReconciliationAction, ViewportData};
 
 struct RegisteredRuntime {
     context_raw: *mut dear_imgui_rs::sys::ImGuiContext,
@@ -370,7 +373,7 @@ pub(super) fn request_geometry_refresh_for_window(
 
 pub(super) fn apply_pending_geometry_refresh(control: &RuntimeControl) {
     for entry in control.viewports.borrow().iter() {
-        let refresh = entry.data.take_geometry_refresh();
+        let mut refresh = entry.data.take_geometry_refresh();
         if refresh.is_empty() {
             continue;
         }
@@ -379,6 +382,39 @@ pub(super) fn apply_pending_geometry_refresh(control: &RuntimeControl) {
         };
         if unsafe { entry.native_ownership_loss(viewport).is_some() } {
             continue;
+        }
+        if entry.data.has_client_geometry_reconciliation() {
+            let window = entry.data.window();
+            let Some(observed) = observe_client_geometry(window) else {
+                entry.data.cancel_client_geometry_reconciliation();
+                refresh.position = true;
+                refresh.size = true;
+                unsafe {
+                    (*viewport).PlatformRequestMove |= refresh.position;
+                    (*viewport).PlatformRequestResize |= refresh.size;
+                }
+                continue;
+            };
+            let Some(decision) = entry.data.observe_client_geometry_reconciliation(
+                window.is_visible() == Some(true),
+                observed.position,
+                observed.size,
+                observed.decoration_offset,
+            ) else {
+                continue;
+            };
+            match decision.action {
+                ClientGeometryReconciliationAction::Wait => continue,
+                ClientGeometryReconciliationAction::ApplyTarget => {
+                    let dpi_scale = unsafe { viewport_target_dpi_scale(viewport) };
+                    request_client_geometry(window, decision.position, decision.size, dpi_scale);
+                    continue;
+                }
+                ClientGeometryReconciliationAction::PublishNative => {
+                    refresh.position = true;
+                    refresh.size = true;
+                }
+            }
         }
         unsafe {
             (*viewport).PlatformRequestMove |= refresh.position;

--- a/backends/dear-imgui-winit/src/multi_viewport/runtime.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/runtime.rs
@@ -834,7 +834,15 @@ impl RuntimeControl {
     }
 
     pub(crate) fn note_window_geometry(&self, window_id: WindowId, position: bool, size: bool) {
-        request_geometry_refresh_for_window(self, window_id, position, size);
+        if request_geometry_refresh_for_window(self, window_id, position, size) {
+            self.request_main_window_redraw();
+        }
+    }
+
+    pub(crate) fn request_main_window_redraw(&self) {
+        if let Some(main_window) = self.main_window() {
+            main_window.request_redraw();
+        }
     }
 
     pub(crate) fn reconcile_geometry_state(&self) {

--- a/backends/dear-imgui-winit/src/multi_viewport/viewport_data.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/viewport_data.rs
@@ -22,6 +22,276 @@ impl GeometryRefresh {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ClientGeometryReconciliationAction {
+    Wait,
+    ApplyTarget,
+    PublishNative,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ClientGeometryReconciliationDecision {
+    pub(super) action: ClientGeometryReconciliationAction,
+    pub(super) position: [f32; 2],
+    pub(super) size: [f32; 2],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClientGeometryReconciliationPhase {
+    AwaitingResponse,
+    WatchingLateExtents,
+    AwaitingCorrection,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ClientGeometryReconciliation {
+    pub(super) position: [f32; 2],
+    pub(super) size: [f32; 2],
+    decoration_offset: Option<[f32; 2]>,
+    starting_geometry_epoch: u64,
+    phase: ClientGeometryReconciliationPhase,
+}
+
+impl ClientGeometryReconciliation {
+    fn new(
+        position: [f32; 2],
+        size: [f32; 2],
+        decoration_offset: Option<[f32; 2]>,
+        starting_geometry_epoch: u64,
+    ) -> Self {
+        Self {
+            position,
+            size,
+            decoration_offset,
+            starting_geometry_epoch,
+            phase: ClientGeometryReconciliationPhase::AwaitingResponse,
+        }
+    }
+
+    fn observe(
+        mut self,
+        geometry_epoch: u64,
+        visible: bool,
+        actual_position: [f32; 2],
+        actual_size: [f32; 2],
+        decoration_offset: Option<[f32; 2]>,
+    ) -> (Option<Self>, ClientGeometryReconciliationAction) {
+        let observed_post_request_geometry = geometry_epoch > self.starting_geometry_epoch;
+        if !visible || !observed_post_request_geometry {
+            return (Some(self), ClientGeometryReconciliationAction::Wait);
+        }
+
+        if client_geometry_matches(self.position, self.size, actual_position, actual_size) {
+            self.starting_geometry_epoch = geometry_epoch;
+            match self.phase {
+                ClientGeometryReconciliationPhase::AwaitingResponse => {
+                    self.phase = ClientGeometryReconciliationPhase::WatchingLateExtents;
+                    // Publish the first stable-looking geometry immediately so an event loop using
+                    // ControlFlow::Wait never depends on a synthetic timer. Keep a short-lived watch
+                    // for one late X11 frame-extents change, which may arrive after the first
+                    // ConfigureNotify.
+                    return (
+                        Some(self),
+                        ClientGeometryReconciliationAction::PublishNative,
+                    );
+                }
+                ClientGeometryReconciliationPhase::WatchingLateExtents
+                | ClientGeometryReconciliationPhase::AwaitingCorrection => {
+                    return (None, ClientGeometryReconciliationAction::PublishNative);
+                }
+            }
+        }
+
+        if self.phase != ClientGeometryReconciliationPhase::AwaitingCorrection
+            && frame_extent_change_explains_geometry(
+                self.position,
+                self.size,
+                actual_position,
+                actual_size,
+                self.decoration_offset,
+                decoration_offset,
+            )
+        {
+            self.phase = ClientGeometryReconciliationPhase::AwaitingCorrection;
+            self.decoration_offset = decoration_offset;
+            self.starting_geometry_epoch = geometry_epoch;
+            return (Some(self), ClientGeometryReconciliationAction::ApplyTarget);
+        }
+
+        // A second divergent native event is authoritative. This bounds X11 frame-extents
+        // correction without fighting a real title-bar move or resize initiated by the user.
+        (None, ClientGeometryReconciliationAction::PublishNative)
+    }
+
+    fn retarget(
+        mut self,
+        position: [f32; 2],
+        size: [f32; 2],
+        decoration_offset: Option<[f32; 2]>,
+        starting_geometry_epoch: u64,
+    ) -> Self {
+        self.position = position;
+        self.size = size;
+        self.decoration_offset = decoration_offset;
+        self.starting_geometry_epoch = starting_geometry_epoch;
+        self.phase = ClientGeometryReconciliationPhase::AwaitingResponse;
+        self
+    }
+}
+
+fn client_geometry_matches(
+    expected_position: [f32; 2],
+    expected_size: [f32; 2],
+    actual_position: [f32; 2],
+    actual_size: [f32; 2],
+) -> bool {
+    vec2_approximately_equals(expected_position, actual_position)
+        && vec2_approximately_equals(expected_size, actual_size)
+}
+
+fn frame_extent_change_explains_geometry(
+    target_position: [f32; 2],
+    target_size: [f32; 2],
+    actual_position: [f32; 2],
+    actual_size: [f32; 2],
+    previous_offset: Option<[f32; 2]>,
+    current_offset: Option<[f32; 2]>,
+) -> bool {
+    let (Some(previous_offset), Some(current_offset)) = (previous_offset, current_offset) else {
+        return false;
+    };
+    if vec2_approximately_equals(previous_offset, current_offset)
+        || !vec2_approximately_equals(target_size, actual_size)
+    {
+        return false;
+    }
+    let expected_position = [
+        target_position[0] + current_offset[0] - previous_offset[0],
+        target_position[1] + current_offset[1] - previous_offset[1],
+    ];
+    vec2_approximately_equals(expected_position, actual_position)
+}
+
+fn vec2_approximately_equals(expected: [f32; 2], actual: [f32; 2]) -> bool {
+    expected
+        .into_iter()
+        .zip(actual)
+        .all(|(expected, actual)| (expected - actual).abs() <= 1.0)
+}
+
+#[cfg(test)]
+mod client_geometry_reconciliation_tests {
+    use super::*;
+
+    #[test]
+    fn waits_for_a_post_request_native_geometry_event() {
+        let pending =
+            ClientGeometryReconciliation::new([120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]), 4);
+
+        let (pending, action) =
+            pending.observe(4, true, [131.0, 285.0], [640.0, 480.0], Some([0.0, 0.0]));
+
+        assert_eq!(action, ClientGeometryReconciliationAction::Wait);
+        let pending = pending.unwrap();
+        assert_eq!(pending.position, [120.0, 240.0]);
+        assert_eq!(pending.size, [640.0, 480.0]);
+    }
+
+    #[test]
+    fn changed_frame_extents_are_corrected_then_native_geometry_wins() {
+        let pending =
+            ClientGeometryReconciliation::new([120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]), 7);
+
+        let (pending, action) =
+            pending.observe(8, true, [131.0, 285.0], [640.0, 480.0], Some([11.0, 45.0]));
+        assert_eq!(action, ClientGeometryReconciliationAction::ApplyTarget);
+        let (pending, action) =
+            pending
+                .unwrap()
+                .observe(9, true, [132.0, 286.0], [640.0, 480.0], Some([11.0, 45.0]));
+        assert!(pending.is_none());
+        assert_eq!(action, ClientGeometryReconciliationAction::PublishNative);
+    }
+
+    #[test]
+    fn a_matching_response_to_the_correction_completes_the_transaction() {
+        let pending =
+            ClientGeometryReconciliation::new([120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]), 7);
+        let (pending, action) =
+            pending.observe(8, true, [131.0, 285.0], [640.0, 480.0], Some([11.0, 45.0]));
+        assert_eq!(action, ClientGeometryReconciliationAction::ApplyTarget);
+
+        let (pending, action) =
+            pending
+                .unwrap()
+                .observe(9, true, [120.0, 240.0], [640.0, 480.0], Some([11.0, 45.0]));
+        assert!(pending.is_none());
+        assert_eq!(action, ClientGeometryReconciliationAction::PublishNative);
+    }
+
+    #[test]
+    fn matching_native_geometry_is_published_immediately_then_watch_is_retired() {
+        let pending =
+            ClientGeometryReconciliation::new([120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]), 7);
+        let (pending, action) =
+            pending.observe(8, true, [120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]));
+        assert_eq!(action, ClientGeometryReconciliationAction::PublishNative);
+
+        let (pending, action) =
+            pending
+                .unwrap()
+                .observe(9, true, [120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]));
+        assert!(pending.is_none());
+        assert_eq!(action, ClientGeometryReconciliationAction::PublishNative);
+    }
+
+    #[test]
+    fn a_native_move_with_unchanged_frame_extents_is_not_overridden() {
+        let pending = ClientGeometryReconciliation::new(
+            [120.0, 240.0],
+            [640.0, 480.0],
+            Some([11.0, 45.0]),
+            7,
+        );
+        let (pending, action) =
+            pending.observe(8, true, [170.0, 240.0], [640.0, 480.0], Some([11.0, 45.0]));
+
+        assert!(pending.is_none());
+        assert_eq!(action, ClientGeometryReconciliationAction::PublishNative);
+    }
+
+    #[test]
+    fn a_user_move_in_the_same_batch_as_frame_extents_wins() {
+        let pending =
+            ClientGeometryReconciliation::new([120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]), 7);
+
+        let (pending, action) =
+            pending.observe(8, true, [181.0, 285.0], [640.0, 480.0], Some([11.0, 45.0]));
+
+        assert!(pending.is_none());
+        assert_eq!(action, ClientGeometryReconciliationAction::PublishNative);
+    }
+
+    #[test]
+    fn resizing_updates_the_target_of_an_in_flight_reconciliation() {
+        let pending = ClientGeometryReconciliation::new(
+            [120.0, 240.0],
+            [640.0, 480.0],
+            Some([11.0, 45.0]),
+            7,
+        );
+        let updated = pending.retarget(pending.position, [800.0, 600.0], Some([11.0, 45.0]), 8);
+
+        assert_eq!(updated.position, [120.0, 240.0]);
+        assert_eq!(updated.size, [800.0, 600.0]);
+        assert_eq!(updated.starting_geometry_epoch, 8);
+        assert_eq!(
+            updated.phase,
+            ClientGeometryReconciliationPhase::AwaitingResponse
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct ViewportWindowPolicy {
     pub(super) decorations: bool,
     pub(super) top_most: bool,
@@ -70,6 +340,8 @@ pub(super) struct ViewportData {
     pub(super) window_policy: Cell<ViewportWindowPolicy>,
     pub(super) last_log_fb_scale: Cell<f32>,
     pending_geometry_refresh: Cell<GeometryRefresh>,
+    pending_client_geometry_reconciliation: Cell<Option<ClientGeometryReconciliation>>,
+    geometry_event_epoch: Cell<u64>,
 }
 
 impl ViewportData {
@@ -82,6 +354,8 @@ impl ViewportData {
             window_policy: Cell::new(ViewportWindowPolicy::default()),
             last_log_fb_scale: Cell::new(0.0),
             pending_geometry_refresh: Cell::new(GeometryRefresh::default()),
+            pending_client_geometry_reconciliation: Cell::new(None),
+            geometry_event_epoch: Cell::new(0),
         })
     }
 
@@ -121,6 +395,87 @@ impl ViewportData {
 
     pub(super) fn take_geometry_refresh(&self) -> GeometryRefresh {
         self.pending_geometry_refresh.take()
+    }
+
+    pub(super) fn note_geometry_event(&self) {
+        if self.pending_client_geometry_reconciliation.get().is_none() {
+            return;
+        }
+        self.geometry_event_epoch
+            .set(self.geometry_event_epoch.get().wrapping_add(1));
+    }
+
+    pub(super) fn cancel_client_geometry_reconciliation(&self) {
+        self.pending_client_geometry_reconciliation.set(None);
+    }
+
+    pub(super) fn request_client_geometry_reconciliation(
+        &self,
+        position: [f32; 2],
+        size: [f32; 2],
+        decoration_offset: Option<[f32; 2]>,
+    ) {
+        self.pending_client_geometry_reconciliation
+            .set(Some(ClientGeometryReconciliation::new(
+                position,
+                size,
+                decoration_offset,
+                self.geometry_event_epoch.get(),
+            )));
+    }
+
+    pub(super) fn update_reconciling_client_size(&self, size: [f32; 2]) {
+        let Some(pending) = self.pending_client_geometry_reconciliation.get() else {
+            return;
+        };
+        self.pending_client_geometry_reconciliation
+            .set(Some(pending.retarget(
+                pending.position,
+                size,
+                pending.decoration_offset,
+                self.geometry_event_epoch.get(),
+            )));
+    }
+
+    pub(super) fn update_reconciling_client_position(&self, position: [f32; 2]) {
+        let Some(pending) = self.pending_client_geometry_reconciliation.get() else {
+            return;
+        };
+        self.pending_client_geometry_reconciliation
+            .set(Some(pending.retarget(
+                position,
+                pending.size,
+                pending.decoration_offset,
+                self.geometry_event_epoch.get(),
+            )));
+    }
+
+    pub(super) fn has_client_geometry_reconciliation(&self) -> bool {
+        self.pending_client_geometry_reconciliation.get().is_some()
+    }
+
+    pub(super) fn observe_client_geometry_reconciliation(
+        &self,
+        visible: bool,
+        actual_position: [f32; 2],
+        actual_size: [f32; 2],
+        decoration_offset: Option<[f32; 2]>,
+    ) -> Option<ClientGeometryReconciliationDecision> {
+        let pending = self.pending_client_geometry_reconciliation.get()?;
+        let decision = ClientGeometryReconciliationDecision {
+            action: ClientGeometryReconciliationAction::Wait,
+            position: pending.position,
+            size: pending.size,
+        };
+        let (pending, action) = pending.observe(
+            self.geometry_event_epoch.get(),
+            visible,
+            actual_position,
+            actual_size,
+            decoration_offset,
+        );
+        self.pending_client_geometry_reconciliation.set(pending);
+        Some(ClientGeometryReconciliationDecision { action, ..decision })
     }
 }
 

--- a/backends/dear-imgui-winit/src/multi_viewport/viewport_data.rs
+++ b/backends/dear-imgui-winit/src/multi_viewport/viewport_data.rs
@@ -197,6 +197,22 @@ mod client_geometry_reconciliation_tests {
     }
 
     #[test]
+    fn visibility_wait_preserves_the_transaction_for_the_visible_observation() {
+        let pending =
+            ClientGeometryReconciliation::new([120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]), 7);
+
+        let (pending, action) =
+            pending.observe(8, false, [120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]));
+        assert_eq!(action, ClientGeometryReconciliationAction::Wait);
+
+        let (pending, action) = pending
+            .expect("an invisible window must retain its reconciliation")
+            .observe(8, true, [120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]));
+        assert!(pending.is_some());
+        assert_eq!(action, ClientGeometryReconciliationAction::PublishNative);
+    }
+
+    #[test]
     fn changed_frame_extents_are_corrected_then_native_geometry_wins() {
         let pending =
             ClientGeometryReconciliation::new([120.0, 240.0], [640.0, 480.0], Some([0.0, 0.0]), 7);

--- a/backends/dear-imgui-winit/src/platform/input_events.rs
+++ b/backends/dear-imgui-winit/src/platform/input_events.rs
@@ -252,6 +252,8 @@ impl WinitPlatform {
                 scale_factor,
                 inner_size_writer,
             } => {
+                #[cfg(not(feature = "multi-viewport"))]
+                let _ = inner_size_writer;
                 let new_hidpi = self.hidpi_factor_for_scale(*scale_factor);
                 #[cfg(feature = "multi-viewport")]
                 if self.control.has_live_runtime() {

--- a/backends/dear-imgui-winit/src/platform/input_events.rs
+++ b/backends/dear-imgui-winit/src/platform/input_events.rs
@@ -248,10 +248,20 @@ impl WinitPlatform {
                     .set_display_size(sanitize::finite_non_negative_size(logical_size));
                 false
             }
-            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+            WindowEvent::ScaleFactorChanged {
+                scale_factor,
+                inner_size_writer,
+            } => {
                 let new_hidpi = self.hidpi_factor_for_scale(*scale_factor);
                 #[cfg(feature = "multi-viewport")]
                 if self.control.has_live_runtime() {
+                    if let Some(size) = crate::multi_viewport::scale_factor_inner_size_override(
+                        imgui_ctx.io().config_dpi_scale_viewports(),
+                        window.inner_size(),
+                    ) {
+                        let mut inner_size_writer = inner_size_writer.clone();
+                        let _ = inner_size_writer.request_inner_size(size);
+                    }
                     self.control
                         .note_runtime_window_geometry(window.id(), true, true);
                     // Native desktop coordinates do not change when a viewport crosses a DPI

--- a/examples/ci/wgpu_multi_viewport_smoke.rs
+++ b/examples/ci/wgpu_multi_viewport_smoke.rs
@@ -52,6 +52,11 @@ struct LifecycleSmokeState {
     saw_secondary_while_held: bool,
     saw_merged_viewport: bool,
     game_window_pos: [f32; 2],
+    wait_move_probe_requested: bool,
+    wait_move_probe_issued: bool,
+    wait_move_probe_resumed: bool,
+    wait_move_probe_target: Option<[i32; 2]>,
+    wait_move_probe_error: Option<String>,
     secondary_submission_before_main_acquire: Option<SecondarySubmissionEvidence>,
     main_present_bracketed_by_test_engine: bool,
 }
@@ -453,6 +458,9 @@ impl ViewportScenario for ViewportSmokeScenario {
                             detached_drag_pos[1],
                             4.0,
                         )?;
+                        test.item_click("Main/Begin Wait Move Probe")?;
+                        test.yield_frames(ScriptCount::new(30)?)?;
+                        test.assert_item_read_int_eq("Main/Wait Move Probe", 1)?;
                     } else {
                         test.window_move("Game View", external_pos[0], external_pos[1])?;
                         test.yield_frames(ScriptCount::new(30)?)?;
@@ -476,6 +484,11 @@ impl ViewportScenario for ViewportSmokeScenario {
                     saw_secondary_while_held: false,
                     saw_merged_viewport: false,
                     game_window_pos: [0.0, 0.0],
+                    wait_move_probe_requested: false,
+                    wait_move_probe_issued: false,
+                    wait_move_probe_resumed: false,
+                    wait_move_probe_target: None,
+                    wait_move_probe_error: None,
                     secondary_submission_before_main_acquire: None,
                     main_present_bracketed_by_test_engine: false,
                 })
@@ -492,14 +505,73 @@ impl ViewportScenario for ViewportSmokeScenario {
         )
     }
 
-    fn before_ui(&mut self, viewport_count: i32) {
+    fn before_ui(&mut self, viewport_count: i32, secondary_window: Option<&Window>) {
         let Some(ViewportSmokeMode::Lifecycle(lifecycle)) = self.mode.as_mut() else {
             return;
         };
+        if lifecycle.wait_move_probe_issued && !lifecycle.wait_move_probe_resumed {
+            let Some(window) = secondary_window else {
+                lifecycle.wait_move_probe_error =
+                    Some("Wait move probe lost its secondary Winit window".into());
+                return;
+            };
+            let Some(target) = lifecycle.wait_move_probe_target else {
+                lifecycle.wait_move_probe_error =
+                    Some("Wait move probe did not record its native target position".into());
+                return;
+            };
+            match window.outer_position() {
+                Ok(position)
+                    if position.x.abs_diff(target[0]) <= 4
+                        && position.y.abs_diff(target[1]) <= 4 =>
+                {
+                    // Continuous redraw remains disabled until the native position actually
+                    // changes. Reaching the target therefore proves a secondary window event
+                    // woke the main window while the event loop was waiting.
+                    lifecycle.wait_move_probe_resumed = true;
+                }
+                Ok(position) => {
+                    lifecycle.wait_move_probe_error = Some(format!(
+                        "Wait move probe observed native position ({}, {}) instead of ({}, {})",
+                        position.x, position.y, target[0], target[1]
+                    ));
+                    return;
+                }
+                Err(error) => {
+                    lifecycle.wait_move_probe_error = Some(format!(
+                        "Wait move probe could not verify native position: {error}"
+                    ));
+                    return;
+                }
+            }
+        }
         if viewport_count > 1 {
             lifecycle.saw_secondary_viewport = true;
         } else if lifecycle.saw_secondary_viewport {
             lifecycle.saw_merged_viewport = true;
+        }
+        if lifecycle.wait_move_probe_requested && !lifecycle.wait_move_probe_issued {
+            let Some(window) = secondary_window else {
+                lifecycle.wait_move_probe_error =
+                    Some("Wait move probe could not find a created secondary Winit window".into());
+                return;
+            };
+            match window.outer_position() {
+                Ok(position) => {
+                    let target = winit::dpi::PhysicalPosition::new(
+                        position.x.saturating_add(32),
+                        position.y.saturating_add(24),
+                    );
+                    window.set_outer_position(target);
+                    lifecycle.wait_move_probe_target = Some([target.x, target.y]);
+                    lifecycle.wait_move_probe_issued = true;
+                }
+                Err(error) => {
+                    lifecycle.wait_move_probe_error = Some(format!(
+                        "Wait move probe could not read native position: {error}"
+                    ));
+                }
+            }
         }
     }
 
@@ -519,6 +591,13 @@ impl ViewportScenario for ViewportSmokeScenario {
         if lifecycle.require_secondary_while_held && ui.button("Begin Held Drag Probe") {
             lifecycle.held_probe_armed = true;
         }
+        if lifecycle.require_secondary_while_held && ui.button("Begin Wait Move Probe") {
+            lifecycle.wait_move_probe_requested = true;
+        }
+        let mut wait_move_probe = i32::from(lifecycle.wait_move_probe_resumed);
+        ui.input_int_config("Wait Move Probe")
+            .flags(dear_imgui_rs::InputScalarFlags::READ_ONLY)
+            .build(&mut wait_move_probe);
     }
 
     fn extend_game_window(&mut self, ui: &Ui) {
@@ -581,6 +660,11 @@ impl ViewportScenario for ViewportSmokeScenario {
         presented: bool,
         secondary_submission_evidence: Option<SecondarySubmissionEvidence>,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(ViewportSmokeMode::Lifecycle(lifecycle)) = self.mode.as_mut()
+            && let Some(error) = lifecycle.wait_move_probe_error.take()
+        {
+            return Err(error.into());
+        }
         let bracketed_present = self
             .last_drive_presented
             .take()
@@ -634,16 +718,19 @@ impl ViewportScenario for ViewportSmokeScenario {
                 }
                 if !lifecycle.saw_secondary_viewport
                     || lifecycle.require_secondary_while_held
-                        && (!lifecycle.held_probe_complete || !lifecycle.saw_secondary_while_held)
+                        && (!lifecycle.held_probe_complete
+                            || !lifecycle.saw_secondary_while_held
+                            || !lifecycle.wait_move_probe_resumed)
                     || !lifecycle.saw_merged_viewport
                     || lifecycle.secondary_submission_before_main_acquire.is_none()
                     || !lifecycle.main_present_bracketed_by_test_engine
                 {
                     return Err(format!(
-                        "viewport smoke did not observe the complete lifecycle and presentation order: secondary={}, secondary_while_held={}, held_probe_complete={}, merged={}, secondary_submission_before_main_acquire={:?}, main_present_bracketed={}",
+                        "viewport smoke did not observe the complete lifecycle and presentation order: secondary={}, secondary_while_held={}, held_probe_complete={}, wait_move_probe_resumed={}, merged={}, secondary_submission_before_main_acquire={:?}, main_present_bracketed={}",
                         lifecycle.saw_secondary_viewport,
                         lifecycle.saw_secondary_while_held,
                         lifecycle.held_probe_complete,
+                        lifecycle.wait_move_probe_resumed,
                         lifecycle.saw_merged_viewport,
                         lifecycle.secondary_submission_before_main_acquire,
                         lifecycle.main_present_bracketed_by_test_engine,
@@ -660,6 +747,14 @@ impl ViewportScenario for ViewportSmokeScenario {
 
     fn complete(&self) -> bool {
         self.complete
+    }
+
+    fn redraw_continuously(&self) -> bool {
+        !matches!(
+            self.mode.as_ref(),
+            Some(ViewportSmokeMode::Lifecycle(lifecycle))
+                if lifecycle.wait_move_probe_issued && !lifecycle.wait_move_probe_resumed
+        )
     }
 
     fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/ci/wgpu_multi_viewport_smoke.rs
+++ b/examples/ci/wgpu_multi_viewport_smoke.rs
@@ -51,6 +51,7 @@ struct LifecycleSmokeState {
     saw_secondary_viewport: bool,
     saw_secondary_while_held: bool,
     saw_merged_viewport: bool,
+    game_window_pos: [f32; 2],
     secondary_submission_before_main_acquire: Option<SecondarySubmissionEvidence>,
     main_present_bracketed_by_test_engine: bool,
 }
@@ -370,6 +371,7 @@ impl ViewportScenario for ViewportSmokeScenario {
             winit::dpi::PhysicalSize::new(main_size.width as f32, main_size.height as f32),
         );
         let external_pos = [main_pos.x + main_size.width + 100.0, main_pos.y + 100.0];
+        let detached_drag_pos = [external_pos[0] + 160.0, external_pos[1] + 120.0];
         let redock_pos = [
             main_pos.x + main_size.width * 0.5,
             main_pos.y + main_size.height * 0.5,
@@ -432,6 +434,25 @@ impl ViewportScenario for ViewportSmokeScenario {
                         test.mouse_up(MouseButton::Left)?;
                         test.yield_frames(ScriptCount::new(30)?)?;
                         test.assert_item_read_int_eq("Main/Viewport Count", 1)?;
+
+                        // Exercise the original regression path: WindowMove resolves the live
+                        // tab/title-bar point and drives a real mouse drag. Repeating it after
+                        // detachment proves the standalone viewport remains draggable there.
+                        test.window_move("Game View", external_pos[0], external_pos[1])?;
+                        test.yield_frames(ScriptCount::new(30)?)?;
+                        test.assert_item_read_int_eq("Main/Viewport Count", 2)?;
+                        test.window_move("Game View", detached_drag_pos[0], detached_drag_pos[1])?;
+                        test.yield_frames(ScriptCount::new(30)?)?;
+                        test.assert_item_read_float_eq(
+                            "Main/Game View Pos X",
+                            detached_drag_pos[0],
+                            4.0,
+                        )?;
+                        test.assert_item_read_float_eq(
+                            "Main/Game View Pos Y",
+                            detached_drag_pos[1],
+                            4.0,
+                        )?;
                     } else {
                         test.window_move("Game View", external_pos[0], external_pos[1])?;
                         test.yield_frames(ScriptCount::new(30)?)?;
@@ -454,6 +475,7 @@ impl ViewportScenario for ViewportSmokeScenario {
                     saw_secondary_viewport: false,
                     saw_secondary_while_held: false,
                     saw_merged_viewport: false,
+                    game_window_pos: [0.0, 0.0],
                     secondary_submission_before_main_acquire: None,
                     main_present_bracketed_by_test_engine: false,
                 })
@@ -488,9 +510,22 @@ impl ViewportScenario for ViewportSmokeScenario {
         let Some(ViewportSmokeMode::Lifecycle(lifecycle)) = self.mode.as_mut() else {
             return;
         };
+        ui.input_float_config("Game View Pos X")
+            .flags(dear_imgui_rs::InputScalarFlags::READ_ONLY)
+            .build(&mut lifecycle.game_window_pos[0]);
+        ui.input_float_config("Game View Pos Y")
+            .flags(dear_imgui_rs::InputScalarFlags::READ_ONLY)
+            .build(&mut lifecycle.game_window_pos[1]);
         if lifecycle.require_secondary_while_held && ui.button("Begin Held Drag Probe") {
             lifecycle.held_probe_armed = true;
         }
+    }
+
+    fn extend_game_window(&mut self, ui: &Ui) {
+        let Some(ViewportSmokeMode::Lifecycle(lifecycle)) = self.mode.as_mut() else {
+            return;
+        };
+        lifecycle.game_window_pos = ui.window_pos();
     }
 
     fn after_ui(&mut self, ui: &Ui, viewport_count: i32) {

--- a/examples/support/wgpu_multi_viewport_runtime.rs
+++ b/examples/support/wgpu_multi_viewport_runtime.rs
@@ -42,7 +42,7 @@ pub(crate) trait ViewportScenario {
         true
     }
 
-    fn before_ui(&mut self, _viewport_count: i32) {}
+    fn before_ui(&mut self, _viewport_count: i32, _secondary_window: Option<&Window>) {}
 
     fn extend_main_window(&mut self, _ui: &Ui, _viewport_count: &mut i32) {}
 
@@ -71,6 +71,10 @@ pub(crate) trait ViewportScenario {
 
     fn complete(&self) -> bool {
         false
+    }
+
+    fn redraw_continuously(&self) -> bool {
+        true
     }
 
     fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error>> {
@@ -598,7 +602,19 @@ impl<S: ViewportScenario> AppWindow<S> {
         self.platform.prepare_frame(&mut self.imgui, &self.window)?;
         let mut viewport_count =
             i32::try_from(self.imgui.platform_io().viewports_iter().count()).unwrap_or(i32::MAX);
-        self.scenario.before_ui(viewport_count);
+        let secondary_window = self
+            .imgui
+            .platform_io()
+            .viewports_iter()
+            .find(|viewport| viewport.is_platform_window() && viewport.platform_window_created())
+            .and_then(|viewport| {
+                let handle = viewport.platform_handle().cast::<Window>();
+                // SAFETY: Dear ImGui's Winit platform backend stores a live `winit::Window`
+                // pointer in PlatformHandle for the lifetime of the platform viewport. The
+                // reference remains scoped to this frame and is not retained by the scenario.
+                unsafe { handle.as_ref() }
+            });
+        self.scenario.before_ui(viewport_count, secondary_window);
         let frame = self.imgui.begin_frame();
         let ui = frame.ui();
         if self.scenario.show_example_ui() {
@@ -715,9 +731,17 @@ impl<S: ViewportScenario> ApplicationHandler for App<S> {
         }
     }
 
-    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         if let Some(app) = &self.window {
-            app.window.request_redraw();
+            let redraw_continuously = app.scenario.redraw_continuously();
+            event_loop.set_control_flow(if redraw_continuously {
+                ControlFlow::Poll
+            } else {
+                ControlFlow::Wait
+            });
+            if redraw_continuously {
+                app.window.request_redraw();
+            }
         }
     }
 
@@ -751,7 +775,8 @@ impl<S: ViewportScenario> ApplicationHandler for App<S> {
             }
             WindowEvent::RedrawRequested if is_main_window => match app.redraw(event_loop) {
                 Ok(()) if app.scenario.complete() => event_loop.exit(),
-                Ok(()) => app.window.request_redraw(),
+                Ok(()) if app.scenario.redraw_continuously() => app.window.request_redraw(),
+                Ok(()) => {}
                 Err(error) => {
                     self.error = Some(error.to_string());
                     event_loop.exit();
@@ -766,7 +791,11 @@ pub(crate) fn run<S: ViewportScenario>(
     scenario: S,
 ) -> Result<Option<S::Output>, Box<dyn std::error::Error>> {
     let event_loop = EventLoop::new()?;
-    event_loop.set_control_flow(ControlFlow::Poll);
+    event_loop.set_control_flow(if scenario.redraw_continuously() {
+        ControlFlow::Poll
+    } else {
+        ControlFlow::Wait
+    });
     let mut app = App::new(scenario);
     let event_loop_result = event_loop.run_app(&mut app);
     let app_error = app.error.take();

--- a/examples/support/wgpu_multi_viewport_runtime.rs
+++ b/examples/support/wgpu_multi_viewport_runtime.rs
@@ -46,6 +46,8 @@ pub(crate) trait ViewportScenario {
 
     fn extend_main_window(&mut self, _ui: &Ui, _viewport_count: &mut i32) {}
 
+    fn extend_game_window(&mut self, _ui: &Ui) {}
+
     fn after_ui(&mut self, _ui: &Ui, _viewport_count: i32) {}
 
     fn trace_secondary_submissions(&self) -> bool {
@@ -621,6 +623,7 @@ impl<S: ViewportScenario> AppWindow<S> {
             ui.window("Game View")
                 .size([520.0, 540.0], Condition::FirstUseEver)
                 .build(|| {
+                    scenario.extend_game_window(ui);
                     let avail = ui.content_region_avail();
                     let side = avail[0].min(avail[1]).max(64.0);
                     ui.text("Offscreen WGPU texture rendered each frame:");


### PR DESCRIPTION
- What
  - Preserve Dear ImGui viewport `Pos`/`Size` as client-space geometry across Windows decorations, physical-coordinate DPI transitions, and asynchronous X11 frame extents.
  - Wake the main frame from secondary viewport input, geometry, redraw, close, and X11 visibility events when applications use `ControlFlow::Wait`.
  - Extend the WGPU Test Engine smoke to drag an already-detached viewport by its live title/tab region and verify a native secondary move while continuous redraw is disabled.

- Why
  - Undecorated Windows viewports could receive a synthetic title-bar offset, so dragging the detached title/tab region did not move the native child reliably.
  - Decoration changes, DPI transitions, and late X11 frame extents could make native and Dear ImGui geometry drift or overwrite a genuine native move.
  - Event-driven applications could retain an unfinished geometry transaction without another main-window frame to observe it.

- Affected crates
  - [ ] dear-imgui-rs
  - [ ] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [x] backends/dear-imgui-winit
  - [ ] backends/dear-imgui-sdl3
  - [ ] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [x] CI / tooling / docs

- Behavior
  - [x] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [ ] No behavior change (refactor/cleanup)

- Breaking changes
  - [x] None
  - [ ] Yes (describe):

- Testing / validation
  - `cargo fmt --all`
  - `git diff --check`
  - `cargo +stable check -j 1 -p dear-imgui-winit --features multi-viewport`
  - `cargo +stable nextest run -j 1 -p dear-imgui-winit --features multi-viewport` (140 passed)
  - `cargo +stable check -j 1 -p dear-imgui-examples --features "multi-viewport,test-engine" --bin wgpu_multi_viewport_smoke`
  - Repository Clippy contract for `dear-imgui-winit --all-targets --features multi-viewport`
  - Repository Clippy contract for `wgpu_multi_viewport_smoke --no-deps`
  - Windows WGPU Test Engine drag smoke with `DEAR_IMGUI_VIEWPORT_DRAG_SMOKE=1` (NVIDIA GeForce RTX 4090, Vulkan): detached title/tab drag, held undock, native move under `ControlFlow::Wait`, merge, and secondary-before-main submission all passed.

- Docs
  - [ ] N/A
  - [x] Updated README / crate docs
  - Updated the backend changelog.

- Links
  - Related #75

This is a follow-up to the already merged native viewport contract work in #75.
