### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,55 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ## [Unreleased]
 
-### Added
+## [0.16.0] - 2026-08-14
 
-- Added source-build support for `x86_64-pc-windows-gnullvm` and `aarch64-pc-windows-gnullvm` with llvm-mingw. CI final-links the maintained C++ sys crates, runtime/ABI-tests x64 in both default and `+crt-static` modes, and cross-link/PE-tests Arm64 gnullvm plus the existing Arm64 MSVC `/MD` source path. gnullvm prebuilts, FreeType, and SDL3's external native dependency are not included. Fixes [#73](https://github.com/Latias94/dear-imgui-rs/issues/73).
+0.16 is an intentionally source-breaking release that finalizes the ownership-first API introduced through the alpha train. Context, frame, texture, font, native callback, renderer, platform-window, and GPU-completion state now move through explicit capabilities instead of remaining reachable through stale pointers or manual phase controls. See the [compatibility guide](https://github.com/Latias94/dear-imgui-rs/blob/v0.16.0/docs/COMPATIBILITY.md), [custom backend guide](https://github.com/Latias94/dear-imgui-rs/blob/v0.16.0/docs/CUSTOM_BACKENDS.md), and [task-oriented examples](https://github.com/Latias94/dear-imgui-rs/blob/v0.16.0/examples/README.md) for complete integration patterns; the tagged [changelog](https://github.com/Latias94/dear-imgui-rs/blob/v0.16.0/CHANGELOG.md) preserves the detailed prerelease migration history.
+
+### Highlights
+
+- Upgraded the native baseline to Dear ImGui v1.92.9b docking through cimgui and aligned the Test Engine and maintained extensions with its metadata and rendering contracts. Native, WASM, prebuilt, stack-layout, and Test Engine profiles now carry reproducible binding and artifact provenance.
+- Replaced broadly accessible native frame and draw state with one-use synchronous render capabilities or pointer-free detached snapshots. Managed texture feedback, font-atlas ownership, external texture handles, and renderer teardown are bound to the exact Context and render epoch that created them.
+- Added declarative, transactionally validated docking layouts, stable window identity, checked numeric format contracts, and lexical UI scopes that restore native state on ordinary errors without exposing unsafe end/pop protocols.
+- Unified Winit, SDL3, WGPU, Glow, Ash, and Bevy multi-viewport ownership around exact Context generations, callback leases, renderer-before-platform teardown, complete deferred-fault batches, and native-identity validation. Winit and Bevy publish detached monitor facts transactionally and keep secondary windows hidden until their exact native mapping and input/focus policy are ready. [PR #75](https://github.com/Latias94/dear-imgui-rs/pull/75)
+- Redesigned `dear-app` as a state-owning Winit + WGPU runtime with shared surface admission, frame, presentation, recovery, Test Engine, and exactly-once shutdown paths.
+- Added source-build support for `x86_64-pc-windows-gnullvm` and `aarch64-pc-windows-gnullvm` with llvm-mingw. x64 is runtime/ABI-tested in default and `+crt-static` modes; Arm64 gnullvm and Arm64 MSVC `/MD` are cross-link/PE-tested only. gnullvm prebuilts, FreeType, and SDL3's external native dependency are outside this support claim. [PR #74](https://github.com/Latias94/dear-imgui-rs/pull/74), [#73](https://github.com/Latias94/dear-imgui-rs/issues/73)
 
 ### Breaking Changes and Migration
 
-- `dear-imgui-glow` now uses `glow` 0.18. Applications that construct or pass a `glow::Context` must update their direct `glow` dependency to the 0.18 release line.
-- `dear-imgui-build-support` callers that construct `TargetFacts`, `NativeAbiTarget`, `BuildRequestInput`, or `BuildRequest` must now provide or handle `target_abi`, normally from `CARGO_CFG_TARGET_ABI`; `prebuilt_cpp_runtime_linkage`, `configure_cpp_runtime_linkage`, and `emit_prebuilt_cpp_runtime_linkage` also take that ABI argument. Windows GNU-GCC continues to link static `stdc++`, while Windows GNU/LLVM links static `c++`.
+| Area | Required migration |
+| --- | --- |
+| Context and UI scopes | Keep live Contexts on one owner thread, handle fallible activation and suspension, and use lexical `with_*` helpers plus provenance-checked tokens instead of manually ending or popping native scopes. |
+| Renderer frames | Use `SynchronousRendererConsumer` with `PendingFrame -> ReconciledFrame`, or `DetachedRendererConsumer` with move-only `FrameSnapshot`; pass frame capabilities by value and remove renderer-local frame rings or cloned draw lists. |
+| Textures and fonts | Register Context-owned texture data through typed managed/external handles, reconcile request-bound feedback, retain `FontId`, and inspect baked glyph data only through frame-local font capabilities. Arbitrary external font bytes and device-lineage operations remain explicit unsafe contracts. |
+| Docking and viewports | Submit a validated `DockLayout` through `DockspaceBuilder`, use `WindowKey` for stable identity, enable docking separately from native multi-viewport, and treat native viewport topology as backend-owned state. |
+| Winit and renderer routes | Use the owning platform or renderer route's `prepare`/`prepare_frame` transaction followed by its main render or command path. Shut down renderer ownership before the platform runtime and native GPU/window objects; custom compatible platforms use the documented unsafe attachment escape hatch. |
+| SDL3 callbacks | Pass owned `sdl3::event::Event` values. Callback-mode applications drain an atomic `Sdl3CallbackEventBatch`, inspect every retained fault, and replay events through the owning backend rather than borrowing or fabricating pointer-bearing `SDL_Event` values. |
+| Bevy | Install Context work through App-issued typed passes and sealed system configurations, handle fallible Context registry queries, register application input producers through `ImguiAppExt`, and request managed retirement instead of extracting backend-owned Context or native-window state. |
+| `dear-app` | Use `run_ui`, `run_frame`, or `Application`; application callbacks receive narrow lifecycle capabilities rather than unrestricted Context access after platform/renderer attachment. |
+| Native ABI and prebuilts | Regenerate native core prebuilts with `platform-io-aggregate-hooks-v3`; older archives are rejected. Raw aggregate PlatformIO callbacks must use the pointer/out-parameter hooks and repository C++ invocation bridges documented for 0.16. |
+| Build support | `dear-imgui-build-support` callers constructing target/build facts must provide or handle `target_abi`, normally from `CARGO_CFG_TARGET_ABI`; C++ runtime-linkage helpers also take the ABI argument. |
+| Direct dependencies | Applications constructing or passing a `glow::Context` must update to `glow` 0.18. WGPU 30 is the default; WGPU 29, 28, and 27 remain explicit mutually exclusive compatibility features. |
 
 ### Changed
 
-- Updated the workspace's direct `pollster` dependency from 0.4 to 1.0 for WGPU application helpers, examples, and tests.
+- Updated the Bevy backend to 0.19.1, the reflection derive parser to syn 3, and the compatible dependency lock set while retaining Winit 0.30 and Rust 1.92 for the workspace. The Bevy backend requires Rust 1.95. [PR #75](https://github.com/Latias94/dear-imgui-rs/pull/75)
+- Updated the workspace and iOS smoke applications to `pollster` 1.0 alongside the Glow 0.18 upgrade. [PR #77](https://github.com/Latias94/dear-imgui-rs/pull/77)
+- WGPU defaults to version 30 with opt-in 29/28/27 routes; Glow uses 0.18; Ash uses 0.38; SDL3 uses the 0.18 line. Select exactly one WGPU major and one native platform adapter for a multi-viewport renderer route.
+- Releases use one candidate-bound 27-crate train with exact-SHA CI, crates.io Trusted Publishing, complete prebuilt producer/consumer validation, deterministic checksums, and resumable publication that rejects mismatched existing crates, tags, or Release assets.
+
+### Fixed
+
+- Preserved detached Winit viewport client geometry across undecorated Windows positioning, decoration changes, mixed-DPI physical coordinates, and asynchronous X11 frame extents. Secondary input, geometry, close, redraw, and X11 visibility events wake event-driven main loops, so title/tab dragging and native geometry reconciliation continue under `ControlFlow::Wait`. [PR #76](https://github.com/Latias94/dear-imgui-rs/pull/76)
+- Hardened Winit, SDL3, and Bevy native callback ownership against reused viewport pointers, replacement callbacks, incomplete monitor collections, asynchronous native-window creation, and window-first or Context-first teardown. Recoverable monitor failures retain the last complete publication instead of exposing partial or invented geometry. [PR #75](https://github.com/Latias94/dear-imgui-rs/pull/75)
+- Fixed release-note extraction without dirtying verification checkouts. [PR #68](https://github.com/Latias94/dear-imgui-rs/pull/68)
+- Fixed scope snapshots to use Dear ImGui's read-only current-window query. [PR #69](https://github.com/Latias94/dear-imgui-rs/pull/69)
+- Fixed accidental fallback debug-window creation, main-viewport detection across managed Contexts, leaked callback frames, and bounded SDL3 callback coalescing. [PR #70](https://github.com/Latias94/dear-imgui-rs/pull/70)
+- Fixed managed texture and renderer resource lifetime across detached work, atlas repacks, callback replacement, WGPU device recreation, Vulkan retirement, Glow device-object recreation, and failed surface acquisition or presentation.
+- Fixed WGPU secondary surface configuration and loss handling, Bevy overlay composition and startup presentation, font reference-size selection, Windows GNU C++ runtime linkage, SDL3 move/resize responsiveness, and close-time native viewport teardown. [#36](https://github.com/Latias94/dear-imgui-rs/issues/36), [#49](https://github.com/Latias94/dear-imgui-rs/issues/49), [#51](https://github.com/Latias94/dear-imgui-rs/issues/51), [#54](https://github.com/Latias94/dear-imgui-rs/issues/54), [#58](https://github.com/Latias94/dear-imgui-rs/issues/58)
+
+### Known Platform Boundaries
+
+- Wayland continues to support docking inside the host window but not native multi-viewport, because the compositor does not provide the global desktop coordinates required by Dear ImGui. X11 monitor work areas remain conservative full-monitor fallbacks when panel attribution is ambiguous. See the compatibility matrix for the current native evidence grades. [#60](https://github.com/Latias94/dear-imgui-rs/issues/60)
 
 ## [0.16.0-alpha.3] - 2026-08-11
 
@@ -33,12 +70,8 @@ This source-breaking prerelease continues the ownership-first 0.16 migration wit
 
 ### Changed
 
-- Updated the exact Bevy backend train from 0.19.0 to 0.19.1 while retaining Rust 1.95 and WGPU 29 compatibility.
-- Updated the reflection derive implementation to syn 3 after validating the generated macro surface against the full reflection test suite.
-- Refreshed the compatible dependency lock set, including SDL 3.4.14 and WGPU 29.0.4 patch updates, while retaining the stable Winit 0.30 line and the workspace's Rust 1.92 contract.
 - Winit multi-viewport failures now retain the exact Context, viewport generation, native handle, and platform userdata until the close request is observed, preventing stale failures from closing a reused viewport. macOS `NO_FOCUS_ON_APPEARING` windows are shown without activating the application.
 - Bevy frame input is now a move-only, exactly-once transaction that binds route epoch, Context metrics, and cursor/IME authority to the same driver run. Terminal registries and private pass lifecycles fail explicitly instead of returning active-looking empty state.
-- Winit and Bevy native viewports now publish detached monitor facts transactionally and expose work-area provenance or retained-transaction failures without live native handles. Initial or primary-unproven batches fail closed instead of inventing a monitor; Bevy also resolves host and secondary windows through exact `WINIT_WINDOWS` mappings, keeps `Show` intent hidden until the native policy is ready, and uses lease-first retirement with stable-instance diagnostics.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dear-app"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "dear-imgui-rs",
  "dear-imgui-test-engine",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "dear-file-browser"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "dear-imgui-rs",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-ash"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "ash",
  "ash-window",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-bevy"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "flate2",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-glow"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "dear-imgui-rs",
  "dear-imgui-winit",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-reflect"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "dear-imgui-reflect-derive",
  "dear-imgui-rs",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-reflect-derive"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "approx",
  "bitflags 2.13.1",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sdl3"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-test-engine"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.13.1",
  "dear-imgui-rs",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-test-engine-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-wgpu"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bytemuck",
  "dear-imgui-rs",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-winit"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "dear-imgui-rs",
  "objc2 0.6.4",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.13.1",
  "dear-imgui-rs",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo-quat"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.13.1",
  "dear-imgui-rs",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo-quat-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imguizmo-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imnodes"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.13.1",
  "dear-imgui-rs",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imnodes-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "approx",
  "bitflags 2.13.1",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot3d"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.13.1",
  "dear-imgui-rs",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "dear-implot3d-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "dear-node-editor"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.13.1",
  "dear-imgui-rs",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "dear-node-editor-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Mingzhen Zhuang <superfrankie621@gmail.com>"]
@@ -61,33 +61,33 @@ xtask = { path = "xtask", version = "0.1.0" }
 [workspace.dependencies]
 # Workspace release catalog. Keep every publishable package here so member
 # manifests inherit one path and one registry requirement for internal edges.
-build-support = { package = "dear-imgui-build-support", version = "=0.16.0-alpha.3", path = "tools/build-support" }
-dear-app = { version = "=0.16.0-alpha.3", path = "dear-app" }
-dear-file-browser = { version = "=0.16.0-alpha.3", path = "extensions/dear-file-browser" }
-dear-imgui-ash = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-ash" }
-dear-imgui-bevy = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-bevy" }
-dear-imgui-glow = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-glow" }
-dear-imgui-reflect = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-reflect" }
-dear-imgui-reflect-derive = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-reflect-derive" }
-dear-imgui-rs = { version = "=0.16.0-alpha.3", path = "dear-imgui", default-features = false }
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-sdl3" }
-dear-imgui-sys = { version = "=0.16.0-alpha.3", path = "dear-imgui-sys", default-features = false }
-dear-imgui-test-engine = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-test-engine" }
-dear-imgui-test-engine-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imgui-test-engine-sys", default-features = false }
-dear-imgui-wgpu = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-wgpu" }
-dear-imgui-winit = { version = "=0.16.0-alpha.3", path = "backends/dear-imgui-winit" }
-dear-imguizmo = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo" }
-dear-imguizmo-quat = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo-quat" }
-dear-imguizmo-quat-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo-quat-sys", default-features = false }
-dear-imguizmo-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imguizmo-sys", default-features = false }
-dear-imnodes = { version = "=0.16.0-alpha.3", path = "extensions/dear-imnodes" }
-dear-imnodes-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-imnodes-sys", default-features = false }
-dear-implot = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot" }
-dear-implot-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot-sys", default-features = false }
-dear-implot3d = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot3d" }
-dear-implot3d-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-implot3d-sys", default-features = false }
-dear-node-editor = { version = "=0.16.0-alpha.3", path = "extensions/dear-node-editor" }
-dear-node-editor-sys = { version = "=0.16.0-alpha.3", path = "extensions/dear-node-editor-sys", default-features = false }
+build-support = { package = "dear-imgui-build-support", version = "0.16", path = "tools/build-support" }
+dear-app = { version = "0.16", path = "dear-app" }
+dear-file-browser = { version = "0.16", path = "extensions/dear-file-browser" }
+dear-imgui-ash = { version = "0.16", path = "backends/dear-imgui-ash" }
+dear-imgui-bevy = { version = "0.16", path = "backends/dear-imgui-bevy" }
+dear-imgui-glow = { version = "0.16", path = "backends/dear-imgui-glow" }
+dear-imgui-reflect = { version = "0.16", path = "extensions/dear-imgui-reflect" }
+dear-imgui-reflect-derive = { version = "0.16", path = "extensions/dear-imgui-reflect-derive" }
+dear-imgui-rs = { version = "0.16", path = "dear-imgui", default-features = false }
+dear-imgui-sdl3 = { version = "0.16", path = "backends/dear-imgui-sdl3" }
+dear-imgui-sys = { version = "0.16", path = "dear-imgui-sys", default-features = false }
+dear-imgui-test-engine = { version = "0.16", path = "extensions/dear-imgui-test-engine" }
+dear-imgui-test-engine-sys = { version = "0.16", path = "extensions/dear-imgui-test-engine-sys", default-features = false }
+dear-imgui-wgpu = { version = "0.16", path = "backends/dear-imgui-wgpu" }
+dear-imgui-winit = { version = "0.16", path = "backends/dear-imgui-winit" }
+dear-imguizmo = { version = "0.16", path = "extensions/dear-imguizmo" }
+dear-imguizmo-quat = { version = "0.16", path = "extensions/dear-imguizmo-quat" }
+dear-imguizmo-quat-sys = { version = "0.16", path = "extensions/dear-imguizmo-quat-sys", default-features = false }
+dear-imguizmo-sys = { version = "0.16", path = "extensions/dear-imguizmo-sys", default-features = false }
+dear-imnodes = { version = "0.16", path = "extensions/dear-imnodes" }
+dear-imnodes-sys = { version = "0.16", path = "extensions/dear-imnodes-sys", default-features = false }
+dear-implot = { version = "0.16", path = "extensions/dear-implot" }
+dear-implot-sys = { version = "0.16", path = "extensions/dear-implot-sys", default-features = false }
+dear-implot3d = { version = "0.16", path = "extensions/dear-implot3d" }
+dear-implot3d-sys = { version = "0.16", path = "extensions/dear-implot3d-sys", default-features = false }
+dear-node-editor = { version = "0.16", path = "extensions/dear-node-editor" }
+dear-node-editor-sys = { version = "0.16", path = "extensions/dear-node-editor-sys", default-features = false }
 
 # Core dependencies
 bitflags = "2.11"

--- a/README.md
+++ b/README.md
@@ -168,25 +168,25 @@ under `examples/ci/` are release evidence and are intentionally excluded from th
 
 ## Installation
 
-The latest crates.io prerelease is `0.16.0-alpha.3`, while the latest stable train remains `0.15.1`. Pin the exact prerelease `=0.16.0-alpha.3`; a broad `"0.16"` requirement does not select a prerelease. Applications staying on `0.15.1` can use the [v0.15.1 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.15.1/README.md) for its API and installation snippets.
+The `0.16.0` stable release train uses the compatible `"0.16"` requirement across the workspace crates. Applications staying on `0.15.1` can use the [v0.15.1 README](https://github.com/Latias94/dear-imgui-rs/blob/v0.15.1/README.md) for its API and installation snippets.
 
 ### Core + Backends
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
 # Choose a backend + platform integration
-dear-imgui-wgpu = "=0.16.0-alpha.3"  # or dear-imgui-glow / dear-imgui-ash
-dear-imgui-winit = "=0.16.0-alpha.3" # or dear-imgui-sdl3
+dear-imgui-wgpu = "0.16"  # or dear-imgui-glow / dear-imgui-ash
+dear-imgui-winit = "0.16" # or dear-imgui-sdl3
 ```
 
 `dear-imgui-wgpu` 0.16 defaults to WGPU 30. WGPU 29, 28, and 27 remain available as separate, mutually exclusive compatibility features:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-29"] }
-dear-imgui-winit = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
+dear-imgui-wgpu = { version = "0.16", default-features = false, features = ["wgpu-29"] }
+dear-imgui-winit = "0.16"
 ```
 
 Replace `wgpu-29` with `wgpu-28` or `wgpu-27` when integrating an older WGPU application.
@@ -195,7 +195,7 @@ Replace `wgpu-29` with `wgpu-28` or `wgpu-27` when integrating an older WGPU app
 
 ```toml
 [dependencies]
-dear-app = "=0.16.0-alpha.3" # State-owning Winit + WGPU runtime with docking support
+dear-app = "0.16" # State-owning Winit + WGPU runtime with docking support
 ```
 
 ### Apple Platform Examples
@@ -237,8 +237,8 @@ Example: low-level Android route without a dedicated Android convenience crate:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["backend-shim-android", "backend-shim-opengl3"] }
+dear-imgui-rs = "0.16"
+dear-imgui-sys = { version = "0.16", features = ["backend-shim-android", "backend-shim-opengl3"] }
 ```
 
 Recommended ownership split:
@@ -268,25 +268,25 @@ assembly.
 ```toml
 [dependencies]
 # Plotting
-dear-implot = "=0.16.0-alpha.3"   # 2D plotting
-dear-implot3d = "=0.16.0-alpha.3" # 3D plotting
+dear-implot = "0.16"   # 2D plotting
+dear-implot3d = "0.16" # 3D plotting
 
 # 3D Gizmos
-dear-imguizmo = "=0.16.0-alpha.3"      # Standard 3D gizmo + GraphEditor
-dear-imguizmo-quat = "=0.16.0-alpha.3" # Quaternion-based gizmo
+dear-imguizmo = "0.16"      # Standard 3D gizmo + GraphEditor
+dear-imguizmo-quat = "0.16" # Quaternion-based gizmo
 
 # Node Editor
-dear-imnodes = "=0.16.0-alpha.3"
-dear-node-editor = "=0.16.0-alpha.3" # native-only; add feature "blueprints" for stack layout
+dear-imnodes = "0.16"
+dear-node-editor = "0.16" # native-only; add feature "blueprints" for stack layout
 
 # Test automation
-dear-imgui-test-engine = "=0.16.0-alpha.3"
+dear-imgui-test-engine = "0.16"
 
 # File Browser
-dear-file-browser = "=0.16.0-alpha.3" # Native dialogs + ImGui file browser
+dear-file-browser = "0.16" # Native dialogs + ImGui file browser
 
 # Reflection-based UI helpers
-dear-imgui-reflect = "=0.16.0-alpha.3"
+dear-imgui-reflect = "0.16"
 ```
 
 ### Reflection-based UI (dear-imgui-reflect)
@@ -359,47 +359,47 @@ Quick examples (enable auto prebuilt download):
 - Env (Unix): `IMGUI_SYS_USE_PREBUILT=1 cargo build -p dear-imgui-rs --features prebuilt`
 - Env (Windows PowerShell): `$env:IMGUI_SYS_USE_PREBUILT='1'; cargo build -p dear-imgui-rs --features prebuilt`
 
-## Compatibility (0.16.0-alpha.3)
+## Compatibility (0.16.0)
 
-The workspace follows a release-train model. The table below lists the combinations validated for the 0.16.0-alpha.3 release. See [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for version history and compatibility policy.
+The workspace follows a release-train model. The table below lists the combinations validated for the 0.16.0 release. See [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for version history and compatibility policy.
 
 Core
 
 | Crate           | Version | Notes                                     |
 |-----------------|---------|-------------------------------------------|
-| dear-imgui-rs   | 0.16.0-alpha.3 | Safe Rust API over dear-imgui-sys     |
-| dear-imgui-sys  | 0.16.0-alpha.3 | Dear ImGui v1.92.9b docking via cimgui |
+| dear-imgui-rs   | 0.16.0 | Safe Rust API over dear-imgui-sys     |
+| dear-imgui-sys  | 0.16.0 | Dear ImGui v1.92.9b docking via cimgui |
 
 Backends
 
 | Crate            | Version | External deps     | Notes                          |
 |------------------|---------|-------------------|--------------------------------|
-| dear-imgui-wgpu  | 0.16.0-alpha.3 | wgpu = 30/29/28/27 | WebGPU renderer; WGPU 30 default, native Winit/SDL3 multi-viewport, browser single-window |
-| dear-imgui-glow  | 0.16.0-alpha.3 | glow = 0.17       | OpenGL renderer (winit/glutin) |
-| dear-imgui-ash   | 0.16.0-alpha.3 | ash = 0.38        | Native Vulkan renderer with Winit/SDL3 multi-viewport adapters |
-| dear-imgui-winit | 0.16.0-alpha.3 | winit = 0.30.13   | Winit platform backend         |
-| dear-imgui-sdl3  | 0.16.0-alpha.3 | sdl3 = 0.18.4     | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
-| dear-imgui-bevy  | 0.16.0-alpha.3 | Bevy = 0.19.1     | Experimental Bevy-native backend with docking, texture interop, and native multi-viewport |
+| dear-imgui-wgpu  | 0.16.0 | wgpu = 30/29/28/27 | WebGPU renderer; WGPU 30 default, native Winit/SDL3 multi-viewport, browser single-window |
+| dear-imgui-glow  | 0.16.0 | glow = 0.18       | OpenGL renderer (winit/glutin) |
+| dear-imgui-ash   | 0.16.0 | ash = 0.38        | Native Vulkan renderer with Winit/SDL3 multi-viewport adapters |
+| dear-imgui-winit | 0.16.0 | winit = 0.30.13   | Winit platform backend         |
+| dear-imgui-sdl3  | 0.16.0 | sdl3 = 0.18.4     | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
+| dear-imgui-bevy  | 0.16.0 | Bevy = 0.19.1     | Experimental Bevy-native backend with docking, texture interop, and native multi-viewport |
 
 Application Runtime
 
 | Crate     | Version | Requires dear-imgui-rs | Notes                                            |
 |-----------|---------|------------------------|--------------------------------------------------|
-| dear-app  | 0.16.0-alpha.3 | 0.16.0-alpha.3       | Generation-aware Winit + WGPU application runtime |
+| dear-app  | 0.16.0 | 0.16.0       | Generation-aware Winit + WGPU application runtime |
 
 Extensions
 
 | Crate               | Version | Requires dear-imgui-rs | Sys crate                   | Notes                                  |
 |---------------------|---------|------------------------|-----------------------------|----------------------------------------|
-| dear-implot         | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot-sys 0.16.0-alpha.3 | 2D plotting                         |
-| dear-imnodes        | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imnodes-sys 0.16.0-alpha.3 | WASM-capable node editor            |
-| dear-node-editor    | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-node-editor-sys 0.16.0-alpha.3 | Native imgui-node-editor; optional blueprints profile |
-| dear-imguizmo       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-sys 0.16.0-alpha.3 | 3D gizmo + GraphEditor              |
-| dear-file-browser   | 0.16.0-alpha.3 | 0.16.0-alpha.3 | —                              | State-owned ImGui UI + native dialog backends |
-| dear-implot3d       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot3d-sys 0.16.0-alpha.3 | 3D plotting                       |
-| dear-imguizmo-quat  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-quat-sys 0.16.0-alpha.3 | Quaternion gizmo              |
-| dear-imgui-test-engine | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imgui-test-engine-sys 0.16.0-alpha.3 | UI automation and test runner |
-| dear-imgui-reflect  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | —                              | Session-owned reflection UI              |
+| dear-implot         | 0.16.0 | 0.16.0 | dear-implot-sys 0.16.0 | 2D plotting                         |
+| dear-imnodes        | 0.16.0 | 0.16.0 | dear-imnodes-sys 0.16.0 | WASM-capable node editor            |
+| dear-node-editor    | 0.16.0 | 0.16.0 | dear-node-editor-sys 0.16.0 | Native imgui-node-editor; optional blueprints profile |
+| dear-imguizmo       | 0.16.0 | 0.16.0 | dear-imguizmo-sys 0.16.0 | 3D gizmo + GraphEditor              |
+| dear-file-browser   | 0.16.0 | 0.16.0 | —                              | State-owned ImGui UI + native dialog backends |
+| dear-implot3d       | 0.16.0 | 0.16.0 | dear-implot3d-sys 0.16.0 | 3D plotting                       |
+| dear-imguizmo-quat  | 0.16.0 | 0.16.0 | dear-imguizmo-quat-sys 0.16.0 | Quaternion gizmo              |
+| dear-imgui-test-engine | 0.16.0 | 0.16.0 | dear-imgui-test-engine-sys 0.16.0 | UI automation and test runner |
+| dear-imgui-reflect  | 0.16.0 | 0.16.0 | —                              | Session-owned reflection UI              |
 
 The workspace MSRV is Rust 1.92. The experimental Bevy backend requires Rust 1.95 because Bevy 0.19 does. Select exactly one WGPU major; `dear-app` follows the WGPU 30 default.
 

--- a/backends/dear-imgui-ash/CHANGELOG.md
+++ b/backends/dear-imgui-ash/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this crate will be documented in this file.
 
 ## Unreleased
 
+## 0.16.0 - 2026-08-14
+
 ### Breaking
 
 - Replace `WinitViewportRuntime` and `Sdl3ViewportRuntime` with `WinitViewportRoute` and `Sdl3ViewportRoute`. Each route captures the exact platform generation at `attach` and exposes one preparation transaction: `prepare(FrameToken)` (plus Winit's `ActiveEventLoop`) reconciles textures, dispatches secondary viewports, and returns all renderer and platform callback faults together. The old `prepare_context`, `prepare_frame`, `poll_fault`, `attach_unchecked`, renderer inspection, and manual trace/bypass entries were removed.

--- a/backends/dear-imgui-ash/README.md
+++ b/backends/dear-imgui-ash/README.md
@@ -425,8 +425,8 @@ the shader gamma path will not match (you'll effectively decode twice).
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.3  |
-| dear-imgui-rs | 0.16.0-alpha.3  |
+| Crate         | 0.16.0  |
+| dear-imgui-rs | 0.16.0  |
 | ash           | 0.38    |
 | ash-window    | 0.13 (`multi-viewport-winit`) |
 

--- a/backends/dear-imgui-bevy/CHANGELOG.md
+++ b/backends/dear-imgui-bevy/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.16.0 - 2026-08-14
+
 ### Breaking Changes
 
 - `ImguiContexts::{primary_id,ids,contains}` now return `Result` so a retained registry reports terminal App shutdown instead of looking like an active empty registry.

--- a/backends/dear-imgui-bevy/README.md
+++ b/backends/dear-imgui-bevy/README.md
@@ -10,27 +10,27 @@ The backend owns Dear ImGui Contexts on Bevy's main thread, routes Bevy window i
 | --- | --- |
 | Rust | `1.95.0` or newer |
 | Bevy | exactly `0.19.1` |
-| dear-imgui-rs | exactly `0.16.0-alpha.3` |
+| dear-imgui-rs | exactly `0.16.0` |
 
 `dear-imgui-bevy` defaults to the renderer plus deterministic Bevy UI ordering. Native multi-viewport is supported through an explicit feature and runtime opt-in. WASM supports the normal and headless feature sets but cannot create native platform windows.
 
 ## Installation
 
-Use matching exact prerelease dependencies:
+Use matching stable release dependencies:
 
 ```toml
 [dependencies]
 bevy = "=0.19.1"
-dear-imgui-bevy = "=0.16.0-alpha.3"
-dear-imgui-rs = "=0.16.0-alpha.3"
+dear-imgui-bevy = "0.16"
+dear-imgui-rs = "0.16"
 ```
 
-Users upgrading from alpha.2 must apply the Bevy migration steps in the root changelog.
+Users upgrading from a 0.16 prerelease must apply the Bevy migration steps in the root changelog.
 
 For a headless integration that drives private UI passes without installing the Bevy renderer:
 
 ```toml
-dear-imgui-bevy = { version = "=0.16.0-alpha.3", default-features = false }
+dear-imgui-bevy = { version = "0.16", default-features = false }
 ```
 
 ## Quick Start

--- a/backends/dear-imgui-glow/CHANGELOG.md
+++ b/backends/dear-imgui-glow/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-14
+
 ### Breaking
 
 - Updated the renderer dependency from `glow` 0.17 to 0.18. Applications must construct and pass a `glow` 0.18 `Context`.

--- a/backends/dear-imgui-glow/README.md
+++ b/backends/dear-imgui-glow/README.md
@@ -233,9 +233,9 @@ proof; shared runtime tests remain the teardown evidence. See the
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.3  |
-| dear-imgui-rs | 0.16.0-alpha.3  |
-| glow          | 0.17    |
+| Crate         | 0.16.0  |
+| dear-imgui-rs | 0.16.0  |
+| glow          | 0.18    |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 

--- a/backends/dear-imgui-sdl3/CHANGELOG.md
+++ b/backends/dear-imgui-sdl3/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-14
+
 ### Changed
 
 - SDL callback applications now call `Sdl3CallbackEventHandoff::drain` and inspect the returned atomic `Sdl3CallbackEventBatch` before replaying retained events with the owning backend's `process_callback_event`; the former `try_drain` and `Sdl3CallbackEventQueue` surface was removed. Every distinct queue fault is retained in observation order, and bounded O(1) state-event coalescing prevents sustained callback traffic from starving ordered input.

--- a/backends/dear-imgui-sdl3/README.md
+++ b/backends/dear-imgui-sdl3/README.md
@@ -41,42 +41,42 @@ Typical use cases:
 - `sdlgpu3-renderer`: enables this crate's official SDLGPU3 renderer shim.
 - `multi-viewport`: enables multi-viewport helpers (requires `dear-imgui-rs/multi-viewport`).
 
-Use the exact prerelease requirement for the desired feature combination:
+Use the compatible stable requirement for the desired feature combination:
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["opengl3-renderer"] }
+dear-imgui-sdl3 = { version = "0.16", features = ["opengl3-renderer"] }
 ```
 
 Platform-only usage (SDL3 + WGPU/Glow, no official OpenGL3 renderer):
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", default-features = false }
+dear-imgui-sdl3 = { version = "0.16", default-features = false }
 ```
 
 Enable the official OpenGL3 renderer:
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["opengl3-renderer"] }
+dear-imgui-sdl3 = { version = "0.16", features = ["opengl3-renderer"] }
 ```
 
 Enable the official SDLRenderer3 renderer:
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["sdlrenderer3-renderer"] }
+dear-imgui-sdl3 = { version = "0.16", features = ["sdlrenderer3-renderer"] }
 ```
 
 Enable the official SDLGPU3 renderer:
 
 ```toml
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["sdlgpu3-renderer"] }
+dear-imgui-sdl3 = { version = "0.16", features = ["sdlgpu3-renderer"] }
 ```
 
 ## Compatibility
 
 | Item          | Version  |
 |---------------|----------|
-| Crate         | 0.16.0-alpha.3  |
-| dear-imgui-rs | 0.16.0-alpha.3  |
+| Crate         | 0.16.0  |
+| dear-imgui-rs | 0.16.0  |
 | SDL3 crate    | 0.18.4   |
 | sdl3-sys      | 0.6      |
 
@@ -421,7 +421,7 @@ Example:
 
 ```toml
 [dependencies]
-dear-imgui-sdl3 = { version = "=0.16.0-alpha.3", features = ["opengl3-renderer"] }
+dear-imgui-sdl3 = { version = "0.16", features = ["opengl3-renderer"] }
 sdl3 = { version = "0.18", features = ["build-from-source"] }
 ```
 

--- a/backends/dear-imgui-wgpu/CHANGELOG.md
+++ b/backends/dear-imgui-wgpu/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-14
+
 ### Breaking
 
 - Replace `WinitViewportRuntime` and `Sdl3ViewportRuntime` with `WinitViewportRoute` and `Sdl3ViewportRoute`. Each route captures the exact live platform generation at safe attachment and exposes one frame path: `prepare(FrameToken)` followed by `render_main(prepared, pass, FramebufferExtent)`. The prepared frame exposes its same-frame secondary submission evidence as `WgpuViewportFrameReport`; the obsolete manual-trace report name is not retained.

--- a/backends/dear-imgui-wgpu/README.md
+++ b/backends/dear-imgui-wgpu/README.md
@@ -226,28 +226,28 @@ replacements are preserved rather than overwritten.
 
 ## Selecting wgpu version
 
-The `0.16.0-alpha.3` release defaults to WGPU 30:
+The `0.16.0` release defaults to WGPU 30:
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = "=0.16.0-alpha.3"
+dear-imgui-wgpu = "0.16"
 ```
 
 If your ecosystem is pinned to `wgpu` v29, v28, or v27, select it explicitly:
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-29"] }
+dear-imgui-wgpu = { version = "0.16", default-features = false, features = ["wgpu-29"] }
 ```
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-28"] }
+dear-imgui-wgpu = { version = "0.16", default-features = false, features = ["wgpu-28"] }
 ```
 
 ```toml
 [dependencies]
-dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, features = ["wgpu-27"] }
+dear-imgui-wgpu = { version = "0.16", default-features = false, features = ["wgpu-27"] }
 ```
 
 ## What You Get
@@ -266,7 +266,7 @@ dear-imgui-wgpu = { version = "=0.16.0-alpha.3", default-features = false, featu
 
 | Track | wgpu support |
 |-------|--------------|
-| `0.16.0-alpha.3` | 30 (default), 29 (`wgpu-29`), 28 (`wgpu-28`), 27 (`wgpu-27`) |
+| `0.16.0` | 30 (default), 29 (`wgpu-29`), 28 (`wgpu-28`), 27 (`wgpu-27`) |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 

--- a/backends/dear-imgui-winit/CHANGELOG.md
+++ b/backends/dear-imgui-winit/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-14
+
 ### Breaking Changes
 
 - Make `WinitPlatform` the sole public multi-viewport owner. `with_event_loop` now returns `WinitViewportAttempt`, which preserves the callback output and every deferred platform fault as parallel values instead of dropping one side through nested `Result` precedence.

--- a/backends/dear-imgui-winit/README.md
+++ b/backends/dear-imgui-winit/README.md
@@ -8,8 +8,8 @@ cursor handling and DPI awareness into Dear ImGui. Inspired by
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.3  |
-| dear-imgui-rs | 0.16.0-alpha.3  |
+| Crate         | 0.16.0  |
+| dear-imgui-rs | 0.16.0  |
 | winit         | 0.30.13 |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.

--- a/dear-app/README.md
+++ b/dear-app/README.md
@@ -7,11 +7,11 @@
 
 ## Quick Start
 
-Create a binary crate and add the exact prerelease:
+Create a binary crate and add the stable release:
 
 ```toml
 [dependencies]
-dear-app = "=0.16.0-alpha.3"
+dear-app = "0.16"
 ```
 
 Then use `dear_app::run_ui` for applications that only need persistent UI state:

--- a/dear-imgui-sys/README.md
+++ b/dear-imgui-sys/README.md
@@ -25,7 +25,7 @@ This crate supports multiple build strategies to fit different development workf
 ### 1. Prebuilt Static Libraries (Recommended)
 
 The fastest way to get started is to use prebuilt static libraries instead of compiling from source.
-`0.16.0-alpha.3` archives are published for the supported release targets and profiles.
+`0.16.0` archives are published for the supported release targets and profiles.
 
 ```bash
 # Option A: Point to the library directory inside an extracted core artifact.
@@ -33,7 +33,7 @@ The fastest way to get started is to use prebuilt static libraries instead of co
 export IMGUI_SYS_LIB_DIR=/path/to/extracted/dear-imgui-artifact/lib
 
 # Option B: Use a package-tool-generated local archive or HTTP(S) URL.
-export IMGUI_SYS_PREBUILT_URL=/path/to/dear-imgui-prebuilt-0.16.0-alpha.3-<target>-static.tar.gz
+export IMGUI_SYS_PREBUILT_URL=/path/to/dear-imgui-prebuilt-0.16.0-<target>-static.tar.gz
 cargo build -p dear-imgui-sys --features prebuilt
 
 # Option C: Enable HTTP(S) downloads / auto-download from GitHub releases
@@ -183,14 +183,14 @@ For a complete, up-to-date guide (including required tools, commands, and troubl
 
 This is a low-level sys crate providing unsafe FFI bindings. Most users should use the higher-level [`dear-imgui-rs`](https://crates.io/crates/dear-imgui-rs) crate instead, which provides safe Rust wrappers.
 
-Use the exact prerelease requirement:
+Use the compatible stable requirement:
 
 ```toml
 [dependencies]
-dear-imgui-sys = "=0.16.0-alpha.3"
+dear-imgui-sys = "0.16"
 
 # Enable features as needed
-dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["freetype", "wasm"] }
+dear-imgui-sys = { version = "0.16", features = ["freetype", "wasm"] }
 ```
 
 ### Direct FFI Usage (Advanced)
@@ -223,7 +223,7 @@ can expose optional backend shim modules behind `backend-shim-*` features:
 
 ```toml
 [dependencies]
-dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["backend-shim-opengl3"] }
+dear-imgui-sys = { version = "0.16", features = ["backend-shim-opengl3"] }
 ```
 
 These features expose self-contained modules such as:
@@ -356,8 +356,8 @@ There are two first-class Android directions.
 
    ```toml
    [dependencies]
-   dear-imgui-rs = "=0.16.0-alpha.3"
-   dear-imgui-sys = { version = "=0.16.0-alpha.3", features = ["backend-shim-android", "backend-shim-opengl3"] }
+   dear-imgui-rs = "0.16"
+   dear-imgui-sys = { version = "0.16", features = ["backend-shim-android", "backend-shim-opengl3"] }
    ```
 
    Use `dear-imgui-rs` for the safe core (`Context`, IO, frame lifecycle,

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -8,9 +8,9 @@ paths, see `docs/workstreams/apple-platform-support.md`.
 ## Versioning Policy
 
 - Unified release train: all published `dear-*` crates in this workspace are versioned and released together under the same semver, so consumers can depend on a single minor across the board.
-- Current published prerelease: unified `v0.16.0-alpha.3` (use exact requirements such as `version = "=0.16.0-alpha.3"`).
-- Previous prerelease: unified `v0.16.0-alpha.2`.
-- Current stable train: unified `v0.15.1` (use `version = "0.15"`).
+- Stable 0.16 train: unified `v0.16.0` (use `version = "0.16"`).
+- Previous prerelease: unified `v0.16.0-alpha.3` (prereleases require exact requirements).
+- Previous stable train: unified `v0.15.1` (use `version = "0.15"`).
 - Previous train: unified `v0.14.1` (use `version = "0.14"`).
 - Previous train: unified `v0.13.0` (use `version = "0.13"`).
 - Previous train: unified `v0.12.0` (use `version = "0.12"`).
@@ -18,57 +18,57 @@ paths, see `docs/workstreams/apple-platform-support.md`.
 - Previous train: unified `v0.10.4` (use `version = "0.10"`).
 - Previous train: unified `v0.9.0` (use `version = "0.9"`).
 - Previous train: unified `v0.8.0` (use `version = "0.8"`).
-- Internal dependency constraints in this repo pin to the exact current prerelease (for example, `=0.16.0-alpha.3`). Mixing different release trains across our crates is unsupported.
+- Internal dependency constraints use the compatible current stable minor (`0.16`); prerelease trains use exact requirements. Mixing different release trains across our crates is unsupported.
 
-## Current Prerelease (0.16.0-alpha.3)
+## 0.16 Stable Release
 
 Core
 
 | Crate           | Version | Upstream        | Notes                                     |
 |-----------------|---------|-----------------|-------------------------------------------|
-| dear-imgui-rs   | 0.16.0-alpha.3  | —               | Safe Rust API over dear-imgui-sys         |
-| dear-imgui-sys  | 0.16.0-alpha.3  | ImGui v1.92.9b  | Docking branch via cimgui; three binding profiles |
+| dear-imgui-rs   | 0.16.0  | —               | Safe Rust API over dear-imgui-sys         |
+| dear-imgui-sys  | 0.16.0  | ImGui v1.92.9b  | Docking branch via cimgui; three binding profiles |
 
 Backends
 
 | Crate             | Version | External deps           | Notes |
 |-------------------|---------|-------------------------|-------|
-| dear-imgui-wgpu   | 0.16.0-alpha.3  | wgpu = 30/29/28/27     | WGPU 30 default; native Winit/SDL3 multi-viewport; browser single-window |
-| dear-imgui-glow   | 0.16.0-alpha.3  | glow = 0.17            | OpenGL 3.0+/ES 3.0+/WebGL 2 renderer; live sampler capability with restorative fallback |
-| dear-imgui-ash    | 0.16.0-alpha.3  | ash = 0.38             | Native Vulkan renderer; shared Winit/SDL3 multi-viewport runtime |
-| dear-imgui-winit  | 0.16.0-alpha.3  | winit = 0.30.13        | Winit platform backend |
-| dear-imgui-sdl3   | 0.16.0-alpha.3  | sdl3 = 0.18.4, sdl3-sys 0.6 | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
-| dear-imgui-bevy   | 0.16.0-alpha.3  | Bevy = 0.19.1          | Bevy-native backend; default renderer and Bevy UI ordering, explicit advanced routes, Rust 1.95 minimum |
+| dear-imgui-wgpu   | 0.16.0  | wgpu = 30/29/28/27     | WGPU 30 default; native Winit/SDL3 multi-viewport; browser single-window |
+| dear-imgui-glow   | 0.16.0  | glow = 0.18            | OpenGL 3.0+/ES 3.0+/WebGL 2 renderer; live sampler capability with restorative fallback |
+| dear-imgui-ash    | 0.16.0  | ash = 0.38             | Native Vulkan renderer; shared Winit/SDL3 multi-viewport runtime |
+| dear-imgui-winit  | 0.16.0  | winit = 0.30.13        | Winit platform backend |
+| dear-imgui-sdl3   | 0.16.0  | sdl3 = 0.18.4, sdl3-sys 0.6 | SDL3 platform backend with optional official OpenGL3, SDLRenderer3, and SDLGPU3 renderers |
+| dear-imgui-bevy   | 0.16.0  | Bevy = 0.19.1          | Bevy-native backend; default renderer and Bevy UI ordering, explicit advanced routes, Rust 1.95 minimum |
 
 Utilities
 
 | Crate     | Version | External deps | Notes |
 |-----------|---------|---------------|-------|
-| dear-app  | 0.16.0-alpha.3  | winit, wgpu 30 | Generation-aware application runtime |
+| dear-app  | 0.16.0  | winit, wgpu 30 | Generation-aware application runtime |
 
 Tooling
 
 | Crate                    | Version | External deps | Notes |
 |--------------------------|---------|---------------|-------|
-| dear-imgui-build-support | 0.16.0-alpha.3  | ureq = 3.3    | Binding specification, build, package, and prebuilt helpers |
+| dear-imgui-build-support | 0.16.0  | ureq = 3.3    | Binding specification, build, package, and prebuilt helpers |
 
 Extensions
 
 | Crate               | Version | Requires dear-imgui-rs | Sys crate                    | Notes                                  |
 |---------------------|---------|------------------------|------------------------------|----------------------------------------|
-| dear-implot         | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot-sys 0.16.0-alpha.3 | 2D plotting |
-| dear-imnodes        | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imnodes-sys 0.16.0-alpha.3 | WASM-capable node editor |
-| dear-node-editor    | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-node-editor-sys 0.16.0-alpha.3 | Native-only; opt-in blueprints profile |
-| dear-imguizmo       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-sys 0.16.0-alpha.3 | 3D gizmo |
-| dear-file-browser   | 0.16.0-alpha.3 | 0.16.0-alpha.3 | — | State-owned ImGui UI + native dialogs |
-| dear-implot3d       | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-implot3d-sys 0.16.0-alpha.3 | 3D plotting |
-| dear-imguizmo-quat  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imguizmo-quat-sys 0.16.0-alpha.3 | Quaternion gizmo |
-| dear-imgui-test-engine | 0.16.0-alpha.3 | 0.16.0-alpha.3 | dear-imgui-test-engine-sys 0.16.0-alpha.3 | UI automation and test runner |
-| dear-imgui-reflect  | 0.16.0-alpha.3 | 0.16.0-alpha.3 | — | Session-owned reflection UI |
+| dear-implot         | 0.16.0 | 0.16.0 | dear-implot-sys 0.16.0 | 2D plotting |
+| dear-imnodes        | 0.16.0 | 0.16.0 | dear-imnodes-sys 0.16.0 | WASM-capable node editor |
+| dear-node-editor    | 0.16.0 | 0.16.0 | dear-node-editor-sys 0.16.0 | Native-only; opt-in blueprints profile |
+| dear-imguizmo       | 0.16.0 | 0.16.0 | dear-imguizmo-sys 0.16.0 | 3D gizmo |
+| dear-file-browser   | 0.16.0 | 0.16.0 | — | State-owned ImGui UI + native dialogs |
+| dear-implot3d       | 0.16.0 | 0.16.0 | dear-implot3d-sys 0.16.0 | 3D plotting |
+| dear-imguizmo-quat  | 0.16.0 | 0.16.0 | dear-imguizmo-quat-sys 0.16.0 | Quaternion gizmo |
+| dear-imgui-test-engine | 0.16.0 | 0.16.0 | dear-imgui-test-engine-sys 0.16.0 | UI automation and test runner |
+| dear-imgui-reflect  | 0.16.0 | 0.16.0 | — | Session-owned reflection UI |
 
 ## 0.16 Architecture Contracts
 
-The 0.16 train is not source-compatible with 0.15.x, and alpha.2 deliberately removes provisional alpha.1 APIs whose contracts were not sound enough to stabilize. The baseline is Dear ImGui v1.92.9b docking via cimgui, Rust 1.92 for the workspace, Rust 1.95 for the Bevy backend, WGPU 30 by default with explicit 29/28/27 routes, and Bevy 0.19.1. Alpha.3 migrations live in the `0.16.0-alpha.3` section of `CHANGELOG.md`; applications coming from 0.15.x must also apply the alpha.2 and alpha.1 migrations.
+The 0.16 train is not source-compatible with 0.15.x. Its baseline is Dear ImGui v1.92.9b docking via cimgui, Rust 1.92 for the workspace, Rust 1.95 for the Bevy backend, WGPU 30 by default with explicit 29/28/27 routes, Glow 0.18, and Bevy 0.19.1. The `0.16.0` section of `CHANGELOG.md` summarizes the complete stable migration; the alpha sections preserve the incremental prerelease history.
 
 The safe Rust layer intentionally breaks APIs that expose C++ lifecycle
 protocols, wrong-context state, stale GPU handles, or platform-specific ABI
@@ -98,9 +98,9 @@ target.
 | Bevy native multi-viewport | `multi-viewport` implies `render`, `bevy_winit`, and the narrow `dear-imgui-winit/native-platform-support` capability layer; it does not instantiate a second Winit platform runtime. Each Context opts in explicitly. Secondary state is keyed by stable `ImguiViewportInstanceId`; the numeric `ViewportId` is only the current routing projection and may change during docking. The host and secondary ECS entities must resolve through exact `WINIT_WINDOWS` mappings. `Show` remains hidden until the mapping and Windows policy lease are ready, and `NO_INPUTS`/`NO_FOCUS_ON_CLICK` are enforced by the native policy. Monitor facts are published transactionally from detached Winit snapshots; ECS monitor geometry is not a fallback. `ImguiNativeViewportSupport` reports coordinate capability, while the independent `NativeMonitor` diagnostic batch reports collection, primary-identity, and work-area fallback state. Wayland falls back to host-window docking because global desktop client coordinates are unavailable. |
 | Bevy WASM | `wasm` supports both default and headless builds; combining WASM with native `multi-viewport` is rejected. |
 
-Native desktop evidence is graded separately from implementation and compile coverage. The current
-worktree did not execute the complete manual desktop checklist below, so these rows must not be
-reported as newly verified native behavior without a named CI or PR test environment:
+Native desktop evidence is graded separately from implementation and compile coverage. The release
+evidence does not include the complete manual desktop checklist below, so these rows must not be
+reported as verified native behavior without a named CI or PR test environment:
 
 | Native behavior | Implemented source and repository evidence | Current claim |
 | --- | --- | --- |
@@ -316,7 +316,7 @@ import-style binding artifact. `xtask verify-bindings` regenerates and compares
 all supported profiles; arbitrary bindgen clang-argument overrides are rejected
 for canonical artifacts.
 
-The binding generator contract, formatter, allow/block lists, enum normalization, header shims, opaque types, provider name, and exact compatibility target facts all participate in the deterministic binding-spec hash. `dear-imgui-build-support` ships on the same 0.16.0-alpha.3 train as every other publishable crate.
+The binding generator contract, formatter, allow/block lists, enum normalization, header shims, opaque types, provider name, and exact compatibility target facts all participate in the deterministic binding-spec hash. `dear-imgui-build-support` ships on the same 0.16.0 train as every other publishable crate.
 
 Source identity is package data rather than repository state. The exact 40-hex
 cimgui and nested Dear ImGui revisions live in

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -17,12 +17,12 @@ The repository workflow token defaults to read-only. The protected crates.io job
 Preparation intentionally changes the worktree; validation requires the resulting commit to be clean.
 
 ```bash
-python3 tools/tasks.py release-prepare 0.16.0-alpha.3
+python3 tools/tasks.py release-prepare 0.16.0
 
 # Review generated bindings, source metadata, Cargo.lock, CHANGELOG.md, and docs.
 git diff
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.3"
+git commit -m "chore: prepare release v0.16.0"
 
 python3 tools/tasks.py release-check
 ```
@@ -34,7 +34,7 @@ Before merging, require normal CI to pass on Linux, Windows, and macOS. The root
 Merge the candidate to `main`, then dispatch the release workflow with the matching tag:
 
 ```bash
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
+gh workflow run release.yml --ref main -f tag=v0.16.0
 ```
 
 The workflow binds the tag to the workspace version and the exact `main` commit before doing any irreversible work. It then:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -159,17 +159,17 @@ These checks generate/use bindings only and won’t build/link native code.
 Preparation and validation remain separate because preparation intentionally changes the worktree:
 
 ```bash
-python3 tools/tasks.py release-prepare 0.16.0-alpha.3
+python3 tools/tasks.py release-prepare 0.16.0
 git diff
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.3"
+git commit -m "chore: prepare release v0.16.0"
 python3 tools/tasks.py release-check
 ```
 
 After the candidate is merged to `main` and normal CI is green, run the single release entry point:
 
 ```bash
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
+gh workflow run release.yml --ref main -f tag=v0.16.0
 ```
 
 `release.yml` binds the tag, workspace version, `main` ref, and exact candidate;

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -17,11 +17,11 @@ revision instead of renaming its files or remapping it under the v1 module name.
 
 WASM support is explicit and target-specific. The only supported Rust target is
 `wasm32-unknown-unknown`, and every dependency path to the core crate must
-enable the `wasm` feature. Use the exact prerelease requirement:
+enable the `wasm` feature. Use the compatible stable requirement:
 
 ```toml
 [dependencies]
-dear-imgui-rs = { version = "=0.16.0-alpha.3", features = ["wasm"] }
+dear-imgui-rs = { version = "0.16", features = ["wasm"] }
 ```
 
 For Bevy, enable `wasm` alongside the features needed by the application and
@@ -29,8 +29,8 @@ take both packages from the same release train:
 
 ```toml
 [dependencies]
-dear-imgui-bevy = { version = "=0.16.0-alpha.3", features = ["render", "wasm"] }
-dear-imgui-rs = { version = "=0.16.0-alpha.3", features = ["wasm"] }
+dear-imgui-bevy = { version = "0.16", features = ["render", "wasm"] }
+dear-imgui-rs = { version = "0.16", features = ["wasm"] }
 ```
 
 Five safe native extensions expose the same `wasm` feature and forward it to

--- a/examples-android/dear-imgui-android-smoke/Cargo.lock
+++ b/examples-android/dear-imgui-android-smoke/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "serde",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags",
  "dear-imgui-sys",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "dear-imgui-build-support",

--- a/examples-ios/dear-imgui-ios-sdl3-smoke/Cargo.lock
+++ b/examples-ios/dear-imgui-ios-sdl3-smoke/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "pkg-config",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags",
  "dear-imgui-sys",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sdl3"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-wgpu"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bytemuck",
  "dear-imgui-rs",
@@ -677,9 +677,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pollster"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "portable-atomic"

--- a/examples-ios/dear-imgui-ios-sdl3-smoke/Cargo.toml
+++ b/examples-ios/dear-imgui-ios-sdl3-smoke/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["staticlib"]
 dear-imgui-rs = { path = "../../dear-imgui", default-features = false }
 dear-imgui-sdl3 = { path = "../../backends/dear-imgui-sdl3" }
 dear-imgui-wgpu = { path = "../../backends/dear-imgui-wgpu" }
-pollster = "0.4"
+pollster = "1.0"
 sdl3 = { version = "0.18", features = ["raw-window-handle"] }

--- a/examples-ios/dear-imgui-ios-smoke/Cargo.lock
+++ b/examples-ios/dear-imgui-ios-smoke/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "dear-imgui-build-support"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "serde",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-rs"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bitflags 2.11.1",
  "dear-imgui-sys",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-sys"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "cc",
  "dear-imgui-build-support",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-wgpu"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "bytemuck",
  "dear-imgui-rs",
@@ -376,14 +376,12 @@ dependencies = [
 
 [[package]]
 name = "dear-imgui-winit"
-version = "0.16.0-alpha.3"
+version = "0.16.0"
 dependencies = [
  "dear-imgui-rs",
- "objc2-app-kit 0.3.2",
  "thiserror 2.0.18",
  "web-sys",
  "web-time",
- "windows-sys 0.61.2",
  "winit",
 ]
 
@@ -961,17 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-app-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
-dependencies = [
- "bitflags 2.11.1",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,7 +1090,7 @@ checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
+ "objc2-app-kit",
  "objc2-foundation 0.2.2",
 ]
 
@@ -1330,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "pollster"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "portable-atomic"
@@ -2459,7 +2446,7 @@ dependencies = [
  "memmap2",
  "ndk",
  "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
+ "objc2-app-kit",
  "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",

--- a/examples-ios/dear-imgui-ios-smoke/Cargo.toml
+++ b/examples-ios/dear-imgui-ios-smoke/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["staticlib"]
 dear-imgui-rs = { path = "../../dear-imgui", default-features = false }
 dear-imgui-wgpu = { path = "../../backends/dear-imgui-wgpu" }
 dear-imgui-winit = { path = "../../backends/dear-imgui-winit" }
-pollster = "0.4"
+pollster = "1.0"
 winit = "0.30.13"

--- a/extensions/BEST_PRACTICES.md
+++ b/extensions/BEST_PRACTICES.md
@@ -120,10 +120,10 @@ Use C bindings (cimgui family) + bindgen when available:
 Centralize all prebuilt download/extract/naming logic via the shared helper crate:
 
 - Depend on `dear-imgui-build-support` in your `-sys` crate as a build-dependency.
-  Use the exact prerelease requirement:
+  Use the compatible stable requirement:
   ```toml
   [build-dependencies]
-  build-support = { package = "dear-imgui-build-support", version = "=0.16.0-alpha.3", features = ["binding-spec"] }
+  build-support = { package = "dear-imgui-build-support", version = "0.16", features = ["binding-spec"] }
   ```
 
   Workspace members should inherit the repository catalog instead:

--- a/extensions/dear-file-browser/README.md
+++ b/extensions/dear-file-browser/README.md
@@ -33,8 +33,8 @@ File dialogs and in-UI file browser for `dear-imgui-rs` with two backends:
 
 | Item          | Version |
 |---------------|---------|
-| Crate         | 0.16.0-alpha.3  |
-| dear-imgui-rs | 0.16.0-alpha.3  |
+| Crate         | 0.16.0  |
+| dear-imgui-rs | 0.16.0  |
 
 ## Features
 

--- a/extensions/dear-imgui-reflect/README.md
+++ b/extensions/dear-imgui-reflect/README.md
@@ -19,18 +19,18 @@ Dear ImGui context or panel whose settings and drafts it should retain.
 
 ## Cargo Integration
 
-Use the exact prerelease requirements:
+Use compatible stable requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-imgui-reflect = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
+dear-imgui-reflect = "0.16"
 ```
 
 Optional math support:
 
 ```toml
-dear-imgui-reflect = { version = "=0.16.0-alpha.3", features = ["glam", "mint"] }
+dear-imgui-reflect = { version = "0.16", features = ["glam", "mint"] }
 glam = "0.32"
 mint = "0.5"
 ```
@@ -199,8 +199,8 @@ See `examples/03-features/reflect_demo.rs` for a complete inspector and
 
 | Item | Version |
 |---|---|
-| Crate | 0.16.0-alpha.3 |
-| dear-imgui-rs | 0.16.0-alpha.3 |
+| Crate | 0.16.0 |
+| dear-imgui-rs | 0.16.0 |
 
 ## License
 

--- a/extensions/dear-imgui-test-engine/README.md
+++ b/extensions/dear-imgui-test-engine/README.md
@@ -25,20 +25,20 @@ For native build/link options, see `extensions/dear-imgui-test-engine-sys/README
 
 | Item                        | Version |
 |-----------------------------|---------|
-| Crate                       | 0.16.0-alpha.3  |
-| dear-imgui-rs               | 0.16.0-alpha.3  |
-| dear-imgui-test-engine-sys  | 0.16.0-alpha.3  |
+| Crate                       | 0.16.0  |
+| dear-imgui-rs               | 0.16.0  |
+| dear-imgui-test-engine-sys  | 0.16.0  |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md).
 
 ## Quick Start
 
-Use the exact prerelease requirements:
+Use compatible stable requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-imgui-test-engine = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
+dear-imgui-test-engine = "0.16"
 ```
 
 ```rust

--- a/extensions/dear-imguizmo-quat/README.md
+++ b/extensions/dear-imguizmo-quat/README.md
@@ -19,9 +19,9 @@ Safe, idiomatic Rust bindings for ImGuIZMO.quat (quaternion + 3D gizmo helpers) 
 
 | Item                   | Version |
 |------------------------|---------|
-| Crate                  | 0.16.0-alpha.3  |
-| dear-imgui-rs          | 0.16.0-alpha.3  |
-| dear-imguizmo-quat-sys | 0.16.0-alpha.3  |
+| Crate                  | 0.16.0  |
+| dear-imgui-rs          | 0.16.0  |
+| dear-imguizmo-quat-sys | 0.16.0  |
 
 See also: docs/COMPATIBILITY.md in the workspace for the full matrix.
 
@@ -93,12 +93,12 @@ use one saved value rather than a stack, so avoid nesting `set_*`/`restore_*` or
 
 ## Quick Start
 
-Use the exact prerelease requirements:
+Use compatible stable requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-imguizmo-quat = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
+dear-imguizmo-quat = "0.16"
 ```
 
 Minimal usage with the Ui extension and builder API:

--- a/extensions/dear-imguizmo/README.md
+++ b/extensions/dear-imguizmo/README.md
@@ -26,9 +26,9 @@ This project is a Rust wrapper around the C shim (cimguizmo), not a direct C++ b
 
 | Item              | Version |
 |-------------------|---------|
-| Crate             | 0.16.0-alpha.3  |
-| dear-imgui-rs     | 0.16.0-alpha.3  |
-| dear-imguizmo-sys | 0.16.0-alpha.3  |
+| Crate             | 0.16.0  |
+| dear-imgui-rs     | 0.16.0  |
+| dear-imguizmo-sys | 0.16.0  |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 
@@ -74,12 +74,12 @@ All matrix arguments in the API are generic over a `Mat4Like` trait, implemented
 
 ## Quick Start
 
-Use the exact prerelease requirements:
+Use compatible stable requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-imguizmo = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
+dear-imguizmo = "0.16"
 ```
 
 Minimal usage (dear-imgui-style API):

--- a/extensions/dear-imnodes/README.md
+++ b/extensions/dear-imnodes/README.md
@@ -27,9 +27,9 @@ Safe, idiomatic Rust bindings for [ImNodes](https://github.com/Nelarius/imnodes)
 
 | Item              | Version |
 |-------------------|---------|
-| Crate             | 0.16.0-alpha.3  |
-| dear-imgui-rs     | 0.16.0-alpha.3  |
-| dear-imnodes-sys  | 0.16.0-alpha.3  |
+| Crate             | 0.16.0  |
+| dear-imgui-rs     | 0.16.0  |
+| dear-imnodes-sys  | 0.16.0  |
 
 See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob/main/docs/COMPATIBILITY.md) for the full workspace matrix.
 

--- a/extensions/dear-implot/README.md
+++ b/extensions/dear-implot/README.md
@@ -21,9 +21,9 @@ For native build/link options (source, system/prebuilt, remote prebuilt), see `e
 
 | Item              | Version |
 |-------------------|---------|
-| Crate             | 0.16.0-alpha.3  |
-| dear-imgui-rs     | 0.16.0-alpha.3  |
-| dear-implot-sys   | 0.16.0-alpha.3  |
+| Crate             | 0.16.0  |
+| dear-imgui-rs     | 0.16.0  |
+| dear-implot-sys   | 0.16.0  |
 
 ### WASM (WebAssembly) support
 
@@ -64,12 +64,12 @@ See also: [docs/COMPATIBILITY.md](https://github.com/Latias94/dear-imgui-rs/blob
 
 This crate integrates with `dear-imgui-rs` directly — add both crates, then build plots inside an ImGui window using a `PlotContext` bound to the current ImGui context.
 
-Use the exact prerelease requirements:
+Use compatible stable requirements:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-implot = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
+dear-implot = "0.16"
 ```
 
 ```rust
@@ -134,8 +134,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dear-imgui-rs = "=0.16.0-alpha.3"
-dear-implot = "=0.16.0-alpha.3"
+dear-imgui-rs = "0.16"
+dear-implot = "0.16"
 ```
 
 Basic usage:

--- a/extensions/dear-implot3d/README.md
+++ b/extensions/dear-implot3d/README.md
@@ -22,9 +22,9 @@ the ergonomics of `dear-implot`.
 
 | Item               | Version |
 |--------------------|---------|
-| Crate              | 0.16.0-alpha.3  |
-| dear-imgui-rs      | 0.16.0-alpha.3  |
-| dear-implot3d-sys  | 0.16.0-alpha.3  |
+| Crate              | 0.16.0  |
+| dear-imgui-rs      | 0.16.0  |
+| dear-implot3d-sys  | 0.16.0  |
 
 See also: docs/COMPATIBILITY.md in the workspace for the full matrix.
 

--- a/extensions/dear-node-editor/README.md
+++ b/extensions/dear-node-editor/README.md
@@ -46,9 +46,9 @@ layout compatibility notice.
 
 | Item                 | Version |
 |----------------------|---------|
-| Crate                | 0.16.0-alpha.3  |
-| dear-imgui-rs        | 0.16.0-alpha.3  |
-| dear-node-editor-sys | 0.16.0-alpha.3  |
+| Crate                | 0.16.0  |
+| dear-imgui-rs        | 0.16.0  |
+| dear-node-editor-sys | 0.16.0  |
 
 ## Quick Start
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,26 +12,27 @@ The workspace uses a **unified release train** model. All 27 publishable package
 
 ```bash
 # Generate the complete release diff.
-python3 tools/tasks.py release-prepare 0.16.0-alpha.3
+python3 tools/tasks.py release-prepare 0.16.0
 
 # Review and commit versions, bindings, lockfile, changelog, and docs.
 git diff
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.3"
+git commit -m "chore: prepare release v0.16.0"
 
 # Validate the committed clean release candidate.
 python3 tools/tasks.py release-check
 
 # After merging to main and normal CI passes, run the complete release.
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
+gh workflow run release.yml --ref main -f tag=v0.16.0
 ```
 
 `release-prepare` intentionally leaves changes in the working tree. `release-check` runs the strict clean-tree, changelog, locked dependency graph, reproducible binding, package/offline, documentation, and test gates. Keeping these phases separate prevents release preparation from failing its own clean-tree check.
 
-Local success is necessary but not sufficient. `release.yml` binds the tag to
-the exact `main` commit, requires successful normal CI, builds and consumes all
-five prebuilt targets, publishes the complete 27-crate train through Trusted
-Publishing, and only then creates the tag and GitHub Release.
+Local success is necessary but not sufficient. `release.yml` binds the candidate
+to the exact `main` commit, requires successful normal CI, builds and consumes all
+five prebuilt targets, reserves or verifies the tag in the protected environment,
+publishes the complete 27-crate train through Trusted Publishing, and then creates
+the GitHub Release.
 
 ## Available Scripts
 
@@ -59,7 +60,7 @@ python3 tools/tasks.py doc
 python3 tools/tasks.py clean
 
 # Create a release diff, then validate it after commit
-python3 tools/tasks.py release-prepare 0.16.0-alpha.3
+python3 tools/tasks.py release-prepare 0.16.0
 python3 tools/tasks.py release-check
 ```
 
@@ -68,7 +69,7 @@ python3 tools/tasks.py release-check
 The workspace root is the single version source. Publishable manifests use `version.workspace = true`, and internal dependencies inherit their root workspace declarations. `[workspace.metadata.dear-imgui-release]` is the shared policy for the core package and private package paths/versions; Rust and Python release validators derive package counts from the actual workspace members. Update the release train with:
 
 ```bash
-cargo run -p xtask -- release-version 0.16.0-alpha.3 --allow-prerelease-relabel
+cargo run -p xtask -- release-version 0.16.0
 ```
 
 The command updates the root release version and inherited internal dependency requirements as one validated workspace operation. It never offers partial crate selection. Documentation remains an explicit review step.
@@ -219,23 +220,24 @@ job, prebuilt build, or consumer directly fails the release.
 
 ```bash
 # 1. Generate versions, bindings, provenance, and lockfile changes.
-python3 tools/tasks.py release-prepare 0.16.0-alpha.3
+python3 tools/tasks.py release-prepare 0.16.0
 
 # 2. Review CHANGELOG.md, compatibility docs, generated files, and Cargo.lock.
 git diff
 
 # 3. Commit and validate the exact candidate.
 git add -A
-git commit -m "chore: prepare release v0.16.0-alpha.3"
+git commit -m "chore: prepare release v0.16.0"
 python3 tools/tasks.py release-check
 
 # 4. Merge to main, require normal CI to pass, then run the complete release.
-gh workflow run release.yml --ref main -f tag=v0.16.0-alpha.3
+gh workflow run release.yml --ref main -f tag=v0.16.0
 ```
 
 The release workflow acquires a short-lived crates.io token only after all
-prebuilt targets pass, resumes exact already-published versions automatically,
-and creates the tag and GitHub Release only after all 27 crates are available.
+prebuilt targets pass, reserves or verifies the candidate tag before the first
+upload, resumes exact already-published versions automatically, and creates the
+GitHub Release only after all 27 crates are available.
 
 ## Common Tasks
 

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -367,6 +367,8 @@ def task_release_prepare(args, repo_root: Path) -> int:
                 lambda: run_command(
                     [
                         sys.executable,
+                        "-X",
+                        "utf8",
                         "-B",
                         "-m",
                         "unittest",

--- a/tools/tests/test_release_metadata.py
+++ b/tools/tests/test_release_metadata.py
@@ -204,12 +204,15 @@ class MetadataTests(unittest.TestCase):
 
 
 class CurrentReleaseTrainTests(unittest.TestCase):
-    def test_release_train_uses_exact_catalog_requirements(self):
+    def test_release_train_uses_canonical_catalog_requirements(self):
         workspace = tomllib.loads(
             REPO_ROOT.joinpath("Cargo.toml").read_text(encoding="utf-8")
         )
         version = workspace["workspace"]["package"]["version"]
         catalog = workspace["workspace"]["dependencies"]
+        expected_requirement = release_metadata.expected_internal_requirement(
+            version
+        ).removeprefix("^")
 
         self.assertEqual(
             {
@@ -217,7 +220,7 @@ class CurrentReleaseTrainTests(unittest.TestCase):
                 for dependency in catalog.values()
                 if "path" in dependency
             },
-            {f"={version}"},
+            {expected_requirement},
         )
 
         metadata = release_metadata.load_workspace_metadata(REPO_ROOT)

--- a/tools/tests/test_tasks.py
+++ b/tools/tests/test_tasks.py
@@ -189,6 +189,8 @@ class ReleaseTaskTests(unittest.TestCase):
                 ],
                 [
                     TASKS.sys.executable,
+                    "-X",
+                    "utf8",
                     "-B",
                     "-m",
                     "unittest",
@@ -252,7 +254,7 @@ class ReleaseTaskTests(unittest.TestCase):
         self.assertTrue(all("--locked" in command for command in commands[2:5]))
         self.assertIn("--dry-run", commands[5])
         self.assertEqual(
-            commands[6][1:5], ["-B", "-m", "unittest", "discover"]
+            commands[6][1:7], ["-X", "utf8", "-B", "-m", "unittest", "discover"]
         )
         self.assertEqual(len(commands), 7)
         self.assertIn("cargo metadata --no-deps --format-version 1", output.getvalue())


### PR DESCRIPTION
- What
  - Promotes the complete 27-crate release train from `0.16.0-alpha.3` to stable `0.16.0`, with compatible internal `0.16` requirements and refreshed lockfiles.
  - Consolidates the stable release notes and compatibility guidance, and hardens release tooling for stable-version policy and UTF-8 subprocess output on Windows.

- Why
  - The alpha train and the merged Bevy, Winit multi-viewport, and runtime dependency work are ready for a stable release, but crates.io metadata, documentation, locks, and package validation must agree before publication.
  - Publication remains a separate post-merge step: CI must pass on the exact `main` SHA before the protected `v0.16.0` release workflow is dispatched.

- Affected crates
  - [x] dear-imgui-rs
  - [x] dear-imgui-sys
  - [x] backends/dear-imgui-wgpu
  - [x] backends/dear-imgui-glow
  - [x] backends/dear-imgui-winit
  - [x] backends/dear-imgui-sdl3
  - [x] backends/dear-imgui-ash
  - [x] backends/dear-imgui-bevy
  - [x] dear-app
  - [x] extensions/dear-implot(-sys)
  - [x] extensions/dear-implot3d(-sys)
  - [x] extensions/dear-imnodes(-sys)
  - [x] extensions/dear-node-editor(-sys)
  - [x] extensions/dear-imguizmo(-sys)
  - [x] extensions/dear-imguizmo-quat(-sys)
  - [x] extensions/dear-imgui-test-engine(-sys)
  - [x] extensions/dear-file-browser
  - [x] extensions/dear-imgui-reflect
  - [x] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [x] Packaging (.tar.gz)
  - [x] No runtime behavior change (release metadata, validation, and documentation)

- Breaking changes
  - [ ] None
  - [x] Yes: `0.16.0` stabilizes the documented `0.15` to `0.16` API migration. This PR adds no new breaking change after `0.16.0-alpha.3`.

- Testing / validation
  - `python -X utf8 -B tools/pre_publish_check.py`: locked metadata, source provenance, bindings, release notes, docs, workflow policy, `wasm32-unknown-unknown`, and all per-package nextest gates passed.
  - `EMSDK=<CI-pinned 5.0.5> python -X utf8 -B tools/ci/verify_packaged_core.py`: all 27 source archives, the packaged Emscripten provider, native prebuilt archives, and offline consumers passed.
  - `python -X utf8 -B -m unittest discover -s tools/tests -p 'test_*.py'`: 262 passed, 1 skipped.
  - Checked on Windows `x86_64-pc-windows-msvc`, Rust `wasm32-unknown-unknown`, and the packaged Emscripten provider route.

- Docs
  - [ ] N/A
  - [x] Updated README / crate docs

- Links
  - Related: #50, #75, #76, #77
