### PR TITLE
fix(scope): use stable table IDs across table pool growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog prose uses soft wrapping: do not hard-wrap paragraphs or bullet text j
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed false native table scope order violations when creating nested tables grows Dear ImGui's table pool. Table scope identity now uses the stable table ID instead of a relocatable memory address.
+
 ## [0.17.0] - 2026-08-17
 
 ### Added

--- a/backends/dear-imgui-bevy/src/viewport/bridge.rs
+++ b/backends/dear-imgui-bevy/src/viewport/bridge.rs
@@ -321,7 +321,7 @@ impl ImguiViewportBridgeContext {
         if let Some(error) = self.inner.callback_fault.get() {
             return Err(error);
         }
-        Ok(self.inner.state.borrow_mut().commands.drain(..).collect())
+        Ok(std::mem::take(&mut self.inner.state.borrow_mut().commands))
     }
 
     pub(super) fn pending_create_instances(&self) -> HashSet<ImguiViewportInstanceId> {

--- a/dear-imgui/src/scope.rs
+++ b/dear-imgui/src/scope.rs
@@ -22,7 +22,7 @@ pub(crate) struct WindowScope {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct TableScope {
     window: WindowScope,
-    table: usize,
+    table: sys::ImGuiID,
     instance: i16,
 }
 
@@ -60,7 +60,7 @@ impl ScopeSnapshot {
             window: Some(window),
             table: Some(TableScope {
                 window,
-                table: table as usize,
+                table: unsafe { (*table).ID },
                 instance: unsafe { (*table).InstanceCurrent },
             }),
             row: unsafe { (*table).CurrentRow },

--- a/dear-imgui/tests/nested_tables.rs
+++ b/dear-imgui/tests/nested_tables.rs
@@ -1,0 +1,50 @@
+use dear_imgui_rs::{Condition, Context, TableFlags};
+
+#[test]
+fn nested_tables_can_be_created_while_parent_is_open() {
+    let mut context = Context::create();
+    context.io_mut().set_display_size([800.0, 600.0]);
+    context.io_mut().set_delta_time(1.0 / 60.0);
+    context
+        .set_ini_filename::<std::path::PathBuf>(None)
+        .unwrap();
+    context
+        .font_atlas()
+        .try_claim_legacy_renderer()
+        .unwrap()
+        .build();
+    let mut rendered_parents = 0;
+    let mut rendered_children = 0;
+    for _ in 0..3 {
+        let ui = context.frame();
+        ui.window("Nested table scope regression")
+            .size([800.0, 600.0], Condition::Always)
+            .build(|| {
+                ui.table("parent")
+                    .flags(TableFlags::SCROLL_Y)
+                    .column("Name")
+                    .done()
+                    .build(|ui| {
+                        rendered_parents += 1;
+                        // Allocate distinct tables while the parent token is alive,
+                        // exercising growth of ImGui's table pool.
+                        for i in 0..32 {
+                            ui.table_next_row();
+                            ui.table_next_column();
+                            ui.table(format!("child##{i}"))
+                                .column("Value")
+                                .done()
+                                .build(|ui| {
+                                    rendered_children += 1;
+                                    ui.table_next_row();
+                                    ui.table_next_column();
+                                    ui.text("instance");
+                                });
+                        }
+                    });
+            });
+        drop(context.render_legacy());
+    }
+    assert_eq!(rendered_parents, 3);
+    assert!(rendered_children > 0);
+}


### PR DESCRIPTION
- What
  - Use ImGuiTable.ID instead of the table’s memory address for native scope identity.
  - Add a nested-table regression test and changelog entry.

- Why
    - Creating nested tables can grow ImGui’s table pool and relocate an active parent table. Comparing its saved address then incorrectly triggers TableToken was dropped
        outside its original table instance, followed by Missing EndTable().

- Affected crates
  - [x] dear-imgui-rs
  - [ ] dear-imgui-sys
  - [ ] backends/dear-imgui-wgpu
  - [ ] backends/dear-imgui-glow
  - [ ] backends/dear-imgui-winit
  - [ ] backends/dear-imgui-sdl3
  - [ ] dear-app
  - [ ] extensions/dear-implot(-sys)
  - [ ] extensions/dear-implot3d(-sys)
  - [ ] extensions/dear-imnodes(-sys)
  - [ ] extensions/dear-node-editor(-sys)
  - [ ] extensions/dear-imguizmo(-sys)
  - [ ] extensions/dear-imguizmo-quat(-sys)
  - [ ] extensions/dear-imgui-cte(-sys)
  - [ ] extensions/dear-file-browser
  - [ ] extensions/dear-imgui-reflect
  - [ ] CI / tooling / docs

- Behavior
  - [ ] Source build only
  - [ ] Prebuilt logic (feature/env)
  - [ ] Packaging (.tar.gz)
  - [ ] No behavior change (refactor/cleanup)
  - Runtime bug fix in the Rust wrapper; native build and packaging logic are unchanged.


- Breaking changes
  - [x] None
  - [ ] Yes (describe):

- Testing / validation
  - cargo test --offline --locked -p dear-imgui-rs --test nested_tables
    - Confirmed failure without the fix and success with it.

  - cargo test --offline --locked -p dear-imgui-rs --lib --tests -- --test-threads=1
    - 554 tests passed. Default parallel execution encountered shared-context failures.

  - Platform: Linux, x86_64-unknown-linux-gnu, native source build.


- Docs
  - [ ] N/A
  - [ ] Updated README / crate docs
  - Updated CHANGELOG.md.



- Links
  - Fixes: no existing issue.
  - Related: none.
