### PR TITLE
chore(deps): update glow and pollster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ### Breaking Changes and Migration
 
+- `dear-imgui-glow` now uses `glow` 0.18. Applications that construct or pass a `glow::Context` must update their direct `glow` dependency to the 0.18 release line.
 - `dear-imgui-build-support` callers that construct `TargetFacts`, `NativeAbiTarget`, `BuildRequestInput`, or `BuildRequest` must now provide or handle `target_abi`, normally from `CARGO_CFG_TARGET_ABI`; `prebuilt_cpp_runtime_linkage`, `configure_cpp_runtime_linkage`, and `emit_prebuilt_cpp_runtime_linkage` also take that ABI argument. Windows GNU-GCC continues to link static `stdc++`, while Windows GNU/LLVM links static `c++`.
+
+### Changed
+
+- Updated the workspace's direct `pollster` dependency from 0.4 to 1.0 for WGPU application helpers, examples, and tests.
 
 ## [0.16.0-alpha.3] - 2026-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
  "dear-imnodes",
  "dear-implot",
  "dear-implot3d",
- "pollster",
+ "pollster 1.0.1",
  "thiserror 2.0.20",
  "tracing",
  "wgpu 30.0.0",
@@ -2527,7 +2527,7 @@ dependencies = [
  "dear-imgui-rs",
  "image",
  "indexmap",
- "pollster",
+ "pollster 1.0.1",
  "regex",
  "rfd",
  "thiserror 2.0.20",
@@ -2631,11 +2631,11 @@ dependencies = [
  "dear-node-editor",
  "env_logger",
  "glam",
- "glow 0.17.0",
+ "glow 0.18.0",
  "glutin",
  "glutin-winit",
  "image",
- "pollster",
+ "pollster 1.0.1",
  "raw-window-handle",
  "sdl3",
  "sdl3-main",
@@ -2653,10 +2653,10 @@ dependencies = [
  "dear-imgui-rs",
  "dear-imgui-winit",
  "env_logger",
- "glow 0.17.0",
+ "glow 0.18.0",
  "glutin",
  "glutin-winit",
- "pollster",
+ "pollster 1.0.1",
  "raw-window-handle",
  "static_assertions",
  "thiserror 2.0.20",
@@ -2762,7 +2762,7 @@ dependencies = [
  "dear-implot",
  "dear-implot3d",
  "log",
- "pollster",
+ "pollster 1.0.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2780,7 +2780,7 @@ dependencies = [
  "dear-imgui-sdl3",
  "dear-imgui-winit",
  "objc2 0.6.4",
- "pollster",
+ "pollster 1.0.1",
  "raw-window-handle",
  "sdl3-sys",
  "static_assertions",
@@ -3576,6 +3576,18 @@ name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263218b0ba2b0715c3370fb04674f5f8aa331594b521c94ff0a8e4a8472d1386"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -5353,6 +5365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "pollster"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5820,7 +5838,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "percent-encoding",
- "pollster",
+ "pollster 0.4.0",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ glam = "0.32"
 # Graphics and windowing
 wgpu = "30.0"
 winit = "0.30.13"
-glow = "0.17"
+glow = "0.18"
 glutin = "0.32"
 glutin-winit = "0.5"
 raw-window-handle = "0.6"
@@ -124,7 +124,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # Utility
 mint = "0.5.9"
 env_logger = "0.11"
-pollster = "0.4"
+pollster = "1.0"
 web-time = "1.1"
 
 # WASM dependencies

--- a/backends/dear-imgui-glow/CHANGELOG.md
+++ b/backends/dear-imgui-glow/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+### Breaking
+
+- Updated the renderer dependency from `glow` 0.17 to 0.18. Applications must construct and pass a `glow` 0.18 `Context`.
+
 ### Changed
 
 - OpenGL capabilities are now detected from the live context. The renderer requires OpenGL 3.0+,


### PR DESCRIPTION
- What
  - Update the workspace's direct `glow` dependency from 0.17 to 0.18.
  - Update the workspace's direct `pollster` dependency from 0.4 to 1.0.
  - Document the `glow::Context` source migration in the root and renderer changelogs.
- Why
  - Keep the directly owned runtime dependency lines current after validating desktop, WASM, and renderer consumers.
  - Preserve deliberate compatibility constraints: Bevy 0.19 still shares the workspace's public `glam` 0.32 type line, and WGPU 27/28/29 remain opt-in compatibility routes while WGPU 30 stays the default.

## Affected Crates

- [ ] `dear-imgui-sys`
- [ ] `dear-imgui-rs`
- [ ] `dear-imgui-winit`
- [ ] `dear-imgui-sdl3`
- [x] `dear-imgui-wgpu`
- [x] `dear-imgui-glow`
- [ ] `dear-imgui-ash`
- [ ] `dear-imgui-bevy`
- [x] `dear-imgui-examples`
- [x] `dear-app`
- [ ] `dear-node-editor`
- [ ] `dear-file-browser`
- [x] CI / tooling / docs only

## Behavior Changes

- [ ] Rust API behavior
- [ ] Raw / FFI ABI
- [ ] Default features
- [ ] Multi-viewport behavior
- [ ] Renderer behavior
- [x] Source-build behavior

## Breaking Changes and Migration

- [x] Yes
- [ ] No

Applications that construct or pass a `glow::Context` to `dear-imgui-glow` must update their direct `glow` dependency to the 0.18 release line.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo +stable check -j 1 --locked --workspace --all-targets --exclude dear-imgui-examples --exclude dear-imgui-web-demo --exclude xtask`
- [x] `cargo +stable nextest run -j 1 -p dear-imgui-glow --all-features` (88 passed)
- [x] `cargo +stable nextest run -j 1 -p dear-imgui-wgpu` (42 passed)
- [x] Glow/WGPU examples, WASM consumers, `dear-app`, `dear-file-browser`, and standalone iOS smoke packages were checked during the upgrade audit.

## Documentation

- [x] Updated
- [ ] Not needed

The Unreleased changelogs document the new dependency lines. Published `0.16.0-alpha.3` compatibility tables remain historical and unchanged.

## Related Issues / PRs

- None.
